### PR TITLE
feat: Add AWS Bedrock provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Visor is a general SDLC automation framework:
 - Config‑first: One `.visor.yaml` defines checks, prompts, schemas, and templates — no hidden logic.
 - Structured outputs: JSON Schema validation drives deterministic rendering, annotations, and SARIF.
 - Orchestrated pipelines: Dependencies, parallelism, and tag‑based profiles; run in Actions or any CI.
-- Multi‑provider AI: Google Gemini, Anthropic Claude, OpenAI — plus MCP tools and Claude Code SDK.
+- Multi‑provider AI: Google Gemini, Anthropic Claude, OpenAI, AWS Bedrock — plus MCP tools and Claude Code SDK.
 - Assistants & commands: `/review` to rerun checks, `/visor …` for Q&A, predictable comment groups.
 - HTTP & schedules: Receive webhooks, call external APIs, and run cron‑scheduled audits and reports.
 - Extensible providers: `ai`, `http`, `http_client`, `log`, `command`, `claude-code` — or add your own.
@@ -249,13 +249,17 @@ Learn more: [docs/observability.md](docs/observability.md)
 
 ## 🤖 AI Configuration
 
-Set one provider key (Google/Anthropic/OpenAI) via env.
+Set one provider key (Google/Anthropic/OpenAI/AWS Bedrock) via env.
 
 Example (Action):
 ```yaml
 - uses: probelabs/visor@v1
   env:
     GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+    # Or for AWS Bedrock:
+    # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    # AWS_REGION: us-east-1
 ```
 
 Learn more: [docs/ai-configuration.md](docs/ai-configuration.md)

--- a/docs/ai-configuration.md
+++ b/docs/ai-configuration.md
@@ -72,6 +72,93 @@ To force Bedrock provider:
 export FORCE_PROVIDER=bedrock
 ```
 
+### YAML Configuration
+
+#### Global Provider Settings
+
+Configure a default AI provider in `.visor.yaml`:
+
+```yaml
+# Global configuration for all checks
+ai_provider: bedrock  # or google, anthropic, openai
+ai_model: anthropic.claude-sonnet-4-20250514-v1:0  # Optional, uses default if not specified
+
+checks:
+  security-review:
+    type: ai
+    prompt: "Analyze code for security vulnerabilities"
+```
+
+#### Per-Check Provider Configuration
+
+Override the provider for specific checks:
+
+```yaml
+# Use different providers for different checks
+checks:
+  security-review:
+    type: ai
+    ai_provider: bedrock
+    ai_model: anthropic.claude-sonnet-4-20250514-v1:0
+    prompt: "Analyze code for security vulnerabilities using AWS Bedrock"
+
+  performance-review:
+    type: ai
+    ai_provider: google
+    ai_model: gemini-2.0-flash-exp
+    prompt: "Analyze code for performance issues using Gemini"
+
+  style-review:
+    type: ai
+    ai:
+      provider: openai
+      model: gpt-4-turbo
+    prompt: "Review code style and best practices"
+```
+
+#### AWS Bedrock Specific Configuration
+
+Complete example for Bedrock with all options:
+
+```yaml
+version: "1.0"
+
+# Global Bedrock settings
+ai_provider: bedrock
+ai_model: anthropic.claude-sonnet-4-20250514-v1:0
+
+# Environment variables can be referenced
+env:
+  AWS_REGION: us-east-1
+  # AWS credentials should be set as environment variables, not in config
+
+checks:
+  comprehensive-review:
+    type: ai
+    ai_provider: bedrock
+    prompt: |
+      Perform a comprehensive code review including:
+      - Security vulnerabilities
+      - Performance optimizations
+      - Code quality and best practices
+      - Architectural concerns
+    schema: code-review  # Use structured output format
+
+  custom-bedrock-model:
+    type: ai
+    ai:
+      provider: bedrock
+      model: anthropic.claude-3-opus-20240229  # Use a different Bedrock model
+      timeout: 120000  # 2 minute timeout for complex analysis
+    prompt: "Perform deep architectural analysis"
+
+output:
+  pr_comment:
+    format: markdown
+    group_by: check
+    collapse: true
+```
+
 ### Fallback Behavior
 
 If no key is configured, Visor falls back to fast, heuristic checks (simple patterns, basic style/perf). For best results, set a provider.

--- a/docs/ai-configuration.md
+++ b/docs/ai-configuration.md
@@ -9,6 +9,7 @@ Visor supports multiple AI providers. Configure one via environment variables.
 | Google Gemini | `GOOGLE_API_KEY` | `gemini-2.0-flash-exp`, `gemini-1.5-pro` |
 | Anthropic Claude | `ANTHROPIC_API_KEY` | `claude-3-opus`, `claude-3-sonnet` |
 | OpenAI GPT | `OPENAI_API_KEY` | `gpt-4`, `gpt-4-turbo`, `gpt-3.5-turbo` |
+| AWS Bedrock | AWS credentials (see below) | `anthropic.claude-sonnet-4-20250514-v1:0` (default) |
 
 ### GitHub Actions Setup
 Add the provider key as a secret (Settings → Secrets → Actions), then expose it:
@@ -20,13 +21,55 @@ steps:
     env:
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       # or ANTHROPIC_API_KEY / OPENAI_API_KEY
+      # For AWS Bedrock:
+      # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # AWS_REGION: us-east-1
 ```
 
 ### Local Development
 
 ```bash
-export GOOGLE_API_KEY="your-api-key"   # or ANTHROPIC/OPENAI
+# Google Gemini
+export GOOGLE_API_KEY="your-api-key"
 export MODEL_NAME="gemini-2.0-flash-exp"
+
+# AWS Bedrock
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+export AWS_REGION="us-east-1"
+# Optional: Use specific model
+export MODEL_NAME="anthropic.claude-sonnet-4-20250514-v1:0"
+```
+
+### AWS Bedrock Configuration
+
+Bedrock supports multiple authentication methods:
+
+1. **IAM Credentials** (recommended):
+   ```bash
+   export AWS_ACCESS_KEY_ID="your-access-key"
+   export AWS_SECRET_ACCESS_KEY="your-secret-key"
+   export AWS_REGION="us-east-1"
+   ```
+
+2. **Temporary Session Credentials**:
+   ```bash
+   export AWS_ACCESS_KEY_ID="your-access-key"
+   export AWS_SECRET_ACCESS_KEY="your-secret-key"
+   export AWS_SESSION_TOKEN="your-session-token"
+   export AWS_REGION="us-east-1"
+   ```
+
+3. **API Key Authentication** (if configured):
+   ```bash
+   export AWS_BEDROCK_API_KEY="your-api-key"
+   export AWS_BEDROCK_BASE_URL="https://your-custom-endpoint.com"  # Optional
+   ```
+
+To force Bedrock provider:
+```bash
+export FORCE_PROVIDER=bedrock
 ```
 
 ### Fallback Behavior

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Override global AI settings at the check level:
 
 ```yaml
 # Global AI settings (optional)
-ai_provider: anthropic
+ai_provider: anthropic  # or google, openai, bedrock
 ai_model: claude-3-sonnet
 ai_temperature: 0.2
 
@@ -20,6 +20,12 @@ checks:
       model: gemini-1.5-pro
       temperature: 0.1
     prompt: "Analyze performance metrics and provide optimization suggestions"
+
+  security-review:
+    type: ai
+    ai_provider: bedrock  # Use AWS Bedrock for this check
+    ai_model: anthropic.claude-sonnet-4-20250514-v1:0
+    prompt: "Analyze code for security vulnerabilities"
 ```
 
 ### Environment Variables
@@ -32,6 +38,10 @@ env:
   OPENAI_API_KEY: "${{ env.OPENAI_API_KEY }}"
   ANTHROPIC_API_KEY: "${{ env.ANTHROPIC_API_KEY }}"
   GOOGLE_API_KEY: "${{ env.GOOGLE_API_KEY }}"
+  # AWS Bedrock credentials
+  AWS_ACCESS_KEY_ID: "${{ env.AWS_ACCESS_KEY_ID }}"
+  AWS_SECRET_ACCESS_KEY: "${{ env.AWS_SECRET_ACCESS_KEY }}"
+  AWS_REGION: "${{ env.AWS_REGION }}"
   SLACK_WEBHOOK: "${{ env.SLACK_WEBHOOK }}"
 
 checks:

--- a/examples/bedrock-config.yaml
+++ b/examples/bedrock-config.yaml
@@ -1,0 +1,91 @@
+# Example Visor configuration for AWS Bedrock
+# This demonstrates various ways to configure and use AWS Bedrock as your AI provider
+
+version: "1.0"
+
+# Global AI provider settings
+# Set Bedrock as the default provider for all AI checks
+ai_provider: bedrock
+ai_model: anthropic.claude-sonnet-4-20250514-v1:0  # Default Bedrock model
+
+# Environment variables for AWS authentication
+# These should be set in your environment or CI/CD secrets
+env:
+  AWS_REGION: us-east-1  # Specify your AWS region
+
+checks:
+  # Basic check using global Bedrock settings
+  security-analysis:
+    type: ai
+    prompt: |
+      Analyze the code changes for security vulnerabilities including:
+      - SQL injection risks
+      - XSS vulnerabilities
+      - Authentication/authorization issues
+      - Sensitive data exposure
+      - Input validation problems
+
+  # Check with explicit Bedrock configuration
+  performance-review:
+    type: ai
+    ai_provider: bedrock
+    ai_model: anthropic.claude-3-opus-20240229  # Use a different Bedrock model
+    prompt: |
+      Review code for performance issues:
+      - Inefficient algorithms (O(n²) or worse)
+      - Memory leaks or excessive allocations
+      - Database query optimization opportunities
+      - Caching opportunities
+    schema: code-review  # Use structured output
+
+  # Check using nested AI configuration
+  architecture-review:
+    type: ai
+    ai:
+      provider: bedrock
+      model: anthropic.claude-sonnet-4-20250514-v1:0
+      timeout: 180000  # 3 minutes for complex analysis
+    prompt: |
+      Perform architectural analysis:
+      - Design pattern violations
+      - SOLID principles adherence
+      - Code coupling and cohesion
+      - Module boundaries and dependencies
+      - Potential technical debt
+
+  # Mixed provider example - use different providers for different checks
+  quick-style-check:
+    type: ai
+    ai_provider: google  # Override to use Google Gemini for this check
+    ai_model: gemini-2.0-flash-exp
+    prompt: "Quick style and formatting check"
+
+# Output configuration
+output:
+  pr_comment:
+    format: markdown
+    group_by: check
+    collapse: true
+  github_checks:
+    enabled: true
+    per_check: true  # Create separate GitHub check runs for each check
+
+# Example GitHub Actions workflow to use this configuration:
+#
+# name: AI Code Review with AWS Bedrock
+# on: [pull_request]
+#
+# jobs:
+#   review:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: probelabs/visor@v1
+#         with:
+#           config-path: examples/bedrock-config.yaml
+#         env:
+#           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#           AWS_REGION: us-east-1
+#           # Optional: Override model via environment
+#           # MODEL_NAME: anthropic.claude-3-opus-20240229

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/auth-app": "^8.1.0",
         "@octokit/core": "^7.0.3",
         "@octokit/rest": "^22.0.0",
-        "@probelabs/probe": "^0.6.0-rc102",
+        "@probelabs/probe": "^0.6.0-rc103",
         "@types/commander": "^2.12.0",
         "@types/uuid": "^10.0.0",
         "cli-table3": "^0.6.5",
@@ -4406,9 +4406,9 @@
       }
     },
     "node_modules/@probelabs/probe": {
-      "version": "0.6.0-rc102",
-      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc102.tgz",
-      "integrity": "sha512-ukZQqrrMGfscb+OuJmL/a21JXcZsLb6cfAEZnOCc486Lmry85JW1CRYn7rubiKWW9SzlwElatrWt7RtdNu6eHA==",
+      "version": "0.6.0-rc103",
+      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc103.tgz",
+      "integrity": "sha512-6uTBRvmE16TYBWCulipIjLxrBK2fKjm3Rv61zTfaUz06qDm59ZIMcCHtWlgrF6A8uhVWDl3niGz0o6ua5hi4Iw==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@octokit/auth-app": "^8.1.0",
     "@octokit/core": "^7.0.3",
     "@octokit/rest": "^22.0.0",
-    "@probelabs/probe": "^0.6.0-rc102",
+    "@probelabs/probe": "^0.6.0-rc103",
     "@types/commander": "^2.12.0",
     "@types/uuid": "^10.0.0",
     "cli-table3": "^0.6.5",

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -255,6 +255,21 @@ export async function main(): Promise<void> {
       console.error('  - ANTHROPIC_API_KEY');
       console.error('\nExample:');
       console.error('  export CLAUDE_CODE_API_KEY="your-api-key-here"\n');
+    } else if (error instanceof Error && error.message.includes('No API key configured')) {
+      console.error('\n❌ Error: No API key or credentials configured for AI provider.');
+      console.error('Please set one of the following:');
+      console.error('\nFor Google Gemini:');
+      console.error('  export GOOGLE_API_KEY="your-api-key"');
+      console.error('\nFor Anthropic Claude:');
+      console.error('  export ANTHROPIC_API_KEY="your-api-key"');
+      console.error('\nFor OpenAI:');
+      console.error('  export OPENAI_API_KEY="your-api-key"');
+      console.error('\nFor AWS Bedrock:');
+      console.error('  export AWS_ACCESS_KEY_ID="your-access-key"');
+      console.error('  export AWS_SECRET_ACCESS_KEY="your-secret-key"');
+      console.error('  export AWS_REGION="us-east-1"');
+      console.error('\nOr use API key authentication for Bedrock:');
+      console.error('  export AWS_BEDROCK_API_KEY="your-api-key"\n');
     } else {
       console.error('❌ Error:', error instanceof Error ? error.message : error);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,6 +243,14 @@ export async function run(): Promise<void> {
         'Set CLAUDE_CODE_API_KEY or ANTHROPIC_API_KEY in your GitHub secrets.',
       ].join(' ');
       setFailed(errorMessage);
+    } else if (error instanceof Error && error.message.includes('No API key configured')) {
+      const errorMessage = [
+        'No API key or credentials configured for AI provider.',
+        'Set one of the following in GitHub secrets:',
+        'GOOGLE_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY,',
+        'or AWS credentials (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY).',
+      ].join(' ');
+      setFailed(errorMessage);
     } else {
       setFailed(error instanceof Error ? error.message : 'Unknown error');
     }

--- a/src/providers/ai-check-provider.ts
+++ b/src/providers/ai-check-provider.ts
@@ -28,7 +28,7 @@ export class AICheckProvider extends CheckProvider {
   }
 
   getDescription(): string {
-    return 'AI-powered code review using Google Gemini, Anthropic Claude, or OpenAI GPT models';
+    return 'AI-powered code review using Google Gemini, Anthropic Claude, OpenAI GPT, or AWS Bedrock models';
   }
 
   async validateConfig(config: unknown): Promise<boolean> {
@@ -58,7 +58,7 @@ export class AICheckProvider extends CheckProvider {
     if (cfg.ai) {
       if (
         cfg.ai.provider &&
-        !['google', 'anthropic', 'openai', 'mock'].includes(cfg.ai.provider as string)
+        !['google', 'anthropic', 'openai', 'bedrock', 'mock'].includes(cfg.ai.provider as string)
       ) {
         return false;
       }
@@ -535,7 +535,12 @@ export class AICheckProvider extends CheckProvider {
         aiConfig.timeout = config.ai.timeout as number;
       }
       if (config.ai.provider !== undefined) {
-        aiConfig.provider = config.ai.provider as 'google' | 'anthropic' | 'openai' | 'mock';
+        aiConfig.provider = config.ai.provider as
+          | 'google'
+          | 'anthropic'
+          | 'openai'
+          | 'bedrock'
+          | 'mock';
       }
       if (config.ai.debug !== undefined) {
         aiConfig.debug = config.ai.debug as boolean;
@@ -547,7 +552,12 @@ export class AICheckProvider extends CheckProvider {
       aiConfig.model = config.ai_model as string;
     }
     if (config.ai_provider !== undefined) {
-      aiConfig.provider = config.ai_provider as 'google' | 'anthropic' | 'openai' | 'mock';
+      aiConfig.provider = config.ai_provider as
+        | 'google'
+        | 'anthropic'
+        | 'openai'
+        | 'bedrock'
+        | 'mock';
     }
 
     // Get custom prompt from config - REQUIRED, no fallbacks
@@ -708,14 +718,18 @@ export class AICheckProvider extends CheckProvider {
     return !!(
       process.env.GOOGLE_API_KEY ||
       process.env.ANTHROPIC_API_KEY ||
-      process.env.OPENAI_API_KEY
+      process.env.OPENAI_API_KEY ||
+      // AWS Bedrock credentials check
+      (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) ||
+      process.env.AWS_BEDROCK_API_KEY
     );
   }
 
   getRequirements(): string[] {
     return [
-      'At least one of: GOOGLE_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY',
+      'At least one of: GOOGLE_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY, or AWS credentials (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)',
       'Optional: MODEL_NAME environment variable',
+      'Optional: AWS_REGION for Bedrock provider',
       'Network access to AI provider APIs',
     ];
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -228,7 +228,7 @@ export interface EnvConfig {
  */
 export interface AIProviderConfig {
   /** AI provider to use */
-  provider?: 'google' | 'anthropic' | 'openai' | 'mock';
+  provider?: 'google' | 'anthropic' | 'openai' | 'bedrock' | 'mock';
   /** Model name to use */
   model?: string;
   /** API key (usually from environment variables) */
@@ -319,7 +319,7 @@ export interface CheckConfig {
   /** AI model to use for this check - overrides global setting */
   ai_model?: string;
   /** AI provider to use for this check - overrides global setting */
-  ai_provider?: 'google' | 'anthropic' | 'openai' | 'mock' | string;
+  ai_provider?: 'google' | 'anthropic' | 'openai' | 'bedrock' | 'mock' | string;
   /** MCP servers for this AI check - overrides global setting */
   ai_mcp_servers?: Record<string, McpServerConfig>;
   /** Claude Code configuration (for claude-code type checks) */
@@ -513,7 +513,7 @@ export interface VisorConfig {
   /** Global AI model setting */
   ai_model?: string;
   /** Global AI provider setting */
-  ai_provider?: 'google' | 'anthropic' | 'openai' | 'mock' | 'claude-code' | string;
+  ai_provider?: 'google' | 'anthropic' | 'openai' | 'bedrock' | 'mock' | 'claude-code' | string;
   /** Global MCP servers configuration for AI checks */
   ai_mcp_servers?: Record<string, McpServerConfig>;
   /** Maximum number of checks to run in parallel (default: 3) */

--- a/tests/unit/ai-review-service.test.ts
+++ b/tests/unit/ai-review-service.test.ts
@@ -113,7 +113,7 @@ describe('AIReviewService', () => {
       const service = new AIReviewService();
 
       await expect(service.executeReview(mockPRInfo, 'security')).rejects.toThrow(
-        'No API key configured. Please set GOOGLE_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY environment variable.'
+        'No API key configured. Please set GOOGLE_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY environment variable, or configure AWS credentials for Bedrock (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY).'
       );
     });
 
@@ -375,7 +375,7 @@ describe('AIReviewService', () => {
       };
 
       await expect(service.executeReview(prInfo, 'security')).rejects.toThrow(
-        'No API key configured. Please set GOOGLE_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY environment variable.'
+        'No API key configured. Please set GOOGLE_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY environment variable, or configure AWS credentials for Bedrock (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY).'
       );
     });
 


### PR DESCRIPTION
## Summary
- Added AWS Bedrock as a supported AI provider for code reviews
- Implemented automatic detection of AWS credentials
- Enhanced error messages to guide users on configuration
- **Added comprehensive YAML configuration documentation**

## Changes

### Core Implementation
- **Provider Types**: Added 'bedrock' to all AI provider union types in `src/types/config.ts`
- **Credential Detection**: AI Review Service now auto-detects AWS credentials (IAM, session tokens, API keys)
- **Provider Validation**: Updated AI Check Provider to validate and support Bedrock
- **Error Handling**: Enhanced CLI and Action error messages for missing AWS credentials

### Documentation Updates
- **AI Configuration Guide** (`docs/ai-configuration.md`):
  - Added YAML configuration examples for global and per-check Bedrock settings
  - Documented how to override providers for specific checks
  - Included complete Bedrock configuration example
- **General Configuration** (`docs/configuration.md`):
  - Updated examples to show Bedrock provider option
  - Added AWS credentials to environment variable examples
- **README**:
  - Listed AWS Bedrock in supported providers
  - Added AWS credential examples in GitHub Actions setup
- **Example Configuration** (`examples/bedrock-config.yaml`):
  - Created complete working example with multiple Bedrock configurations
  - Included comments explaining each configuration option
  - Added GitHub Actions workflow example

## Authentication Methods Supported
1. **IAM Credentials**: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
2. **Session Tokens**: Including `AWS_SESSION_TOKEN` for temporary credentials
3. **API Key**: `AWS_BEDROCK_API_KEY` for simplified authentication
4. **Custom Endpoints**: `AWS_BEDROCK_BASE_URL` for private deployments

## Configuration Examples

### Global Provider Setting
\`\`\`yaml
ai_provider: bedrock
ai_model: anthropic.claude-sonnet-4-20250514-v1:0
\`\`\`

### Per-Check Configuration
\`\`\`yaml
checks:
  security-review:
    type: ai
    ai_provider: bedrock
    ai_model: anthropic.claude-3-opus-20240229
    prompt: "Analyze for security vulnerabilities"
\`\`\`

## Testing
- Built successfully with `npm run build`
- All tests pass including updated test cases
- No new dependencies required (ProbeAgent handles Bedrock internally)

## Related
- Implements Bedrock support requested in https://github.com/probelabs/probe/pull/190

🤖 Generated with Claude Code (https://claude.ai/code)