### PR TITLE
CLI DX: centralized logger + --output-file flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,12 +237,12 @@ Learn more: [docs/performance.md](docs/performance.md)
 
 ## 👀 Observability
 
-Use JSON for pipelines or SARIF for code scanning.
+Use JSON for pipelines or SARIF for code scanning. To avoid any chance of logs mixing with the result stream, prefer the built‑in `--output-file`.
 
 Examples:
 ```bash
-visor --check security --output json
-visor --check security --output sarif > visor-results.sarif
+visor --check security --output json --output-file visor-results.json
+visor --check security --output sarif --output-file visor-results.sarif
 ```
 
 Learn more: [docs/observability.md](docs/observability.md)

--- a/docs/NPM_USAGE.md
+++ b/docs/NPM_USAGE.md
@@ -60,7 +60,12 @@ npx -y @probelabs/visor --check performance --check architecture --config .visor
 
 ### Generate SARIF report for CI/CD
 ```bash
-npx -y @probelabs/visor --check security --output sarif > results.sarif
+npx -y @probelabs/visor --check security --output sarif --output-file results.sarif
+```
+
+### Save JSON to a file (recommended)
+```bash
+npx -y @probelabs/visor --check all --output json --output-file visor-results.json
 ```
 
 ## Configuration

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,6 +1,12 @@
 ## 👀 Observability
 
 - Machine-readable output: `--output json` or `--output sarif`.
-- Redirect SARIF to file for upload: `> visor-results.sarif`.
-- Enable verbose logs with `--debug`.
+- Prefer the built‑in `--output-file <path>` to save results without touching stdout.
+- Status/progress logs are written to stderr; control verbosity via `-q`, `-v`, or `--debug`.
 
+Examples:
+
+```
+visor --check all --output json --output-file results.json
+visor --check security --output sarif --output-file visor-results.sarif
+```

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -5,3 +5,16 @@
 - Markdown: render comments as markdown
 - SARIF 2.1.0: `--output sarif` for code scanning
 
+### Saving outputs reliably
+
+- Use the built‑in `--output-file <path>` to write the formatted result directly to a file without mixing with logs.
+- All status logs are sent to stderr; stdout contains only the formatted result when not using `--output-file`.
+
+Examples:
+
+```
+visor --check all --output json --output-file results.json
+visor --check security --output sarif --output-file visor-results.sarif
+visor --check architecture --output markdown --output-file report.md
+visor --check style --output table --output-file summary.txt
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ export class CLI {
         []
       )
       .option('-o, --output <format>', 'Output format (table, json, markdown, sarif)', 'table')
+      .option('--output-file <path>', 'Write formatted output to a file instead of stdout')
       .option('--config <path>', 'Path to configuration file')
       .option(
         '--timeout <ms>',
@@ -43,6 +44,8 @@ export class CLI {
         value => parseInt(value, 10)
       )
       .option('--debug', 'Enable debug mode for detailed output')
+      .option('-v, --verbose', 'Increase verbosity (without full debug)')
+      .option('-q, --quiet', 'Reduce verbosity to warnings and errors')
       .option('--fail-fast', 'Stop execution on first failure condition')
       .option('--tags <tags>', 'Include checks with these tags (comma-separated)')
       .option('--exclude-tags <tags>', 'Exclude checks with these tags (comma-separated)')
@@ -88,6 +91,7 @@ export class CLI {
           []
         )
         .option('-o, --output <format>', 'Output format (table, json, markdown, sarif)', 'table')
+        .option('--output-file <path>', 'Write formatted output to a file instead of stdout')
         .option('--config <path>', 'Path to configuration file')
         .option(
           '--timeout <ms>',
@@ -100,6 +104,8 @@ export class CLI {
           value => parseInt(value, 10)
         )
         .option('--debug', 'Enable debug mode for detailed output')
+        .option('-v, --verbose', 'Increase verbosity (without full debug)')
+        .option('-q, --quiet', 'Reduce verbosity to warnings and errors')
         .option('--fail-fast', 'Stop execution on first failure condition')
         .option('--tags <tags>', 'Include checks with these tags (comma-separated)')
         .option('--exclude-tags <tags>', 'Exclude checks with these tags (comma-separated)')
@@ -158,10 +164,13 @@ export class CLI {
       return {
         checks: uniqueChecks,
         output: options.output as OutputFormat,
+        outputFile: options.outputFile,
         configPath: options.config,
         timeout: options.timeout,
         maxParallelism: options.maxParallelism,
         debug: options.debug,
+        verbose: options.verbose,
+        quiet: options.quiet,
         failFast: options.failFast,
         tags,
         excludeTags,
@@ -253,6 +262,7 @@ export class CLI {
         []
       )
       .option('-o, --output <format>', 'Output format (table, json, markdown, sarif)', 'table')
+      .option('--output-file <path>', 'Write formatted output to a file instead of stdout')
       .option('--config <path>', 'Path to configuration file')
       .option(
         '--timeout <ms>',
@@ -265,6 +275,8 @@ export class CLI {
         value => parseInt(value, 10)
       )
       .option('--debug', 'Enable debug mode for detailed output')
+      .option('-v, --verbose', 'Increase verbosity (without full debug)')
+      .option('-q, --quiet', 'Reduce verbosity to warnings and errors')
       .option('--fail-fast', 'Stop execution on first failure condition')
       .option('--tags <tags>', 'Include checks with these tags (comma-separated)')
       .option('--exclude-tags <tags>', 'Exclude checks with these tags (comma-separated)')
@@ -327,6 +339,7 @@ Examples:
   visor --check all --output json
   visor --check architecture --check security --output markdown
   visor --check security --output sarif > results.sarif
+  visor --check all --output json --output-file results.json   # Save to file reliably
   visor --check all --timeout 300000 --output json           # 5 minute timeout
   visor --check all --max-parallelism 5 --output json        # Run up to 5 checks in parallel
   visor --check all --debug --output markdown                # Enable debug mode

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,136 @@
+/*
+ * Centralized logger for Visor CLI and Action modes.
+ * - Respects output format (suppresses info in JSON/SARIF unless debug)
+ * - Supports levels: silent < error < warn < info < verbose < debug
+ * - Routes logs to stderr to keep stdout clean for machine-readable output
+ */
+
+export type LogLevel = 'silent' | 'error' | 'warn' | 'info' | 'verbose' | 'debug';
+
+function levelToNumber(level: LogLevel): number {
+  switch (level) {
+    case 'silent':
+      return 0;
+    case 'error':
+      return 10;
+    case 'warn':
+      return 20;
+    case 'info':
+      return 30;
+    case 'verbose':
+      return 40;
+    case 'debug':
+      return 50;
+  }
+}
+
+class Logger {
+  private level: LogLevel = 'info';
+  private isJsonLike: boolean = false;
+  private isTTY: boolean = typeof process !== 'undefined' ? !!process.stderr.isTTY : false;
+
+  configure(
+    opts: {
+      outputFormat?: string;
+      level?: LogLevel;
+      debug?: boolean;
+      verbose?: boolean;
+      quiet?: boolean;
+    } = {}
+  ): void {
+    // Determine base level
+    let lvl: LogLevel = 'info';
+
+    if (opts.debug || process.env.VISOR_DEBUG === 'true') {
+      lvl = 'debug';
+    } else if (opts.verbose || process.env.VISOR_LOG_LEVEL === 'verbose') {
+      lvl = 'verbose';
+    } else if (opts.quiet || process.env.VISOR_LOG_LEVEL === 'quiet') {
+      lvl = 'warn';
+    } else if (opts.level) {
+      lvl = opts.level;
+    } else if (process.env.VISOR_LOG_LEVEL) {
+      const envLvl = process.env.VISOR_LOG_LEVEL as LogLevel;
+      if (['silent', 'error', 'warn', 'info', 'verbose', 'debug'].includes(envLvl)) {
+        lvl = envLvl as LogLevel;
+      }
+    }
+
+    this.level = lvl;
+    const output = opts.outputFormat || process.env.VISOR_OUTPUT_FORMAT || 'table';
+    // In JSON/SARIF we suppress non-error logs unless explicitly verbose/debug
+    this.isJsonLike = output === 'json' || output === 'sarif';
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    const desired = levelToNumber(level);
+    const current = levelToNumber(this.level);
+    if (desired > current) return false;
+    if (
+      this.isJsonLike &&
+      desired < levelToNumber('error') &&
+      this.level !== 'debug' &&
+      this.level !== 'verbose'
+    ) {
+      // In JSON/SARIF, hide info/warn unless explicitly verbose/debug
+      return false;
+    }
+    return true;
+  }
+
+  private write(msg: string): void {
+    // Always route to stderr to keep stdout clean for results
+    try {
+      process.stderr.write(msg + '\n');
+    } catch {
+      // Ignore write errors
+    }
+  }
+
+  info(msg: string): void {
+    if (this.shouldLog('info')) this.write(msg);
+  }
+
+  warn(msg: string): void {
+    if (this.shouldLog('warn')) this.write(msg);
+  }
+
+  error(msg: string): void {
+    if (this.shouldLog('error')) this.write(msg);
+  }
+
+  verbose(msg: string): void {
+    if (this.shouldLog('verbose')) this.write(msg);
+  }
+
+  debug(msg: string): void {
+    if (this.shouldLog('debug')) this.write(msg);
+  }
+
+  step(msg: string): void {
+    // High-level phase indicator
+    if (this.shouldLog('info')) this.write(`▶ ${msg}`);
+  }
+
+  success(msg: string): void {
+    if (this.shouldLog('info')) this.write(`✔ ${msg}`);
+  }
+}
+
+// Singleton instance
+export const logger = new Logger();
+
+// Helper to configure from CLI options in a single place
+export function configureLoggerFromCli(options: {
+  output?: string;
+  debug?: boolean;
+  verbose?: boolean;
+  quiet?: boolean;
+}): void {
+  logger.configure({
+    outputFormat: options.output,
+    debug: options.debug,
+    verbose: options.verbose,
+    quiet: options.quiet,
+  });
+}

--- a/src/providers/log-check-provider.ts
+++ b/src/providers/log-check-provider.ts
@@ -3,6 +3,7 @@ import { PRInfo } from '../pr-analyzer';
 import { ReviewSummary } from '../reviewer';
 import { Liquid } from 'liquidjs';
 import { createExtendedLiquid } from '../liquid-extensions';
+import { logger } from '../logger';
 
 /**
  * Log levels supported by the log provider
@@ -91,9 +92,11 @@ export class LogCheckProvider extends CheckProvider {
       includeMetadata
     );
 
-    // Output to console based on log level
-    const logFn = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
-    logFn(logOutput);
+    // Route through centralized logger to keep stdout clean in JSON/SARIF
+    if (level === 'error') logger.error(logOutput);
+    else if (level === 'warn') logger.warn(logOutput);
+    else if (level === 'debug') logger.debug(logOutput);
+    else logger.info(logOutput);
 
     // Return with the log content as custom data for dependent checks
     return {

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -24,6 +24,10 @@ export interface CliOptions {
   maxParallelism?: number;
   /** Enable debug mode for detailed output */
   debug?: boolean;
+  /** Increase verbosity (more than info, less than debug) */
+  verbose?: boolean;
+  /** Reduce verbosity to warnings and errors */
+  quiet?: boolean;
   /** Stop execution on first failure condition */
   failFast?: boolean;
   /** Tags to include - checks must have at least one of these tags */
@@ -38,6 +42,8 @@ export interface CliOptions {
   version?: boolean;
   /** Code context mode: auto (default), enabled (force include), disabled (force exclude) */
   codeContext?: 'auto' | 'enabled' | 'disabled';
+  /** When set, write formatted output to this file instead of stdout */
+  outputFile?: string;
 }
 
 /**


### PR DESCRIPTION
This PR improves the Visor CLI developer experience and adds a safe way to persist results.\n\nHighlights\n- Centralized logger (stderr), levels: silent/error/warn/info/verbose/debug\n- Clear step logs and final summary; JSON/SARIF stay clean\n- New flags: `-v/--verbose`, `-q/--quiet`\n- New `--output-file <path>` to write formatted output without relying on shell redirection\n- `log` provider now uses the logger (no stdout pollution)\n- Docs updated: output formats, observability, npm usage\n\nCompatibility\n- All formats preserved: table/json/markdown/sarif\n- Unit tests updated to capture stderr where appropriate\n- Integration and E2E suites green locally\n\nNext\n- (Optional) apply the same logger to Action mode for consistency and less noise in workflows.\n