### PR TITLE
Fix recursion prevention and issue handling

### DIFF
--- a/defaults/.visor.yaml
+++ b/defaults/.visor.yaml
@@ -278,12 +278,11 @@ checks:
         {%- endif %}
 
         ## Repository Analysis Context
-        {%- if pr.title %}
-        **Recent PR Activity**: {{ pr.title }}
+        {%- if event.isPullRequest and pr.title %}
+        **PR Context**: {{ pr.title }}
         {%- endif %}
-        {%- if utils.totalFiles > 0 %}
-        **Project Size**: {{ utils.totalFiles }} files
-        **Technologies**: {% for ext in utils.filesByExtension %}{{ ext[0] }}{% unless forloop.last %}, {% endunless %}{% endfor %}
+        {%- if event.repository %}
+        **Repository**: {{ event.repository.fullName }}
         {%- endif %}
 
         ## Instructions

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/auth-app": "^8.1.0",
         "@octokit/core": "^7.0.3",
         "@octokit/rest": "^22.0.0",
-        "@probelabs/probe": "latest",
+        "@probelabs/probe": "^0.6.0-rc84",
         "@types/commander": "^2.12.0",
         "@types/uuid": "^10.0.0",
         "cli-table3": "^0.6.5",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@octokit/auth-app": "^8.1.0",
     "@octokit/core": "^7.0.3",
     "@octokit/rest": "^22.0.0",
-    "@probelabs/probe": "latest",
+    "@probelabs/probe": "^0.6.0-rc84",
     "@types/commander": "^2.12.0",
     "@types/uuid": "^10.0.0",
     "cli-table3": "^0.6.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -527,7 +527,9 @@ async function handleIssueComment(
       comment.body.includes('*Powered by [Visor](https://github.com/probelabs/visor)'));
 
   if (isVisorBot || hasVisorMarkers) {
-    console.log(`Skipping visor comment to prevent recursion. Author: ${comment.user?.login}, Type: ${comment.user?.type}, Has markers: ${hasVisorMarkers}`);
+    console.log(
+      `Skipping visor comment to prevent recursion. Author: ${comment.user?.login}, Type: ${comment.user?.type}, Has markers: ${hasVisorMarkers}`
+    );
     return;
   }
 
@@ -658,13 +660,7 @@ async function handleIssueComment(
         let prInfo: PRInfo;
         if (isPullRequest) {
           // It's a PR comment - fetch the PR diff
-          prInfo = await analyzer.fetchPRDiff(
-            owner,
-            repo,
-            prNumber,
-            undefined,
-            'issue_comment'
-          );
+          prInfo = await analyzer.fetchPRDiff(owner, repo, prNumber, undefined, 'issue_comment');
         } else {
           // It's an issue comment - create a minimal PRInfo structure for issue assistant
           prInfo = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -440,6 +440,7 @@ async function handleIssueEvent(
     totalAdditions: 0,
     totalDeletions: 0,
     eventType: mapGitHubEventToTrigger('issues', action),
+    isIssue: true, // Flag to indicate this is an issue, not a PR
   };
 
   // Run the checks using CheckExecutionEngine
@@ -513,12 +514,20 @@ async function handleIssueComment(
   }
 
   // Prevent recursion: skip if comment is from visor itself
-  if (
+  // Check both comment author and content markers
+  const isVisorBot =
+    comment.user?.login === 'visor[bot]' ||
+    comment.user?.login === 'github-actions[bot]' ||
+    comment.user?.type === 'Bot';
+
+  const hasVisorMarkers =
     comment.body &&
     (comment.body.includes('<!-- visor-comment-id:') ||
-      comment.body.includes('*Powered by [Visor]'))
-  ) {
-    console.log('Skipping visor comment to prevent recursion');
+      comment.body.includes('*Powered by [Visor](https://probelabs.com/visor)') ||
+      comment.body.includes('*Powered by [Visor](https://github.com/probelabs/visor)'));
+
+  if (isVisorBot || hasVisorMarkers) {
+    console.log(`Skipping visor comment to prevent recursion. Author: ${comment.user?.login}, Type: ${comment.user?.type}, Has markers: ${hasVisorMarkers}`);
     return;
   }
 
@@ -669,7 +678,8 @@ async function handleIssueComment(
             totalAdditions: 0,
             totalDeletions: 0,
             fullDiff: '',
-            eventType: 'issue_comment'
+            eventType: 'issue_comment',
+            isIssue: true, // Flag to indicate this is an issue, not a PR
           };
         }
 

--- a/src/pr-analyzer.ts
+++ b/src/pr-analyzer.ts
@@ -32,6 +32,7 @@ export interface PRInfo {
   fullDiff?: string;
   commitDiff?: string;
   isIncremental?: boolean; // Flag to indicate if this was intended as incremental analysis
+  isIssue?: boolean; // Flag to indicate this is an issue, not a PR
 }
 
 interface NetworkError {

--- a/src/providers/ai-check-provider.ts
+++ b/src/providers/ai-check-provider.ts
@@ -261,6 +261,7 @@ export class AICheckProvider extends CheckProvider {
         ? {
             name: eventContext.event_name || 'unknown',
             action: eventContext.action,
+            isPullRequest: !prInfo.isIssue, // Set based on whether this is a PR or an issue
 
             // Repository Info
             repository: eventContext.repository


### PR DESCRIPTION
## Summary
- Fixed infinite loop when Visor comments on its own issues/PRs
- Resolved issue assistant incorrectly trying to fetch PR diffs for regular issues
- Enhanced recursion detection with better debugging

## Changes Made

### 1. Enhanced Recursion Prevention (`src/index.ts`)
- Added checks for bot usernames (`visor[bot]`, `github-actions[bot]`)
- Added check for user type (`Bot`)
- Fixed detection of both PR and issue comment footers
- Added detailed logging to help debug recursion triggers

### 2. Fixed Issue Assistant Template (`defaults/.visor.yaml`)
- Conditionally show PR context only when `event.isPullRequest` is true
- Removed references to file analysis data that doesn't exist for issues
- Fixed template to properly handle both issues and PRs

### 3. Added Issue vs PR Distinction
- Added `isIssue` flag to `PRInfo` interface
- Set flag when creating PRInfo for issue events
- Pass flag through to templates as `event.isPullRequest`

## Test Plan
- [ ] Test that Visor doesn't respond to its own comments
- [ ] Test issue assistant on regular issues (not PRs)
- [ ] Test issue assistant on PR comments
- [ ] Verify recursion prevention logs show correct author/type

## Related Issues
Fixes the recursion issue reported where Visor kept responding to its own comments.

🤖 Generated with [Claude Code](https://claude.ai/code)