### PR TITLE
fix: add command provider documentation and timeout configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Visor is an AI-powered code review tool for GitHub Pull Requests that can run as
   - `ai-check-provider.ts` - AI-powered analysis (Gemini, Claude, OpenAI)
   - `claude-code-check-provider.ts` - Claude Code SDK integration with MCP tools
   - `tool-check-provider.ts` - Integration with external tools
-  - `script-check-provider.ts` - Custom shell scripts
+  - `command-check-provider.ts` - Execute shell commands
   - `http-check-provider.ts` - HTTP webhook output
   - `http-input-provider.ts` - HTTP webhook input
   - `http-client-provider.ts` - HTTP client for external APIs

--- a/README.md
+++ b/README.md
@@ -366,7 +366,8 @@ Learn more: [docs/http.md](docs/http.md)
 
 Mix providers (`ai`, `http`, `http_client`, `log`, `command`, `claude-code`) or add your own.
 
-Learn more: [docs/pluggable.md](docs/pluggable.md)
+- **Command Provider**: Execute shell commands with templating and security - [docs/command-provider.md](docs/command-provider.md)
+- **Custom Providers**: Build your own providers - [docs/pluggable.md](docs/pluggable.md)
 
 ## 🎯 GitHub Action Reference
 

--- a/docs/command-provider.md
+++ b/docs/command-provider.md
@@ -1,0 +1,440 @@
+# Command Provider Documentation
+
+The `command` provider executes shell commands and captures their output for processing. It's useful for integrating external tools, running tests, performing custom validations, or gathering system information.
+
+## Basic Usage
+
+```yaml
+checks:
+  my-command-check:
+    type: command
+    exec: "npm test"
+```
+
+## Features
+
+- **Shell command execution** - Run any shell command
+- **JSON output parsing** - Automatically parses JSON output
+- **Liquid templating** - Use variables in commands and transforms
+- **Dependency support** - Access outputs from other checks
+- **Environment variables** - Pass custom environment variables
+- **Output transformation** - Transform command output using Liquid templates
+
+## Configuration Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `type` | string | Yes | Must be `"command"` |
+| `exec` | string | Yes | The shell command to execute |
+| `transform` | string | No | Liquid template to transform output |
+| `env` | object | No | Environment variables to pass to the command |
+| `timeout` | number | No | Command timeout in seconds (default: 60) |
+| `depends_on` | array | No | Other checks this depends on |
+| `forEach` | object | No | Run command for each item in a collection |
+| `group` | string | No | Group name for organizing results |
+| `on` | array | No | Events that trigger this check |
+| `tags` | array | No | Tags for filtering checks |
+
+## Examples
+
+### Basic Command Execution
+
+```yaml
+checks:
+  lint:
+    type: command
+    exec: "npm run lint"
+    group: quality
+    on: [pr_opened, pr_updated]
+```
+
+### JSON Output Parsing
+
+Commands that output JSON will be automatically parsed:
+
+```yaml
+checks:
+  security-audit:
+    type: command
+    exec: "npm audit --json"
+    group: security
+```
+
+### Using Liquid Templates
+
+The `exec` field fully supports Liquid templating for dynamic command generation. Templates are processed before command execution.
+
+```yaml
+checks:
+  branch-check:
+    type: command
+    exec: "git diff {{ pr.base }}..{{ pr.branch }} --stat"
+    group: analysis
+```
+
+Available template variables:
+- `pr.number` - Pull request number
+- `pr.title` - Pull request title
+- `pr.author` - Pull request author
+- `pr.branch` - Source branch (head)
+- `pr.base` - Target branch (base)
+- `files` - Array of changed files
+- `fileCount` - Number of changed files
+- `env` - Safe environment variables (see Security section)
+- `outputs.<check_name>` - Outputs from dependency checks
+
+### Using Dependencies
+
+Access outputs from other checks:
+
+```yaml
+checks:
+  get-version:
+    type: command
+    exec: "node -p 'require(\"./package.json\").version'"
+
+  tag-release:
+    type: command
+    exec: "git tag v{{ outputs.get_version }}"
+    depends_on: [get-version]
+```
+
+### Transform Output
+
+Transform command output using Liquid templates:
+
+```yaml
+checks:
+  test-coverage:
+    type: command
+    exec: "npm test -- --coverage --json"
+    transform: |
+      {
+        "coverage": {{ output.coverageMap | json }},
+        "summary": "Coverage: {{ output.coverageSummary.total.lines.pct }}%"
+      }
+```
+
+### Environment Variables
+
+You can use environment variables in three ways:
+
+#### 1. Shell Variable Expansion (Recommended for defaults)
+```yaml
+checks:
+  jira-query:
+    type: command
+    exec: |
+      # Shell expansion with defaults
+      JQL="${VISOR_JQL:-project = MYPROJ}"
+      LIMIT="${VISOR_LIMIT:-10}"
+
+      curl -s "https://jira.example.com/rest/api/2/search?jql=${JQL}&maxResults=${LIMIT}"
+```
+
+#### 2. Liquid Templates
+```yaml
+checks:
+  api-check:
+    type: command
+    exec: |
+      curl "{{ env.API_URL | default: 'https://api.example.com' }}/status"
+```
+
+#### 3. Custom Environment Variables
+```yaml
+checks:
+  integration-test:
+    type: command
+    exec: "npm run test:integration"
+    env:
+      NODE_ENV: test
+      API_URL: https://api.example.com
+      TIMEOUT: "30000"
+```
+
+**Note**: Commands inherit all parent process environment variables. Custom `env` values override inherited ones.
+
+### For Each Execution
+
+Run a command for each item in a collection:
+
+```yaml
+checks:
+  validate-files:
+    type: command
+    exec: "jsonlint {{ item }}"
+    forEach:
+      items: "{{ files | where: 'extension', '.json' }}"
+    group: validation
+```
+
+### Conditional Execution
+
+Run checks only under certain conditions:
+
+```yaml
+checks:
+  deploy-check:
+    type: command
+    exec: "npm run deploy:dry-run"
+    on: [pr_opened]
+    if: "pr.base == 'main'"
+    tags: [deployment, validation]
+```
+
+### Timeout Configuration
+
+Configure longer timeouts for commands that take more time:
+
+```yaml
+checks:
+  build-project:
+    type: command
+    exec: "npm run build"
+    timeout: 300  # 5 minutes
+    group: build
+
+  quick-lint:
+    type: command
+    exec: "eslint src/"
+    timeout: 30   # 30 seconds
+    group: quality
+
+  long-test-suite:
+    type: command
+    exec: "npm run test:e2e"
+    timeout: 600  # 10 minutes
+    group: testing
+```
+
+### Complex Example
+
+A comprehensive example combining multiple features:
+
+```yaml
+checks:
+  # First, get dependencies that need updating
+  outdated-deps:
+    type: command
+    exec: "npm outdated --json || true"
+    timeout: 120  # 2 minutes for npm operations
+    group: dependencies
+    tags: [dependencies, maintenance]
+
+  # Then check for security issues in those dependencies
+  security-check:
+    type: command
+    exec: |
+      if [ -n '{{ outputs.outdated_deps }}' ]; then
+        npm audit --json
+      else
+        echo '{"vulnerabilities": {}}'
+      fi
+    depends_on: [outdated-deps]
+    timeout: 180  # 3 minutes for audit
+    transform: |
+      {
+        "critical": {{ output.metadata.vulnerabilities.critical | default: 0 }},
+        "high": {{ output.metadata.vulnerabilities.high | default: 0 }},
+        "message": "Found {{ output.metadata.vulnerabilities.total | default: 0 }} vulnerabilities"
+      }
+    group: security
+    tags: [security, dependencies]
+```
+
+## Error Handling
+
+The command provider handles errors gracefully:
+
+1. **Command failures** - Non-zero exit codes are captured as errors
+2. **Timeout** - Commands timeout after 60 seconds by default
+3. **Buffer limits** - Output is limited to 10MB
+4. **Transform errors** - Invalid transforms are reported as issues
+
+Example error output:
+```json
+{
+  "issues": [
+    {
+      "file": "command",
+      "line": 0,
+      "ruleId": "command/execution_error",
+      "message": "Command execution failed: npm test exited with code 1",
+      "severity": "error",
+      "category": "logic"
+    }
+  ]
+}
+```
+
+## Security Considerations
+
+### ⚠️ CRITICAL: Command Injection Prevention
+
+**NEVER use uncontrolled user input directly in commands!** This includes PR titles, branch names, commit messages, or any other user-provided data.
+
+#### ❌ DANGEROUS - Command Injection Vulnerable
+```yaml
+# DON'T DO THIS - PR title could contain malicious commands
+checks:
+  bad-example:
+    type: command
+    exec: "echo 'Reviewing: {{ pr.title }}'"  # VULNERABLE!
+    # If pr.title is: '; rm -rf / #
+    # Command becomes: echo 'Reviewing: '; rm -rf / #'
+```
+
+#### ✅ SAFE - Properly Escaped
+```yaml
+checks:
+  # Option 1: Use Liquid filters to escape
+  safe-echo:
+    type: command
+    exec: "echo 'Reviewing: {{ pr.title | escape }}'"
+
+  # Option 2: Pass as environment variable (shell handles escaping)
+  safe-with-env:
+    type: command
+    exec: |
+      PR_TITLE="{{ pr.title }}"
+      echo "Reviewing: $PR_TITLE"
+
+  # Option 3: Use JSON encoding for complex data
+  safe-json:
+    type: command
+    exec: |
+      cat << 'EOF' | jq .
+      {
+        "title": {{ pr.title | json }},
+        "author": {{ pr.author | json }}
+      }
+      EOF
+
+  # Option 4: Avoid user input entirely
+  safest:
+    type: command
+    exec: "echo 'PR #{{ pr.number }} needs review'"  # number is safe
+```
+
+### Input Sanitization Examples
+
+#### Handling File Paths
+```yaml
+checks:
+  # DANGEROUS - file names could contain special characters
+  bad-lint:
+    type: command
+    exec: "eslint {{ files | join: ' ' }}"  # VULNERABLE!
+
+  # SAFE - quote each file properly
+  safe-lint:
+    type: command
+    exec: |
+      {% for file in files %}
+      eslint "{{ file | escape }}"
+      {% endfor %}
+```
+
+#### Working with Branch Names
+```yaml
+checks:
+  # DANGEROUS
+  bad-branch:
+    type: command
+    exec: "git checkout {{ pr.branch }}"  # VULNERABLE!
+
+  # SAFE - use quotes and escape
+  safe-branch:
+    type: command
+    exec: "git checkout '{{ pr.branch | escape }}'"
+```
+
+### Additional Security Best Practices
+
+1. **Environment Variables in Liquid** - Only safe environment variables are exposed in Liquid templates:
+   - Allowed prefixes: `CI_`, `GITHUB_`, `RUNNER_`, `NODE_`, `npm_`
+   - Always available: `PATH`, `HOME`, `USER`, `PWD`
+   - All others are filtered out for security
+
+2. **Shell Environment** - Commands inherit the full process environment, so shell expansion (`$VAR`) has access to all variables
+
+3. **Secrets Management**:
+   ```yaml
+   checks:
+     # BAD - Don't echo secrets
+     bad-secret:
+       type: command
+       exec: "echo $API_KEY"  # DON'T DO THIS
+
+     # GOOD - Use secrets safely
+     good-secret:
+       type: command
+       exec: "curl -H 'Authorization: Bearer $API_KEY' https://api.example.com"
+   ```
+
+4. **File System Access** - Commands run with the same permissions as the visor process:
+   ```yaml
+   checks:
+     # Be careful with file operations
+     file-check:
+       type: command
+       exec: |
+         # Validate path is within project
+         FILE="{{ files[0] | escape }}"
+         if [[ "$FILE" == *".."* ]]; then
+           echo "Invalid file path"
+           exit 1
+         fi
+         cat "$FILE"
+   ```
+
+5. **Timeout Protection** - Commands timeout after 60 seconds by default (configurable via `timeout` field)
+6. **Output Limits** - Command output is limited to 10MB to prevent memory exhaustion
+
+## Integration with Other Providers
+
+The command provider works well with other providers:
+
+```yaml
+checks:
+  # Run tests first
+  test:
+    type: command
+    exec: "npm test -- --json"
+    group: quality
+
+  # Then analyze results with AI
+  test-analysis:
+    type: ai
+    prompt: |
+      Analyze these test results and identify patterns:
+      {{ outputs.test | json }}
+    depends_on: [test]
+    group: analysis
+```
+
+## Tips and Best Practices
+
+1. **Use JSON output** when possible for better integration
+2. **Set appropriate groups** to organize related checks
+3. **Use tags** for filtering check execution
+4. **Handle errors gracefully** - consider using `|| true` for non-critical commands
+5. **Keep commands simple** - complex logic should be in scripts
+6. **Use dependencies** to chain related commands
+7. **Set timeouts** for long-running commands if needed
+8. **Test locally** using the CLI before deploying
+
+## Common Use Cases
+
+- **Running tests**: `npm test`, `pytest`, `go test`
+- **Linting**: `eslint`, `ruff`, `golangci-lint`
+- **Security scanning**: `npm audit`, `safety check`, `gosec`
+- **Build verification**: `npm run build`, `make`, `cargo build`
+- **Documentation generation**: `typedoc`, `sphinx-build`
+- **Deployment checks**: `terraform plan`, `kubectl diff`
+- **Custom validations**: Any shell script or command
+
+## Comparison with Script Provider
+
+Note: There is no "script" provider. The `command` provider is used for executing shell commands. If you see references to a "script" type in error messages or old documentation, use `type: command` instead.

--- a/src/providers/command-check-provider.ts
+++ b/src/providers/command-check-provider.ts
@@ -92,9 +92,13 @@ export class CommandCheckProvider extends CheckProvider {
       const { promisify } = await import('util');
       const execAsync = promisify(exec);
 
+      // Get timeout from config (in seconds) or use default (60 seconds)
+      const timeoutSeconds = (config.timeout as number) || 60;
+      const timeoutMs = timeoutSeconds * 1000;
+
       const { stdout, stderr } = await execAsync(renderedCommand, {
         env: scriptEnv,
-        timeout: 60000, // 60 second timeout
+        timeout: timeoutMs,
         maxBuffer: 10 * 1024 * 1024, // 10MB buffer
       });
 
@@ -206,7 +210,18 @@ export class CommandCheckProvider extends CheckProvider {
   }
 
   getSupportedConfigKeys(): string[] {
-    return ['type', 'exec', 'transform', 'env', 'depends_on', 'on', 'if', 'group', 'forEach'];
+    return [
+      'type',
+      'exec',
+      'transform',
+      'env',
+      'timeout',
+      'depends_on',
+      'on',
+      'if',
+      'group',
+      'forEach',
+    ];
   }
 
   async isAvailable(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Fix incorrect documentation reference from `script-check-provider` to `command-check-provider`
- Add comprehensive command provider documentation with security warnings
- Add configurable timeout support to command provider (in seconds)

## Changes

### Documentation Fixes
- Fixed CLAUDE.md reference to use correct provider name
- Added comprehensive `docs/command-provider.md` with:
  - Complete usage examples
  - Security warnings about command injection
  - Input sanitization examples
  - Environment variable usage (3 methods)
  - Timeout configuration examples

### New Feature: Configurable Timeout
- Command provider now supports `timeout` field (in seconds)
- Default remains 60 seconds
- Example: `timeout: 300` for 5 minutes

### Security Improvements
- Added critical warnings about command injection vulnerabilities
- Documented safe escaping methods for user input
- Examples of dangerous vs safe command patterns

## Test Plan
- [x] All existing tests pass
- [x] Pre-commit hooks passed
- [x] Linting and formatting applied

## Related Issue
Fixes user confusion about "Invalid check type 'script'" error - the correct type is `command`.

🤖 Generated with [Claude Code](https://claude.ai/code)