### PR TITLE
fix: force process exit after cleanup to prevent hanging

### DIFF
--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -421,9 +421,11 @@ export async function main(): Promise<void> {
       sessionRegistry.clearAllSessions();
     }
 
-    if (criticalCount > 0 || hasRepositoryError) {
-      process.exit(1);
-    }
+    // Force exit to prevent hanging from unclosed resources (MCP connections, etc.)
+    // This is necessary because some async resources may not be properly cleaned up
+    // and can keep the event loop alive indefinitely
+    const exitCode = criticalCount > 0 || hasRepositoryError ? 1 : 0;
+    process.exit(exitCode);
   } catch (error) {
     // Import error classes dynamically to avoid circular dependencies
     const { ClaudeCodeSDKNotInstalledError, ClaudeCodeAPIKeyMissingError } = await import(


### PR DESCRIPTION
## Summary
Fixes an issue where Visor CLI would complete all work successfully but then hang indefinitely instead of exiting, particularly problematic in GitHub Actions environments.

## Problem
When running Visor workflows that use MCP servers and AI checks with `forEach` loops, the process would:
1. Complete all checks successfully
2. Clean up AI sessions and MCP connections  
3. Print completion messages
4. **Hang indefinitely** instead of exiting

This caused GitHub Actions workflows to timeout after completing all work.

## Root Cause
Some async resources (MCP server connections, event listeners, or other Node.js handles) were keeping the event loop alive even after cleanup routines completed. The cleanup functions were called, but they didn't fully release all resources.

## Solution
Added a forced `process.exit()` call after cleanup completes, ensuring the process terminates with the appropriate exit code (0 for success, 1 for critical issues/errors).

## Changes
- Modified `src/cli-main.ts` to always call `process.exit()` after session cleanup
- Exit code is determined based on critical issues or repository errors
- This brings the success path in line with error paths (which already had `process.exit()` calls)

## Testing
- Builds successfully
- The fix aligns with existing error handling patterns in the codebase
- Will resolve hanging GitHub Actions workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)