### PR TITLE
fix: resolve command timeout, forEach validation, and fail_if evaluation issues

### DIFF
--- a/src/failure-condition-evaluator.ts
+++ b/src/failure-condition-evaluator.ts
@@ -556,8 +556,12 @@ export class FailureConditionEvaluator {
     const reviewSummaryWithOutput = reviewSummary as ReviewSummary & { output?: unknown };
 
     // Extract output field to avoid nesting (output.output)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { output: extractedOutput, issues: _issues, ...otherFields } = reviewSummaryWithOutput as any;
+    const {
+      output: extractedOutput,
+      // Exclude issues from otherFields since we handle it separately
+      issues: _issues, // eslint-disable-line @typescript-eslint/no-unused-vars
+      ...otherFields
+    } = reviewSummaryWithOutput as any;
 
     const context: FailureConditionContext = {
       output: {

--- a/src/failure-condition-evaluator.ts
+++ b/src/failure-condition-evaluator.ts
@@ -553,6 +553,11 @@ export class FailureConditionEvaluator {
     previousOutputs?: Record<string, ReviewSummary>
   ): FailureConditionContext {
     const { issues, debug } = reviewSummary;
+    const reviewSummaryWithOutput = reviewSummary as ReviewSummary & { output?: unknown };
+
+    // Extract output field to avoid nesting (output.output)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { output: extractedOutput, issues: _issues, ...otherFields } = reviewSummaryWithOutput as any;
 
     const context: FailureConditionContext = {
       output: {
@@ -570,8 +575,9 @@ export class FailureConditionEvaluator {
           replacement: issue.replacement,
         })),
         // Include additional schema-specific data from reviewSummary
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ...(reviewSummary as any), // Pass through any additional fields
+        ...otherFields,
+        // Spread the extracted output directly (avoid output.output nesting)
+        ...(extractedOutput && typeof extractedOutput === 'object' ? extractedOutput : {}),
       },
       outputs: (() => {
         if (!previousOutputs) return {};

--- a/src/providers/command-check-provider.ts
+++ b/src/providers/command-check-provider.ts
@@ -138,6 +138,7 @@ export class CommandCheckProvider extends CheckProvider {
         // Attempt to parse as JSON
         const parsed = JSON.parse(rawOutput);
         output = parsed;
+        logger.debug(`🔧 Debug: Parsed entire output as JSON successfully`);
       } catch {
         // Try to extract JSON from the end of output (for commands with debug logs)
         const extracted = this.extractJsonFromEnd(rawOutput);
@@ -147,13 +148,29 @@ export class CommandCheckProvider extends CheckProvider {
             logger.debug(
               `🔧 Debug: Extracted and parsed JSON from end of output (${extracted.length} chars from ${rawOutput.length} total)`
             );
-          } catch {
+            logger.debug(`🔧 Debug: Extracted JSON content: ${extracted.slice(0, 200)}`);
+          } catch (parseError) {
             // Extraction found something but it's not valid JSON
+            logger.debug(`🔧 Debug: Extracted text is not valid JSON: ${parseError instanceof Error ? parseError.message : 'Unknown error'}`);
             output = rawOutput;
           }
         } else {
           // Not JSON, keep as string
+          logger.debug(`🔧 Debug: No JSON found in output, keeping as string`);
           output = rawOutput;
+        }
+      }
+
+      // Log the parsed structure for debugging
+      if (output !== rawOutput) {
+        try {
+          const outputType = Array.isArray(output) ? `array[${output.length}]` : typeof output;
+          logger.debug(`🔧 Debug: Parsed output type: ${outputType}`);
+          if (typeof output === 'object' && output !== null) {
+            logger.debug(`🔧 Debug: Parsed output keys: ${Object.keys(output).join(', ')}`);
+          }
+        } catch {
+          // Ignore logging errors
         }
       }
 

--- a/src/providers/command-check-provider.ts
+++ b/src/providers/command-check-provider.ts
@@ -151,7 +151,9 @@ export class CommandCheckProvider extends CheckProvider {
             logger.debug(`🔧 Debug: Extracted JSON content: ${extracted.slice(0, 200)}`);
           } catch (parseError) {
             // Extraction found something but it's not valid JSON
-            logger.debug(`🔧 Debug: Extracted text is not valid JSON: ${parseError instanceof Error ? parseError.message : 'Unknown error'}`);
+            logger.debug(
+              `🔧 Debug: Extracted text is not valid JSON: ${parseError instanceof Error ? parseError.message : 'Unknown error'}`
+            );
             output = rawOutput;
           }
         } else {


### PR DESCRIPTION
## Summary

This PR fixes three critical issues discovered during usage:

1. **Command timeout not being read from config** - Commands were always timing out at 60s regardless of config
2. **forEach validation missing** - Empty/undefined forEach outputs continued silently instead of erroring
3. **fail_if evaluation broken** - Conditions weren't evaluated in CLI mode and had context nesting issues

## Issues Fixed

### 1. Command Timeout Configuration
- **Problem**: Setting `timeout: 300` in check config was ignored, defaulting to 60 seconds
- **Fix**: Command provider now correctly reads `config.timeout` value

### 2. forEach Check Validation  
- **Problem**: forEach checks with empty or undefined output continued execution silently
- **Fix**: Added validation that produces clear errors:
  - `forEach/no_items` - When output is an empty array
  - `forEach/undefined_output` - When transform returns undefined

### 3. fail_if Condition Evaluation
- **Problem 1**: fail_if conditions only worked in GitHub Action mode, not CLI
- **Problem 2**: Context had nested output (output.output.field instead of output.field)
- **Fix**: 
  - Added fail_if evaluation to CLI execution path
  - Fixed context building to avoid output nesting
  - Now `fail_if: output.error` correctly evaluates when error field exists

## Changes Made

- `src/providers/command-check-provider.ts`
  - Fixed timeout reading from config
  - Enhanced JSON extraction with better debug logging
  - Improved handling of mixed debug output with JSON

- `src/check-execution-engine.ts`  
  - Added forEach validation in both execution paths
  - Added fail_if evaluation for CLI mode
  - Clear error messages for empty/undefined forEach output

- `src/failure-condition-evaluator.ts`
  - Fixed context nesting issue
  - Extracted output field to top level for direct access

## Testing

Verified all fixes work correctly:
- Timeout: Commands respect configured timeout values
- forEach: Empty arrays and undefined outputs produce appropriate errors
- fail_if: Conditions evaluate correctly with proper field access

## Examples

### Before
```yaml
checks:
  fetch-data:
    type: command
    timeout: 300  # Ignored, timed out at 60s
    forEach: true
    exec: ./fetch.sh
    transform_js: output.items  # Returns [] or undefined - continued silently
    fail_if: output.error  # Didn't work - needed output.output.error
```

### After
```yaml
checks:
  fetch-data:
    type: command
    timeout: 300  # ✅ Respected - 5 minute timeout
    forEach: true
    exec: ./fetch.sh
    transform_js: output.items  # ✅ Errors if empty/undefined
    fail_if: output.error  # ✅ Works correctly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)