### PR TITLE
fix: outputs access, custom schemas, and skipped checks

### DIFF
--- a/src/dependency-resolver.ts
+++ b/src/dependency-resolver.ts
@@ -193,6 +193,46 @@ export class DependencyResolver {
   }
 
   /**
+   * Get all transitive dependencies (ancestors) for a given check
+   * This returns all checks that must complete before the given check can run,
+   * not just the direct dependencies.
+   *
+   * For example, if A -> B -> C, then:
+   * - getAllDependencies(C) returns [A, B]
+   * - getAllDependencies(B) returns [A]
+   * - getAllDependencies(A) returns []
+   *
+   * @param checkId The check to find dependencies for
+   * @param nodes The dependency graph nodes
+   * @returns Array of all transitive dependency IDs
+   */
+  static getAllDependencies(checkId: string, nodes: Map<string, CheckNode>): string[] {
+    const allDeps = new Set<string>();
+    const visited = new Set<string>();
+
+    const collectDependencies = (currentId: string) => {
+      if (visited.has(currentId)) {
+        return;
+      }
+      visited.add(currentId);
+
+      const node = nodes.get(currentId);
+      if (!node) {
+        return;
+      }
+
+      // Add direct dependencies and recurse
+      for (const depId of node.dependencies) {
+        allDeps.add(depId);
+        collectDependencies(depId);
+      }
+    };
+
+    collectDependencies(checkId);
+    return Array.from(allDeps);
+  }
+
+  /**
    * Get execution statistics for debugging
    */
   static getExecutionStats(graph: DependencyGraph): {

--- a/tests/unit/custom-schema-preservation.test.ts
+++ b/tests/unit/custom-schema-preservation.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { AIReviewService } from '../../src/ai-review-service';
+
+/**
+ * Unit Test: Custom Schema Field Preservation
+ *
+ * This test verifies that AI checks with custom schemas preserve
+ * all fields from the AI response and don't force them into the
+ * standard code review schema with "issues" array.
+ */
+describe('Custom Schema Field Preservation', () => {
+  it('should preserve all fields for inline custom schemas', async () => {
+    const mockConfig = {
+      provider: 'mock' as const,
+      model: 'mock',
+      apiKey: 'test-key',
+      debug: false,
+    };
+
+    const service = new AIReviewService(mockConfig);
+
+    const customSchema = {
+      type: 'object',
+      properties: {
+        complexity: { type: 'string' },
+        priority: { type: 'number' },
+        estimated_hours: { type: 'number' },
+      },
+    };
+
+    const mockPRInfo = {
+      number: 123,
+      title: 'Test',
+      body: '',
+      author: 'test',
+      base: 'main',
+      head: 'feat',
+      files: [],
+      totalAdditions: 0,
+      totalDeletions: 0,
+    };
+
+    // Mock the AI response to return custom schema data
+    jest.spyOn(service as any, 'callProbeAgent').mockResolvedValue({
+      response: JSON.stringify({
+        complexity: 'high',
+        priority: 8,
+        estimated_hours: 24,
+      }),
+      effectiveSchema: 'custom',
+    });
+
+    const result = await service.executeReview(
+      mockPRInfo,
+      'Analyze this',
+      customSchema,
+      'test-check'
+    );
+
+    // Should have output field with all custom fields
+    expect((result as any).output).toBeDefined();
+    expect((result as any).output.complexity).toBe('high');
+    expect((result as any).output.priority).toBe(8);
+    expect((result as any).output.estimated_hours).toBe(24);
+
+    // Should have empty issues array (no code review)
+    expect(result.issues).toEqual([]);
+  });
+
+  it('should preserve all fields for file-based custom schemas', async () => {
+    const mockConfig = {
+      provider: 'mock' as const,
+      model: 'mock',
+      apiKey: 'test-key',
+      debug: false,
+    };
+
+    const service = new AIReviewService(mockConfig);
+
+    const mockPRInfo = {
+      number: 123,
+      title: 'Test',
+      body: '',
+      author: 'test',
+      base: 'main',
+      head: 'feat',
+      files: [],
+      totalAdditions: 0,
+      totalDeletions: 0,
+    };
+
+    // Mock the AI response with a file-based schema path
+    jest.spyOn(service as any, 'callProbeAgent').mockResolvedValue({
+      response: JSON.stringify({
+        temperature: 72,
+        conditions: 'sunny',
+        forecast: ['clear', 'rain'],
+      }),
+      effectiveSchema: './schemas/weather.json',
+    });
+
+    const result = await service.executeReview(
+      mockPRInfo,
+      'What is the weather?',
+      './schemas/weather.json',
+      'weather-check'
+    );
+
+    // Should preserve custom fields
+    expect((result as any).output).toBeDefined();
+    expect((result as any).output.temperature).toBe(72);
+    expect((result as any).output.conditions).toBe('sunny');
+    expect((result as any).output.forecast).toEqual(['clear', 'rain']);
+
+    // Should have empty issues array
+    expect(result.issues).toEqual([]);
+  });
+
+  it('should NOT preserve custom fields for code-review schema', async () => {
+    const mockConfig = {
+      provider: 'mock' as const,
+      model: 'mock',
+      apiKey: 'test-key',
+      debug: false,
+    };
+
+    const service = new AIReviewService(mockConfig);
+
+    const mockPRInfo = {
+      number: 123,
+      title: 'Test',
+      body: '',
+      author: 'test',
+      base: 'main',
+      head: 'feat',
+      files: [],
+      totalAdditions: 0,
+      totalDeletions: 0,
+    };
+
+    // Mock the AI response with code-review schema
+    jest.spyOn(service as any, 'callProbeAgent').mockResolvedValue({
+      response: JSON.stringify({
+        issues: [
+          {
+            file: 'test.js',
+            line: 10,
+            ruleId: 'security/xss',
+            message: 'Potential XSS',
+            severity: 'error',
+            category: 'security',
+          },
+        ],
+      }),
+      effectiveSchema: 'code-review',
+    });
+
+    const result = await service.executeReview(
+      mockPRInfo,
+      'Review this code',
+      'code-review',
+      'review-check'
+    );
+
+    // Should have processed issues
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues![0].file).toBe('test.js');
+    expect(result.issues![0].severity).toBe('error');
+
+    // Should NOT have output field for code-review schema
+    expect((result as any).output).toBeUndefined();
+  });
+
+  it('should handle custom schemas with no required fields', async () => {
+    const mockConfig = {
+      provider: 'mock' as const,
+      model: 'mock',
+      apiKey: 'test-key',
+      debug: false,
+    };
+
+    const service = new AIReviewService(mockConfig);
+
+    const customSchema = {
+      type: 'object',
+      properties: {
+        score: { type: 'number' },
+        notes: { type: 'string' },
+      },
+      // No required fields
+    };
+
+    const mockPRInfo = {
+      number: 123,
+      title: 'Test',
+      body: '',
+      author: 'test',
+      base: 'main',
+      head: 'feat',
+      files: [],
+      totalAdditions: 0,
+      totalDeletions: 0,
+    };
+
+    jest.spyOn(service as any, 'callProbeAgent').mockResolvedValue({
+      response: JSON.stringify({
+        score: 95,
+        // notes field omitted
+      }),
+      effectiveSchema: 'custom',
+    });
+
+    const result = await service.executeReview(
+      mockPRInfo,
+      'Score this',
+      customSchema,
+      'score-check'
+    );
+
+    // Should preserve whatever fields are present
+    expect((result as any).output).toBeDefined();
+    expect((result as any).output.score).toBe(95);
+    expect((result as any).output.notes).toBeUndefined();
+    expect(result.issues).toEqual([]);
+  });
+});

--- a/tests/unit/transitive-dependency-outputs.test.ts
+++ b/tests/unit/transitive-dependency-outputs.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from '@jest/globals';
+import { DependencyResolver } from '../../src/dependency-resolver';
+
+/**
+ * Unit Test: Transitive Dependency Outputs Access
+ *
+ * This test verifies that checks have access to outputs from ALL
+ * transitive dependencies (ancestors), not just direct dependencies.
+ *
+ * Example chain: A -> B -> C
+ * - Check C should have access to outputs from both B and A
+ */
+describe('Transitive Dependency Outputs Access', () => {
+  it('should return all transitive dependencies for a check', () => {
+    // Build a dependency chain: A -> B -> C
+    const dependencies = {
+      A: [],
+      B: ['A'],
+      C: ['B'],
+    };
+
+    const graph = DependencyResolver.buildDependencyGraph(dependencies);
+
+    // Get all dependencies for C
+    const allDepsC = DependencyResolver.getAllDependencies('C', graph.nodes);
+
+    // C should have access to both B and A (its transitive dependencies)
+    expect(allDepsC).toContain('B'); // Direct dependency
+    expect(allDepsC).toContain('A'); // Transitive dependency (B depends on A)
+    expect(allDepsC.length).toBe(2);
+  });
+
+  it('should return all transitive dependencies for a complex graph', () => {
+    // Build a complex dependency graph:
+    //   A
+    //   |
+    //   B
+    //  / \
+    // C   D
+    //  \ /
+    //   E
+    const dependencies = {
+      A: [],
+      B: ['A'],
+      C: ['B'],
+      D: ['B'],
+      E: ['C', 'D'],
+    };
+
+    const graph = DependencyResolver.buildDependencyGraph(dependencies);
+
+    // Get all dependencies for E
+    const allDepsE = DependencyResolver.getAllDependencies('E', graph.nodes);
+
+    // E should have access to C, D (direct), B (via C and D), and A (via B)
+    expect(allDepsE).toContain('C'); // Direct dependency
+    expect(allDepsE).toContain('D'); // Direct dependency
+    expect(allDepsE).toContain('B'); // Transitive dependency (via C and D)
+    expect(allDepsE).toContain('A'); // Transitive dependency (via B)
+    expect(allDepsE.length).toBe(4);
+  });
+
+  it('should return empty array for checks with no dependencies', () => {
+    const dependencies = {
+      A: [],
+      B: ['A'],
+    };
+
+    const graph = DependencyResolver.buildDependencyGraph(dependencies);
+
+    // A has no dependencies
+    const allDepsA = DependencyResolver.getAllDependencies('A', graph.nodes);
+    expect(allDepsA).toEqual([]);
+  });
+
+  it('should handle diamond dependency pattern', () => {
+    // Diamond pattern:
+    //     A
+    //    / \
+    //   B   C
+    //    \ /
+    //     D
+    const dependencies = {
+      A: [],
+      B: ['A'],
+      C: ['A'],
+      D: ['B', 'C'],
+    };
+
+    const graph = DependencyResolver.buildDependencyGraph(dependencies);
+
+    // Get all dependencies for D
+    const allDepsD = DependencyResolver.getAllDependencies('D', graph.nodes);
+
+    // D should have B, C, and A (without duplicates)
+    expect(allDepsD).toContain('B');
+    expect(allDepsD).toContain('C');
+    expect(allDepsD).toContain('A');
+    expect(allDepsD.length).toBe(3); // No duplicates despite A being reachable via both B and C
+  });
+
+  it('should handle long dependency chains', () => {
+    // Long chain: A -> B -> C -> D -> E -> F
+    const dependencies = {
+      A: [],
+      B: ['A'],
+      C: ['B'],
+      D: ['C'],
+      E: ['D'],
+      F: ['E'],
+    };
+
+    const graph = DependencyResolver.buildDependencyGraph(dependencies);
+
+    // Get all dependencies for F
+    const allDepsF = DependencyResolver.getAllDependencies('F', graph.nodes);
+
+    // F should have access to all previous checks in the chain
+    expect(allDepsF).toContain('E');
+    expect(allDepsF).toContain('D');
+    expect(allDepsF).toContain('C');
+    expect(allDepsF).toContain('B');
+    expect(allDepsF).toContain('A');
+    expect(allDepsF.length).toBe(5);
+  });
+
+  it('should work with checks that have multiple direct dependencies', () => {
+    // Complex pattern:
+    //   A   B   C
+    //    \ | /
+    //      D
+    const dependencies = {
+      A: [],
+      B: [],
+      C: [],
+      D: ['A', 'B', 'C'],
+    };
+
+    const graph = DependencyResolver.buildDependencyGraph(dependencies);
+
+    // Get all dependencies for D
+    const allDepsD = DependencyResolver.getAllDependencies('D', graph.nodes);
+
+    // D should have access to A, B, and C
+    expect(allDepsD).toContain('A');
+    expect(allDepsD).toContain('B');
+    expect(allDepsD).toContain('C');
+    expect(allDepsD.length).toBe(3);
+  });
+
+  it('should handle mixed direct and transitive dependencies', () => {
+    // Pattern:
+    //   A -> B
+    //   |    |
+    //   v    v
+    //   C <- D
+    //   (D depends on B, C depends on both A and D)
+    const dependencies = {
+      A: [],
+      B: ['A'],
+      D: ['B'],
+      C: ['A', 'D'],
+    };
+
+    const graph = DependencyResolver.buildDependencyGraph(dependencies);
+
+    // Get all dependencies for C
+    const allDepsC = DependencyResolver.getAllDependencies('C', graph.nodes);
+
+    // C should have access to A (direct), D (direct), B (via D), and A (via D -> B -> A)
+    expect(allDepsC).toContain('A'); // Direct dependency
+    expect(allDepsC).toContain('D'); // Direct dependency
+    expect(allDepsC).toContain('B'); // Transitive via D
+    expect(allDepsC.length).toBe(3); // A appears only once despite multiple paths
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes three critical issues with check outputs and dependencies:

### 1. Custom Schema Free-Form Data Preservation

**Problem:** AI checks with custom schemas were forced into the standard code review schema format, losing all custom fields.

**Solution:**
- Detect custom schemas (inline, file-based, or non-built-in)
- Preserve ALL fields in `output` property for custom schemas
- Return empty `issues` array for custom schemas
- Standard code-review schema continues to work as before

**Example:**
```yaml
checks:
  analyze-ticket:
    type: ai
    schema: { complexity: string, priority: number, estimated_hours: number }
    # AI returns: { complexity: "high", priority: 8, estimated_hours: 24 }
    # Before: Lost all fields ❌
    # After: Preserved in output { issues: [], output: { complexity: "high", ... } } ✅

  log-results:
    type: log
    depends_on: [analyze-ticket]
    message: "Complexity: {{ outputs['analyze-ticket'].complexity }}" # Now works! ✅
```

### 2. Transitive Dependency Outputs Access

**Problem:** In dependency chains like A → B → C, check C could only access outputs from B (direct dependency), not from A (transitive dependency).

**Solution:**
- Added `DependencyResolver.getAllDependencies()` to recursively collect all transitive dependencies
- Updated check execution to include ALL ancestor outputs in the `outputs` variable

**Example:**
```yaml
checks:
  A: { type: command, exec: "echo 'A'" }
  B: { type: command, depends_on: [A], exec: "echo '{{ outputs.A }}'" }
  C: { type: command, depends_on: [B], exec: "echo '{{ outputs.A }} {{ outputs.B }}'" }
  # Before: C could NOT access outputs.A ❌
  # After: C can access both outputs.A and outputs.B ✅
```

### 3. Skipped Checks Appearing in Outputs

**Problem:** When a check was skipped (via `if` condition), it still appeared in `outputs` with an empty `issues` array.

**Solution:**
- Don't store skipped check results in the results map
- Skipped checks no longer appear in the `outputs` variable

**Example:**
```yaml
checks:
  maybe-check: { type: command, if: "false", exec: "echo 'hi'" }
  other-check: { type: log, message: "{{ outputs | json }}" }
  # Before: {"maybe-check": {"issues": []}} ❌
  # After: {} ✅
```

## Changes

### Files Modified:
- `src/ai-review-service.ts` - Custom schema detection and field preservation
- `src/dependency-resolver.ts` - Added `getAllDependencies()` method
- `src/check-execution-engine.ts` - Use transitive dependencies; skip storing skipped checks

### Tests Added:
- `tests/unit/custom-schema-preservation.test.ts` (4 tests)
- `tests/unit/transitive-dependency-outputs.test.ts` (7 tests)
- Updated `tests/unit/providers/command-check-provider.test.ts` (1 test)

## Testing

- ✅ All 1116 tests pass
- ✅ No regressions
- ✅ 11 new tests added

## Related Issues

Fixes issues reported by @buger regarding:
1. Custom schemas requiring standard `issues` array
2. Missing transitive dependency outputs in chains
3. Skipped checks polluting the outputs variable