### PR TITLE
fix: Improve debug logging to respect --debug flag and handle undefined values

### DIFF
--- a/src/ai-review-service.ts
+++ b/src/ai-review-service.ts
@@ -3,16 +3,13 @@ import type { ProbeAgentOptions } from '@probelabs/probe';
 import { PRInfo } from './pr-analyzer';
 import { ReviewSummary, ReviewIssue } from './reviewer';
 import { SessionRegistry } from './session-registry';
+import { logger } from './logger';
 
 /**
- * Helper function to log messages respecting JSON/SARIF output format
- * Routes to stderr for JSON/SARIF to avoid contaminating structured output
+ * Helper function to log debug messages using the centralized logger
  */
 function log(...args: unknown[]): void {
-  const isStructuredOutput =
-    process.env.VISOR_OUTPUT_FORMAT === 'json' || process.env.VISOR_OUTPUT_FORMAT === 'sarif';
-  const logFn = isStructuredOutput ? console.error : console.log;
-  logFn(...args);
+  logger.debug(args.join(' '));
 }
 
 export interface AIReviewConfig {


### PR DESCRIPTION
## Summary
Fixed debug messages appearing without `--debug` flag by migrating all `process.env.DEBUG` checks to use the centralized logger and adding proper error handling for undefined values.

## Changes
- **src/check-execution-engine.ts**: Wrapped `log()` calls with `if(debug)` checks, added try-catch for `logger.debug()` calls that use `.slice()`
- **src/providers/command-check-provider.ts**: Replaced `process.env.DEBUG` checks with `logger.debug()` calls, added error handling for undefined values
- **src/ai-review-service.ts**: Changed `log()` helper function to use centralized `logger.debug()`
- **tests/unit/providers/command-check-provider.test.ts**: Updated tests to use `VISOR_DEBUG` instead of `DEBUG`

## How it Works Now
- Debug output is controlled solely by the `--debug` CLI flag or `VISOR_DEBUG=true` environment variable
- The `DEBUG` env var (used by other Node debugging tools) no longer triggers debug output
- Default log level is `info` - debug messages are suppressed unless explicitly requested
- All debug logging safely handles undefined/null values without crashing

## Test Results
✅ All 88 test suites pass (1 skipped as configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)