### PR TITLE
fix: clarify critical severity for new issues only

### DIFF
--- a/dist/output/code-review/schema.json
+++ b/dist/output/code-review/schema.json
@@ -39,7 +39,7 @@
           "severity": {
             "type": "string",
             "enum": ["info", "warning", "error", "critical"],
-            "description": "Issue severity level: info (suggestions/improvements), warning (should fix), error (must fix), critical (blocks deployment)"
+            "description": "Issue severity level based on the NEW CODE being introduced: info (suggestions/improvements), warning (should fix), error (must fix), critical (NEW security vulnerabilities, data loss risks, or breaking changes that block deployment). IMPORTANT: Use 'critical' ONLY when NEW problematic code is INTRODUCED, NOT when existing issues are being FIXED. Fixes and improvements should use 'info' or 'warning' severity."
           },
           "category": {
             "type": "string",

--- a/output/code-review/schema.json
+++ b/output/code-review/schema.json
@@ -39,7 +39,7 @@
           "severity": {
             "type": "string",
             "enum": ["info", "warning", "error", "critical"],
-            "description": "Issue severity level: info (suggestions/improvements), warning (should fix), error (must fix), critical (blocks deployment)"
+            "description": "Issue severity level based on the NEW CODE being introduced: info (suggestions/improvements), warning (should fix), error (must fix), critical (NEW security vulnerabilities, data loss risks, or breaking changes that block deployment). IMPORTANT: Use 'critical' ONLY when NEW problematic code is INTRODUCED, NOT when existing issues are being FIXED. Fixes and improvements should use 'info' or 'warning' severity."
           },
           "category": {
             "type": "string",


### PR DESCRIPTION
## Summary
Fixes the issue where the AI incorrectly marks **fixes for critical problems** as critical themselves, instead of recognizing them as improvements.

## Problem
When reviewing PRs, the AI was assigning "critical" severity to code changes that **fixed** critical issues (e.g., removing an infinite loop, fixing a security vulnerability). This is incorrect - the AI should only mark **newly introduced problematic code** as critical, not beneficial fixes.

### Example of Incorrect Behavior (Before)
```
🔴 Critical	npm/src/agent/schemaUtils.js:890-893	
The removal of the `schema` parameter from the `this.agent.answer()` call is a 
critical fix for an infinite loop. This change is essential for system stability.
```

The AI marked the **removal** of an infinite loop as "critical" because it's fixing a critical issue.

## Solution
Updated the `code-review` schema's severity description to be explicit about when to use "critical":

**Before:**
```json
"severity": "Issue severity level: info (suggestions/improvements), warning (should fix), 
error (must fix), critical (blocks deployment)"
```

**After:**
```json
"severity": "Issue severity level based on the NEW CODE being introduced: 
info (suggestions/improvements), warning (should fix), error (must fix), 
critical (NEW security vulnerabilities, data loss risks, or breaking changes that block deployment). 
IMPORTANT: Use 'critical' ONLY when NEW problematic code is INTRODUCED, NOT when existing 
issues are being FIXED. Fixes and improvements should use 'info' or 'warning' severity."
```

## Changes
- ✅ Updated `output/code-review/schema.json`
- ✅ Updated `dist/output/code-review/schema.json`
- ✅ Clarified that "critical" = NEW problems being INTRODUCED
- ✅ Emphasized that fixes = info or warning severity

## Impact
- AI will now correctly assess the severity of code changes based on whether they introduce or fix issues
- Reduces false positives for critical severity flags
- Makes failure conditions like `fail_if: "criticalIssues > 0"` more accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>