### PR TITLE
fix(deps): skip dependents when fail_if is met

### DIFF
--- a/src/check-execution-engine.ts
+++ b/src/check-execution-engine.ts
@@ -1953,10 +1953,10 @@ export class CheckExecutionEngine {
               return id.endsWith('/__skipped');
             });
 
-            // Check for fatal failures in direct dependencies:
+            // Treat these as fatal in direct dependencies:
             //  - command provider execution/transform failures
             //  - forEach validation/iteration errors
-            //  - any dependency issues with severity error/critical
+            //  - fail_if conditions (global or check-specific)
             const hasFatalFailure = (depRes.issues || []).some(issue => {
               const id = issue.ruleId || '';
               return (
@@ -1968,7 +1968,9 @@ export class CheckExecutionEngine {
                 id.endsWith('/command/transform_error') ||
                 id.endsWith('/forEach/iteration_error') ||
                 id === 'forEach/undefined_output' ||
-                id.endsWith('/forEach/undefined_output')
+                id.endsWith('/forEach/undefined_output') ||
+                id.endsWith('_fail_if') ||
+                id.endsWith('/global_fail_if')
               );
             });
 


### PR DESCRIPTION
Context\n- Some checks use custom schema and set `fail_if: output.error`.\n- Even when the AI response included an `error` field, dependents still ran.\n\nWhat changed\n- In dependency-aware execution, direct dependencies are now treated as fatal if they produce fail_if issues.\n  - We detect ruleIds ending with `_fail_if` or `/global_fail_if` (issues are prefix-scoped).\n  - This matches how we already treat command and forEach errors.\n\nResult\n- When `fail_if` is met on the parent, dependents are skipped ("⏭ Skipped (dependency failed: <parent>)").\n- Global fail-fast behavior remains unchanged.\n\nTests\n- Full suite passes locally.\n\nNotes\n- No changes to config syntax required. Existing `fail_if: output.error` now also gates dependents correctly.