### PR TITLE
fix: improve timeout error handling for command check provider

### DIFF
--- a/src/generated/config-schema.ts
+++ b/src/generated/config-schema.ts
@@ -200,6 +200,10 @@ export const configSchema = {
           $ref: '#/definitions/EnvConfig',
           description: 'Environment variables for this check',
         },
+        timeout: {
+          type: 'number',
+          description: 'Timeout in seconds for command execution (default: 60)',
+        },
         depends_on: {
           type: 'array',
           items: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -328,6 +328,8 @@ export interface CheckConfig {
   claude_code?: ClaudeCodeConfig;
   /** Environment variables for this check */
   env?: EnvConfig;
+  /** Timeout in seconds for command execution (default: 60) */
+  timeout?: number;
   /** Check IDs that this check depends on (optional) */
   depends_on?: string[];
   /** Group name for comment separation (e.g., "code-review", "pr-overview") - optional */


### PR DESCRIPTION
## Summary
- Properly detect and report command timeout errors with specific error handling
- Use `command/timeout` ruleId instead of generic `command/execution_error` for timeouts
- Include configured timeout duration in error message for better debugging

## Changes
Enhanced the error handling in `CommandCheckProvider` to:
1. Detect timeout errors by checking for `killed=true` with `signal='SIGTERM'` or `code='ETIMEDOUT'`
2. Provide clear error message: "Command execution timed out after X seconds"
3. Use specific `command/timeout` ruleId for easier filtering and handling

## Test plan
- [ ] Test command that times out with default 60s timeout
- [ ] Test command that times out with custom timeout setting
- [ ] Verify error message includes timeout duration
- [ ] Verify ruleId is `command/timeout` for timeout errors
- [ ] Verify non-timeout errors still use `command/execution_error` ruleId

🤖 Generated with [Claude Code](https://claude.com/claude-code)