### PR TITLE
fix: Make 'on' field truly optional - checks can run on any event when not specified

### DIFF
--- a/.github/workflows/test-visor.yml
+++ b/.github/workflows/test-visor.yml
@@ -37,6 +37,12 @@ jobs:
           echo "Testing Visor CLI version..."
           ./dist/index.js --cli --version
       
+      - name: 🧪 Create test changes for analysis
+        run: |
+          echo "Creating dummy changes for CLI tests..."
+          echo "test content for CI" > test-file.txt
+          git add test-file.txt
+
       - name: 🧪 Test JSON Output
         run: |
           echo "Testing JSON output format..."
@@ -44,7 +50,7 @@ jobs:
             echo "JSON output test failed"
             exit 1
           }
-      
+
       - name: 🧪 Test SARIF Output
         run: |
           echo "Testing SARIF output format..."
@@ -88,6 +94,12 @@ jobs:
             sample-report.txt
           retention-days: 7
       
+      - name: 🧹 Clean up test files
+        run: |
+          echo "Cleaning up test files..."
+          git reset HEAD test-file.txt 2>/dev/null || true
+          rm -f test-file.txt
+
       - name: ✅ Verify Configuration
         run: |
           echo "Verifying configuration..."

--- a/.visor.test.yaml
+++ b/.visor.test.yaml
@@ -17,6 +17,31 @@ checks:
       timeout: 60000
       debug: false
 
+  # Performance check for CI testing - no 'on' field to test optional behavior
+  performance:
+    type: ai
+    group: test
+    schema: plain
+    prompt: "This is a mock performance analysis for CI testing. No real analysis is performed."
+    ai:
+      provider: mock
+      model: mock
+      timeout: 60000
+      debug: false
+
+  # Style check for CI testing
+  style:
+    type: ai
+    group: test
+    schema: plain
+    prompt: "This is a mock style analysis for CI testing. No real analysis is performed."
+    on: [manual]
+    ai:
+      provider: mock
+      model: mock
+      timeout: 60000
+      debug: false
+
 output:
   pr_comment:
     enabled: false  # Disable PR comments during CI testing

--- a/src/config.ts
+++ b/src/config.ts
@@ -372,10 +372,7 @@ export class ConfigManager {
         if (!checkConfig.type) {
           checkConfig.type = 'ai';
         }
-        // Default 'on' to ['manual'] if not specified
-        if (!checkConfig.on) {
-          checkConfig.on = ['manual'];
-        }
+        // 'on' field is optional - if not specified, check can run on any event
         this.validateCheckConfig(checkName, checkConfig, errors);
       }
     }
@@ -500,20 +497,23 @@ export class ConfigManager {
       }
     }
 
-    if (!checkConfig.on || !Array.isArray(checkConfig.on)) {
-      errors.push({
-        field: `checks.${checkName}.on`,
-        message: `Invalid check configuration for "${checkName}": missing or invalid 'on' field`,
-      });
-    } else {
-      // Validate event triggers
-      for (const event of checkConfig.on) {
-        if (!this.validEventTriggers.includes(event)) {
-          errors.push({
-            field: `checks.${checkName}.on`,
-            message: `Invalid event "${event}". Must be one of: ${this.validEventTriggers.join(', ')}`,
-            value: event,
-          });
+    // 'on' field is optional - if not specified, check can be triggered by any event
+    if (checkConfig.on) {
+      if (!Array.isArray(checkConfig.on)) {
+        errors.push({
+          field: `checks.${checkName}.on`,
+          message: `Invalid check configuration for "${checkName}": 'on' field must be an array`,
+        });
+      } else {
+        // Validate event triggers
+        for (const event of checkConfig.on) {
+          if (!this.validEventTriggers.includes(event)) {
+            errors.push({
+              field: `checks.${checkName}.on`,
+              message: `Invalid event "${event}". Must be one of: ${this.validEventTriggers.join(', ')}`,
+              value: event,
+            });
+          }
         }
       }
     }

--- a/src/event-mapper.ts
+++ b/src/event-mapper.ts
@@ -184,9 +184,9 @@ export class EventMapper {
     eventTrigger: EventTrigger,
     fileContext?: FileChangeContext
   ): boolean {
-    // Check if event trigger matches (default to ['manual'] if not specified)
-    const triggers = checkConfig.on || ['manual'];
-    if (!triggers.includes(eventTrigger)) {
+    // Check if event trigger matches
+    // If 'on' is not specified, the check can run on any event
+    if (checkConfig.on && !checkConfig.on.includes(eventTrigger)) {
       return false;
     }
 
@@ -341,8 +341,8 @@ export class EventMapper {
 
     // Check if any configured checks match this event
     return Object.values(this.config.checks || {}).some(checkConfig => {
-      const triggers = checkConfig.on || ['manual'];
-      return triggers.includes(eventTrigger);
+      // If 'on' is not specified, the check can run on any event
+      return !checkConfig.on || checkConfig.on.includes(eventTrigger);
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,8 +315,8 @@ async function handleEvent(
   const eventChecks: string[] = [];
   for (const [checkName, checkConfig] of Object.entries(config.checks || {})) {
     // Check if this check should run for this event
-    const checkEvents = checkConfig.on || ['pr_opened', 'pr_updated'];
-    if (checkEvents.includes(eventType)) {
+    // If 'on' is not specified, the check can run on any event
+    if (!checkConfig.on || checkConfig.on.includes(eventType)) {
       eventChecks.push(checkName);
     }
   }
@@ -780,13 +780,16 @@ async function handleIssueComment(
         const filteredCheckIds = checkIds.filter(checkId => {
           if (!config?.checks?.[checkId]) return false;
           const checkConfig = config.checks[checkId];
-          const checkEvents = checkConfig.on || ['pr_opened', 'pr_updated'];
+          // If 'on' is not specified, the check can run on any event
+          if (!checkConfig.on) {
+            return true;
+          }
           // For issue comments, only run checks that are configured for issue_comment events
           if (!isPullRequest) {
-            return checkEvents.includes('issue_comment');
+            return checkConfig.on.includes('issue_comment');
           }
           // For PR comments, run checks configured for PR events or issue_comment
-          return checkEvents.includes('pr_updated') || checkEvents.includes('issue_comment');
+          return checkConfig.on.includes('pr_updated') || checkConfig.on.includes('issue_comment');
         });
 
         if (filteredCheckIds.length === 0) {

--- a/tests/unit/config-default-type.test.ts
+++ b/tests/unit/config-default-type.test.ts
@@ -149,14 +149,14 @@ describe('Default Check Type Behavior', () => {
     expect(loadedConfig.checks['simple-check'].prompt).toBe('Just a simple prompt');
   });
 
-  it('should default to ["manual"] when on is not specified', async () => {
+  it('should keep on field undefined when not specified', async () => {
     const config: Partial<VisorConfig> = {
       version: '1.0',
       checks: {
         'test-check': {
           type: 'ai',
           prompt: 'Test prompt',
-          // No 'on' specified - should default to ['manual']
+          // No 'on' specified - remains undefined (can run on any event)
         } as CheckConfig,
         'another-check': {
           type: 'command',
@@ -172,8 +172,8 @@ describe('Default Check Type Behavior', () => {
     const configManager = new ConfigManager();
     const loadedConfig = await configManager.loadConfig(configPath);
 
-    // Check that the on field defaulted to ['manual']
-    expect(loadedConfig.checks['test-check'].on).toEqual(['manual']);
+    // Check that the on field is undefined (not defaulted)
+    expect(loadedConfig.checks['test-check'].on).toBeUndefined();
     // Check that explicitly set on is preserved
     expect(loadedConfig.checks['another-check'].on).toEqual(['pr_opened']);
   });
@@ -184,7 +184,7 @@ describe('Default Check Type Behavior', () => {
       checks: {
         'minimal-check': {
           // No type specified - should default to 'ai'
-          // No on specified - should default to ['manual']
+          // No on specified - remains undefined (can run on any event)
           prompt: 'Minimal check prompt',
         } as CheckConfig,
       },
@@ -196,9 +196,9 @@ describe('Default Check Type Behavior', () => {
     const configManager = new ConfigManager();
     const loadedConfig = await configManager.loadConfig(configPath);
 
-    // Check that both defaults are applied
+    // Check that type defaults to 'ai' but 'on' remains undefined
     expect(loadedConfig.checks['minimal-check'].type).toBe('ai');
-    expect(loadedConfig.checks['minimal-check'].on).toEqual(['manual']);
+    expect(loadedConfig.checks['minimal-check'].on).toBeUndefined();
     expect(loadedConfig.checks['minimal-check'].prompt).toBe('Minimal check prompt');
   });
 


### PR DESCRIPTION
## Summary
- Fixed issue where the `on` field was incorrectly required in check configurations
- When `on` field is not specified, checks can now run on ANY event (not restricted to 'manual')
- Checks still respect `depends_on` and other filtering mechanisms

## Changes
- Updated validation in `config.ts` to make `on` field truly optional
- Modified `event-mapper.ts` to treat missing `on` as "match all events"
- Updated `index.ts` to handle missing `on` field correctly across all code paths
- Removed default value assignments that were forcing `['manual']` or `['pr_opened', 'pr_updated']`
- Updated unit tests to reflect the new behavior

## Behavior
### Before
- Missing `on` field would cause validation error or default to `['manual']`
- Inconsistent behavior across different code paths

### After
- Missing `on` field means check can run on any event
- Consistent behavior: `undefined` `on` field = match all events
- Explicit `on: ['manual']` still restricts to manual triggers only

## Test plan
- [x] Unit tests updated and passing
- [x] Tested with configuration files with and without `on` field
- [x] Verified checks run correctly when `on` is omitted

🤖 Generated with [Claude Code](https://claude.ai/code)