### PR TITLE
Default to CLI mode; explicit --mode github-actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,38 @@ Example:
 node dist/index.js --cli --check all --debug
 ```
 
+Run modes
+
+- Default is CLI mode everywhere (no auto-detection).
+- For GitHub-specific behavior (comments, checks), run with `--mode github-actions` or set `with: mode: github-actions` when using the GitHub Action.
+
+Examples:
+
+```bash
+# Local/CI CLI
+npx @probelabs/visor --config .visor.yaml --check all --output json
+
+# GitHub Actions behavior from any shell/CI
+npx @probelabs/visor --mode github-actions --config .visor.yaml --check all
+```
+
+GitHub Action usage:
+
+```yaml
+- uses: probelabs/visor@vX
+  with:
+    mode: github-actions
+    checks: all
+    output-format: json
+```
+
+To force CLI mode inside a GitHub Action step, you can still use:
+
+```yaml
+env:
+  VISOR_MODE: cli
+```
+
 Learn more: [docs/troubleshooting.md](docs/troubleshooting.md)
 
 ## 🔐 Security Defaults

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ branding:
   color: 'blue'
 
 inputs:
+  mode:
+    description: 'Run mode: github-actions or cli. Default: github-actions'
+    required: false
+    default: 'github-actions'
   github-token:
     description: 'GitHub token for API access (use this OR app-id/private-key)'
     required: false

--- a/docs/ci-cli-mode.md
+++ b/docs/ci-cli-mode.md
@@ -1,0 +1,34 @@
+# Run Modes in CI (including GitHub Actions)
+
+Visor now defaults to CLI mode everywhere (no auto-detection). To enable GitHub-specific behavior (comments, checks), pass `--mode github-actions` or set the action input `mode: github-actions`.
+
+Examples (GitHub Actions – CLI mode):
+
+```yaml
+jobs:
+  visor-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx @probelabs/visor --config .visor.yaml --output json
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+GitHub Actions behavior (comments/checks):
+
+```yaml
+jobs:
+  visor-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx @probelabs/visor --mode github-actions --config .visor.yaml --output json
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+Notes:
+
+- In CLI mode, GitHub credentials aren’t required. Provide your AI provider keys as env vars (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.).
+- If you want PR comments/checks, run with `--mode github-actions` or use the published action with `with: mode: github-actions`.

--- a/docs/dev-playbook.md
+++ b/docs/dev-playbook.md
@@ -6,5 +6,4 @@
 - Secure credentials: prefer GitHub App in production; scope/rotate API keys.
 - Make feedback actionable: group related checks; use `/review --check ...` triggers; enable `reuse_ai_session` for follow-ups.
 - Keep suppressions intentional: annotate context; audit `visor-disable-file` periodically.
-- Validate locally: `node dist/index.js --cli --check security --output markdown`; run tests; `--fail-fast` for fast lanes.
-
+- Validate locally: `npx @probelabs/visor --check security --output markdown`; run tests; `--fail-fast` for fast lanes.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,8 +1,7 @@
 ## 🛠️ Troubleshooting
 
 - Increase logging with `--debug` or action `debug: true`.
-- Validate config locally: `node dist/index.js --cli --check all`.
+- Validate config locally: `npx @probelabs/visor --check all`.
 - Ensure required permissions in Actions: contents/read, pull-requests/write, issues/write, checks/write.
 - If annotations don’t appear, confirm schema is `code-review` and issues have file/line.
 - For remote extends, set `--allowed-remote-patterns` or disable via `--no-remote-extends`.
-

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,7 @@ export class CLI {
       .option('--no-remote-extends', 'Disable loading configurations from remote URLs')
       .option('--enable-code-context', 'Force include code diffs in analysis (CLI mode)')
       .option('--disable-code-context', 'Force exclude code diffs from analysis (CLI mode)')
+      .option('--mode <mode>', 'Run mode (cli|github-actions). Default: cli')
       .addHelpText('after', this.getExamplesText())
       .exitOverride(); // Prevent automatic process.exit for better error handling
 
@@ -115,6 +116,7 @@ export class CLI {
         )
         .option('--enable-code-context', 'Force include code diffs in analysis (CLI mode)')
         .option('--disable-code-context', 'Force exclude code diffs from analysis (CLI mode)')
+        .option('--mode <mode>', 'Run mode (cli|github-actions). Default: cli')
         .allowUnknownOption(false)
         .allowExcessArguments(false) // Don't allow positional arguments
         .addHelpText('after', this.getExamplesText())
@@ -282,6 +284,7 @@ export class CLI {
       .option('--exclude-tags <tags>', 'Exclude checks with these tags (comma-separated)')
       .option('--enable-code-context', 'Force include code diffs in analysis (CLI mode)')
       .option('--disable-code-context', 'Force exclude code diffs from analysis (CLI mode)')
+      .option('--mode <mode>', 'Run mode (cli|github-actions). Default: cli')
       .addHelpText('after', this.getExamplesText());
 
     // Get the basic help and append examples manually if addHelpText doesn't work


### PR DESCRIPTION
This PR changes the default execution mode to CLI everywhere. GitHub-specific behavior now requires an explicit selection via\n\n- CLI: `--mode github-actions`\n- Env: `VISOR_MODE=github-actions` or `INPUT_MODE=github-actions` (for the action wrapper)\n\nAdditional changes:\n- Add `--mode` option to CLI help and parsing.\n- Add `mode` input to action.yml (default `github-actions`) to preserve existing action workflows.\n- Update README and docs (docs/ci-cli-mode.md, troubleshooting, dev-playbook).\n\nWhy: avoids accidental GitHub API auth in CI that merely wants CLI behavior.\n\nMigration notes:\n- For published action usage, set `with: mode: github-actions`.\n- For direct CLI usage that needs comments/checks, pass `--mode github-actions`.\n\nBuild: regenerated `dist/index.js`.