### PR TITLE
feat: Add GitHub App Authentication Support

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -38,7 +38,9 @@ jobs:
         id: visor_review
         uses: ./
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation-id: ${{ secrets.APP_INSTALLATION_ID }}
           auto-review: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
           debug: 'true'
         env:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 Create `.github/workflows/code-review.yml`:
 
+#### Option 1: Using GitHub Token (Default)
 ```yaml
 name: Code Review
 on: pull_request
@@ -36,6 +37,42 @@ jobs:
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
+
+#### Option 2: Using GitHub App Authentication (Recommended for Production)
+For better security and to have comments appear from your custom GitHub App:
+
+```yaml
+name: Code Review with GitHub App
+on: pull_request
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./  # or: gates-ai/visor-action@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # installation-id: ${{ secrets.APP_INSTALLATION_ID }}  # Optional, auto-detected
+        env:
+          # Choose one AI provider (see AI Configuration below)
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+**Setting up GitHub App:**
+1. [Create a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app) with these permissions:
+   - **Pull requests**: Read & Write
+   - **Issues**: Write  
+   - **Metadata**: Read
+2. Generate and download a private key for your app
+3. Install the app on your repository
+4. Add these secrets to your repository:
+   - `APP_ID`: Your GitHub App's ID
+   - `APP_PRIVATE_KEY`: The private key you downloaded (entire contents)
+   - `APP_INSTALLATION_ID`: (Optional) The installation ID for this repository
 
 That's it! Visor will automatically review your PRs with AI-powered analysis.
 

--- a/__mocks__/@octokit/auth-app.ts
+++ b/__mocks__/@octokit/auth-app.ts
@@ -1,0 +1,9 @@
+// Mock for @octokit/auth-app to work around ESM module issues in Jest
+export const createAppAuth = jest.fn(() => {
+  return jest.fn(() => Promise.resolve({
+    type: 'installation',
+    token: 'mock-installation-token',
+    tokenType: 'installation',
+    expiresAt: new Date(Date.now() + 3600000).toISOString()
+  }));
+});

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,21 @@ branding:
 
 inputs:
   github-token:
-    description: 'GitHub token for API access'
-    required: true
+    description: 'GitHub token for API access (use this OR app-id/private-key)'
+    required: false
     default: ${{ github.token }}
+  
+  app-id:
+    description: 'GitHub App ID for authentication (optional, use with private-key)'
+    required: false
+  
+  private-key:
+    description: 'GitHub App private key for authentication (optional, use with app-id)'
+    required: false
+  
+  installation-id:
+    description: 'GitHub App installation ID (optional, auto-detected if not provided)'
+    required: false
   
   auto-review:
     description: 'Enable automatic review on PR open/update'

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,9 @@ module.exports = {
     'src/**/*.ts',
     '!src/**/*.d.ts',
   ],
+  moduleNameMapper: {
+    '^@octokit/auth-app$': '<rootDir>/__mocks__/@octokit/auth-app.ts',
+  },
   transformIgnorePatterns: [
     'node_modules/(?!(@octokit|@actions|@kie)/)',
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@octokit/action": "^8.0.2",
+        "@octokit/auth-app": "^8.1.0",
         "@octokit/core": "^7.0.3",
         "@octokit/rest": "^22.0.0",
         "@types/commander": "^2.12.0",
@@ -2444,6 +2445,72 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@octokit/auth-app": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.1.0.tgz",
+      "integrity": "sha512-6bWhyvLXqCSfHiqlwzn9pScLZ+Qnvh/681GR/UEEPCMIVwfpRDBw0cCzy3/t2Dq8B7W2X/8pBgmw6MOiyE0DXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.1",
+        "@octokit/auth-oauth-user": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "toad-cache": "^3.7.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.1.tgz",
+      "integrity": "sha512-TthWzYxuHKLAbmxdFZwFlmwVyvynpyPmjwc+2/cI3cvbT7mHtsAW9b1LvQaNnAuWL+pFnqtxdmrU8QpF633i1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.1",
+        "@octokit/auth-oauth-user": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.1.tgz",
+      "integrity": "sha512-TOqId/+am5yk9zor0RGibmlqn4V0h8vzjxlw/wYr3qzkQxl8aBPur384D1EyHtqvfz0syeXji4OUvKkHvxk/Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-methods": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.0.tgz",
+      "integrity": "sha512-GV9IW134PHsLhtUad21WIeP9mlJ+QNpFd6V9vuPWmaiN25HEJeEQUcS4y5oRuqCm9iWDLtfIs+9K8uczBXKr6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.1",
+        "@octokit/oauth-methods": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@octokit/auth-token": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
@@ -2493,6 +2560,30 @@
         "@octokit/request": "^10.0.2",
         "@octokit/types": "^14.0.0",
         "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
+      "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.0.tgz",
+      "integrity": "sha512-Q8nFIagNLIZgM2odAraelMcDssapc+lF+y3OlcIPxyAU+knefO8KmozGqfnma1xegRDP4z5M73ABsamn72bOcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0"
       },
       "engines": {
         "node": ">= 20"
@@ -8993,6 +9084,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -9280,6 +9380,12 @@
         "pathe": "^2.0.3",
         "ufo": "^1.5.4"
       }
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@octokit/action": "^8.0.2",
+    "@octokit/auth-app": "^8.1.0",
     "@octokit/core": "^7.0.3",
     "@octokit/rest": "^22.0.0",
     "@types/commander": "^2.12.0",


### PR DESCRIPTION
## Summary
- Adds support for GitHub App authentication so PR comments appear from a custom GitHub App instead of the generic github-actions bot
- Maintains full backward compatibility with existing token authentication
- Implements auto-detection of installation ID when not provided

## Changes
- ✨ Add new action inputs: `app-id`, `private-key`, and `installation-id`
- 🔐 Implement `createAuthenticatedOctokit()` function for dual authentication support
- 🔄 Update all GitHub API calls to use authenticated Octokit instance
- 📚 Add comprehensive documentation for GitHub App setup in README
- 🧪 Add unit tests for authentication logic with Jest mock for ESM compatibility

## How to Use

### Option 1: GitHub Token (Default - existing behavior)
```yaml
- uses: gates-ai/visor-action@v1
  with:
    github-token: ${{ secrets.GITHUB_TOKEN }}
```

### Option 2: GitHub App Authentication (New)
```yaml
- uses: gates-ai/visor-action@v1
  with:
    app-id: ${{ secrets.APP_ID }}
    private-key: ${{ secrets.APP_PRIVATE_KEY }}
    # installation-id: optional, auto-detected
```

## GitHub App Setup
1. Create a GitHub App with these permissions:
   - **Pull requests**: Read & Write
   - **Issues**: Write  
   - **Metadata**: Read
2. Generate and download a private key
3. Install the app on your repository
4. Add secrets: `APP_ID` and `APP_PRIVATE_KEY`

## Test Plan
- [x] Build passes
- [x] ESLint passes
- [x] Unit tests pass (with mock for ESM module)
- [ ] Manual testing with GitHub App
- [ ] Manual testing with token auth (backward compatibility)

## Known Issues
- `@octokit/auth-app` uses ESM modules which require Jest mocking for tests to pass

🤖 Generated with [Claude Code](https://claude.ai/code)