### PR TITLE
Fix event context passing and duplicate headers

### DIFF
--- a/src/check-execution-engine.ts
+++ b/src/check-execution-engine.ts
@@ -367,6 +367,7 @@ export class CheckExecutionEngine {
         const providerConfig: CheckProviderConfig = {
           type: checks[0],
           prompt: 'all',
+          eventContext: prInfo.eventContext, // Pass event context for templates
           ai: timeout ? { timeout } : undefined,
         };
         const result = await provider.execute(prInfo, providerConfig);
@@ -405,6 +406,7 @@ export class CheckExecutionEngine {
         type: 'ai',
         prompt: focus,
         focus: focus,
+        eventContext: prInfo.eventContext, // Pass event context for templates
         ai: timeout ? { timeout } : undefined,
         // Inherit global AI provider and model settings if config is available
         ai_provider: config?.ai_provider,
@@ -547,6 +549,7 @@ export class CheckExecutionEngine {
       focus: checkConfig.focus || this.mapCheckNameToFocus(checkName),
       schema: checkConfig.schema,
       group: checkConfig.group,
+      eventContext: prInfo.eventContext, // Pass event context for templates
       ai: {
         timeout: timeout || 600000,
         debug: debug,
@@ -982,6 +985,7 @@ export class CheckExecutionEngine {
             schema: checkConfig.schema,
             group: checkConfig.group,
             checkName: checkName, // Add checkName for sessionID
+            eventContext: prInfo.eventContext, // Pass event context for templates
             ai: {
               timeout: timeout || 600000,
               debug: debug,
@@ -1260,6 +1264,7 @@ export class CheckExecutionEngine {
           focus: checkConfig.focus || this.mapCheckNameToFocus(checkName),
           schema: checkConfig.schema,
           group: checkConfig.group,
+          eventContext: prInfo.eventContext, // Pass event context for templates
           ai: {
             timeout: timeout || 600000,
             debug: debug, // Pass debug flag to AI provider
@@ -1355,6 +1360,7 @@ export class CheckExecutionEngine {
       focus: checkConfig.focus || this.mapCheckNameToFocus(checkName),
       schema: checkConfig.schema,
       group: checkConfig.group,
+      eventContext: prInfo.eventContext, // Pass event context for templates
       ai: {
         timeout: timeout || 600000,
         ...(checkConfig.ai || {}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -460,12 +460,12 @@ async function handleIssueEvent(
 
     // Format and post results as a comment on the issue
     if (Object.keys(result).length > 0) {
-      let commentBody = `## 🤖 Issue Assistant Results\n\n`;
+      let commentBody = '';
 
+      // Directly use check content without adding extra headers
       for (const checks of Object.values(result)) {
         for (const check of checks) {
           if (check.content && check.content.trim()) {
-            commentBody += `### ${check.checkName}\n`;
             commentBody += `${check.content}\n\n`;
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -441,6 +441,7 @@ async function handleIssueEvent(
     totalDeletions: 0,
     eventType: mapGitHubEventToTrigger('issues', action),
     isIssue: true, // Flag to indicate this is an issue, not a PR
+    eventContext: context.event, // Pass the full event context for templates
   };
 
   // Run the checks using CheckExecutionEngine
@@ -661,6 +662,8 @@ async function handleIssueComment(
         if (isPullRequest) {
           // It's a PR comment - fetch the PR diff
           prInfo = await analyzer.fetchPRDiff(owner, repo, prNumber, undefined, 'issue_comment');
+          // Add event context for templates
+          prInfo.eventContext = context.event;
         } else {
           // It's an issue comment - create a minimal PRInfo structure for issue assistant
           prInfo = {
@@ -676,6 +679,7 @@ async function handleIssueComment(
             fullDiff: '',
             eventType: 'issue_comment',
             isIssue: true, // Flag to indicate this is an issue, not a PR
+            eventContext: context.event, // Pass the full event context for templates
           };
         }
 
@@ -786,6 +790,8 @@ async function handlePullRequestWithConfig(
   let prInfo;
   try {
     prInfo = await analyzer.fetchPRDiff(owner, repo, prNumber, undefined, eventType);
+    // Add event context for templates
+    prInfo.eventContext = context.event;
   } catch (error) {
     // Handle test scenarios with mock repos
     if (inputs['ai-provider'] === 'mock' || inputs['ai-model'] === 'mock') {

--- a/src/pr-analyzer.ts
+++ b/src/pr-analyzer.ts
@@ -33,6 +33,7 @@ export interface PRInfo {
   commitDiff?: string;
   isIncremental?: boolean; // Flag to indicate if this was intended as incremental analysis
   isIssue?: boolean; // Flag to indicate this is an issue, not a PR
+  eventContext?: Record<string, unknown>; // GitHub event context for templates
 }
 
 interface NetworkError {


### PR DESCRIPTION
## Summary
- Pass GitHub event context through to AI templates so they can access comment text
- Remove duplicate headers in issue assistant output

## Changes

### 1. Event Context Passing
- Added `eventContext` field to `PRInfo` interface
- Set `prInfo.eventContext = context.event` for all event types (issues, PR comments, regular PRs)
- Updated all `providerConfig` instances in check-execution-engine to include `eventContext`
- This ensures templates can access `{{ event.comment.body }}` and other event data

### 2. Issue Assistant Headers
- Removed redundant "## 🤖 Issue Assistant Results" header
- The content now displays directly without duplicate headers

## Why These Changes Matter

Previously, the issue assistant template referenced `{{ event.comment.body }}` but the event context wasn't being passed through the system, so the comment text was never available to the AI. This fix ensures that:

- Templates can access the full GitHub event context
- Comment text is available via `{{ event.comment.body }}`
- Issue data is available via `{{ event.issue.* }}`
- Repository info is available via `{{ event.repository.* }}`

## Test Plan
- [ ] Test issue comments - verify comment text is included in AI prompt
- [ ] Test PR comments - verify comment text is available
- [ ] Test issue open events - verify clean output without duplicate headers
- [ ] Verify all event context data is accessible in templates

🤖 Generated with [Claude Code](https://claude.ai/code)