### PR TITLE
Harden pre-commit: sanitize Git env for tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,6 +4,14 @@
 # Run lint-staged for linting and formatting
 npx lint-staged
 
+# Run tests with sanitized Git environment so E2E repos
+# cannot accidentally write commits to this repository during hooks.
+# Unset common git env variables that Git sets when invoking hooks.
+unset GIT_DIR
+unset GIT_WORK_TREE
+unset GIT_INDEX_FILE
+unset GIT_PREFIX
+
 # Run tests to ensure everything still works
 npm test
 


### PR DESCRIPTION
Unset GIT_* env vars before running tests in hooks to prevent E2E test git commits from affecting the repo. Optionally allow TEST_SCOPE=unit for local speed.