### PR TITLE
fix(command): respect per-check timeout in dependency-aware path

### DIFF
--- a/src/check-execution-engine.ts
+++ b/src/check-execution-engine.ts
@@ -1907,6 +1907,9 @@ export class CheckExecutionEngine {
             eventContext: prInfo.eventContext, // Pass event context for templates
             transform: checkConfig.transform,
             transform_js: checkConfig.transform_js,
+            // Important: pass through provider-level timeout from check config
+            // (e.g., command/http_client providers expect seconds/ms here)
+            timeout: checkConfig.timeout,
             level: extendedCheckConfig.level,
             message: extendedCheckConfig.message,
             env: checkConfig.env,


### PR DESCRIPTION
Problem\n- Command checks with `timeout: 300` (seconds) still timed out at 60s when run via dependency-aware execution.\n\nCause\n- The engine didn’t pass `timeout` from the check config to the provider config in the dependency-aware path, so providers fell back to their defaults (60s for command).\n\nFix\n- Pass `timeout` through to providerConfig when building per-check configs for dependency-aware execution.\n  - Command provider reads it as seconds (multiplied to ms).\n  - http_client provider reads it as ms (consistent with its implementation).\n\nResult\n- `timeout` on the check is now honored consistently (e.g., 300 → 5 minutes).\n\nTests\n- Full suite passes locally.