### PR TITLE
docs: fail_if, forEach propagation, and timeouts — add guides and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ visor --help
 
 See full options and examples: [docs/NPM_USAGE.md](docs/NPM_USAGE.md)
 
+Additional guides:
+
+- fail conditions: [docs/fail-if.md](docs/fail-if.md)
+- forEach behavior and dependent propagation: [docs/foreach-dependency-propagation.md](docs/foreach-dependency-propagation.md)
+- timeouts and provider units: [docs/timeouts.md](docs/timeouts.md)
+
 ## 🧩 Core Concepts (1 minute)
 
 - Check – unit of work (`security`, `performance`).

--- a/docs/fail-if.md
+++ b/docs/fail-if.md
@@ -1,0 +1,91 @@
+# Fail If: Turning conditions into failures
+
+Visor lets you declare simple expressions that fail a check when they evaluate to true. This works for any provider (ai, command, http_*, etc.) and is evaluated as part of the execution engine so dependents can be skipped reliably.
+
+## Where to configure
+
+- Per check:
+
+```yaml
+checks:
+  analyze-bug:
+    type: ai
+    schema: ./schemas/ticket-analysis.json
+    fail_if: output.error
+```
+
+- Global (applies to all checks unless the check overrides with its own `fail_if`):
+
+```yaml
+fail_if: outputs["fetch-tickets"].error
+```
+
+## Evaluation context
+
+Inside the expression you can use:
+
+- `output`: the current check’s structured output.
+  - Includes `issues` and any other fields produced by the provider.
+  - For custom schemas, all top‑level JSON fields are preserved and exposed here.
+  - For command output that is JSON, fields are available directly; for plain text, treat `output` as a string.
+- `outputs`: a map of dependency outputs keyed by check name. Each value is that check’s `output` if present; otherwise the whole check result.
+
+Helpers available: `contains(haystack, needle)`, `startsWith(s,prefix)`, `endsWith(s,suffix)`, `length(x)`, `always()`, `success()`, `failure()`, and issue/file matching helpers (see source FailureConditionEvaluator for the full list).
+
+Truthiness rules follow JavaScript: non‑empty strings are truthy, `""` and `null`/`undefined` are falsy, `0` is falsy.
+
+## What happens when a condition is met
+
+- The engine adds an error‑severity issue to the check with ruleId `<checkName>_fail_if` (or `global_fail_if` for the global rule).
+- Direct dependents of that check are skipped with reason `dependency_failed`.
+- Skipped checks do not execute their providers; they appear as ⏭ in the details table.
+
+Only direct dependencies gate execution. Transitive checks are gated through the chain (i.e., if A fails B, and C depends on B, C will also be skipped once B is skipped).
+
+## Examples
+
+Fail when AI (custom schema) reports an error:
+
+```yaml
+checks:
+  analyze-bug:
+    type: ai
+    schema: ./schemas/ticket-analysis.json
+    fail_if: output.error
+  log-results:
+    type: command
+    depends_on: [analyze-bug]
+    exec: echo "OK"
+```
+
+Fail when a dependency produced an error flag:
+
+```yaml
+fail_if: outputs["fetch-tickets"].error
+```
+
+Fail on text output pattern:
+
+```yaml
+checks:
+  lint:
+    type: command
+    exec: run-linter
+    fail_if: contains(output, "ERROR:")
+```
+
+## ForEach and fail_if
+
+When a check uses `forEach: true`, the engine evaluates `fail_if` once on the aggregated result (after all items complete). You can write expressions against the aggregated `output` (often an array), e.g.:
+
+```yaml
+fail_if: output.some(x => x.status === 'fail')
+```
+
+Per‑item fail logic is not evaluated via `fail_if`; use `if:` to skip item work or emit issues inside the per‑item action.
+
+## Notes
+
+- Fail conditions are evaluated during dependency‑aware execution as part of the engine (not only in providers), ensuring dependents are reliably skipped even if a provider path didn’t attach issues.
+- Issue ruleIds are consistent: `<checkName>_fail_if` for per‑check and `global_fail_if` for global.
+

--- a/docs/foreach-dependency-propagation.md
+++ b/docs/foreach-dependency-propagation.md
@@ -1,337 +1,47 @@
-# forEach with Dependencies and transform_js
+# ForEach output: validation and dependent propagation
 
-This document explains how to use `forEach` with `transform_js` to process arrays and pass individual items to dependent checks.
+This doc clarifies how `forEach` output is validated and how it affects dependent checks.
 
-## Overview
+## Valid and invalid outputs
 
-When a check uses `forEach` with `transform_js`, it can extract and transform arrays from command output, and dependent checks will receive individual items from that array.
+- `transform_js` or provider output must resolve to a value. If it is `undefined`, the engine emits an error:
+  - Issue: `forEach/undefined_output`
+  - Effect: direct dependents are skipped (`dependency_failed`).
+- If the value is an array, the engine iterates items.
+- If the value is a string, the engine tries to JSON.parse it; if it parses to an array, that array is used; otherwise it treats the string as a single item.
+- If the value is `null`, it is normalized to an empty array (0 iterations).
 
-## Basic Usage
+## Empty arrays vs undefined
 
-### Simple Array Processing
+- `[]` (empty array): valid — the check runs zero iterations. Dependents that rely on items are effectively skipped (no provider execution), and you’ll see a log like:
 
-```yaml
-checks:
-  fetch-items:
-    type: command
-    exec: echo '[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]'
-    transform_js: output
-    forEach: true
-
-  process-item:
-    type: command
-    depends_on: [fetch-items]
-    exec: |
-      echo "Processing {{ outputs['fetch-items'].name }} with ID {{ outputs['fetch-items'].id }}"
+```
+forEach: no items from "fetch-tickets", skipping check...
 ```
 
-In this example:
-- `fetch-items` returns a JSON array and uses `transform_js` to parse it
-- `forEach: true` tells Visor to iterate over the array
-- `process-item` depends on `fetch-items` and will be executed once for each item
-- Each execution receives one item from the array
+- `undefined`: invalid — treated as a configuration/transform error. The engine emits a `forEach/undefined_output` issue and skips direct dependents.
 
-### Extracting Nested Arrays
-
-```yaml
-checks:
-  fetch-data:
-    type: command
-    exec: |
-      echo '{"status":"ok","users":[{"id":1,"active":true},{"id":2,"active":false}]}'
-    transform_js: |
-      output.users
-    forEach: true
-
-  check-user:
-    type: command
-    depends_on: [fetch-data]
-    exec: |
-      if [ "{{ outputs['fetch-data'].active }}" = "true" ]; then
-        echo "User {{ outputs['fetch-data'].id }} is active"
-      else
-        echo "User {{ outputs['fetch-data'].id }} is inactive"
-      fi
-```
-
-## Raw Array Access
-
-Sometimes you need access to both the current item AND the full array. Visor provides a special `-raw` key for this purpose.
-
-### Accessing the Full Array
-
-```yaml
-checks:
-  fetch-items:
-    type: command
-    exec: echo '[{"id":1,"value":10},{"id":2,"value":20},{"id":3,"value":30}]'
-    transform_js: output
-    forEach: true
-
-  analyze-item:
-    type: command
-    depends_on: [fetch-items]
-    exec: |
-      # Access current item
-      current_value="{{ outputs['fetch-items'].value }}"
-
-      # Access full array via -raw key
-      total_count="{{ outputs['fetch-items-raw'] | size }}"
-
-      # Access specific item from full array
-      first_value="{{ outputs['fetch-items-raw'][0].value }}"
-
-      # Calculate position
-      echo "Processing item with value $current_value (1 of $total_count)"
-      echo "Difference from first: $((current_value - first_value))"
-```
-
-### Comparing with Other Items
-
-```yaml
-checks:
-  fetch-scores:
-    type: command
-    exec: echo '[{"name":"Alice","score":85},{"name":"Bob","score":92},{"name":"Charlie","score":78}]'
-    transform_js: output
-    forEach: true
-
-  compare-score:
-    type: command
-    depends_on: [fetch-scores]
-    exec: |
-      # Current person's score
-      current_score="{{ outputs['fetch-scores'].score }}"
-      current_name="{{ outputs['fetch-scores'].name }}"
-
-      # Calculate average from all scores
-      {% assign total = 0 %}
-      {% for person in outputs['fetch-scores-raw'] %}
-        {% assign total = total | plus: person.score %}
-      {% endfor %}
-      {% assign avg = total | divided_by: outputs['fetch-scores-raw'].size %}
-
-      if [ "$current_score" -gt "$avg" ]; then
-        echo "$current_name scored above average ($current_score vs $avg)"
-      else
-        echo "$current_name scored below average ($current_score vs $avg)"
-      fi
-```
-
-## Complex Transformations
-
-### Flattening Nested Structures
-
-```yaml
-checks:
-  fetch-groups:
-    type: command
-    exec: |
-      echo '{
-        "groups": [
-          {"name": "TeamA", "members": [{"id": "u1", "role": "dev"}, {"id": "u2", "role": "qa"}]},
-          {"name": "TeamB", "members": [{"id": "u3", "role": "dev"}]}
-        ]
-      }'
-    transform_js: |
-      const data = JSON.parse(output);
-      const flattened = [];
-      data.groups.forEach(group => {
-        group.members.forEach(member => {
-          flattened.push({
-            team: group.name,
-            userId: member.id,
-            role: member.role
-          });
-        });
-      });
-      flattened
-    forEach: true
-
-  check-member:
-    type: command
-    depends_on: [fetch-groups]
-    exec: |
-      echo "User {{ outputs['fetch-groups'].userId }} is a {{ outputs['fetch-groups'].role }} in {{ outputs['fetch-groups'].team }}"
-```
-
-### Filtering and Transforming
-
-```yaml
-checks:
-  fetch-issues:
-    type: command
-    exec: |
-      gh api repos/owner/repo/issues --jq '.[].{number,title,state,labels}'
-    transform_js: |
-      const issues = JSON.parse(output);
-      // Only process open bugs
-      issues.filter(issue =>
-        issue.state === 'open' &&
-        issue.labels.some(label => label.name === 'bug')
-      ).map(issue => ({
-        number: issue.number,
-        title: issue.title,
-        labelCount: issue.labels.length
-      }))
-    forEach: true
-
-  analyze-bug:
-    type: command
-    depends_on: [fetch-issues]
-    exec: |
-      echo "Bug #{{ outputs['fetch-issues'].number }}: {{ outputs['fetch-issues'].title }}"
-      echo "Has {{ outputs['fetch-issues'].labelCount }} labels"
-      echo "Total open bugs: {{ outputs['fetch-issues-raw'] | size }}"
-```
-
-## Error Handling
-
-### Invalid JSON
-
-If `transform_js` encounters an error (e.g., invalid JSON), it will report an error issue:
-
-```yaml
-checks:
-  fetch-invalid:
-    type: command
-    exec: echo "not valid json"
-    transform_js: JSON.parse(output)  # This will fail
-    forEach: true
-```
-
-Result: An issue with `ruleId: command/transform_js_error`
-
-### Empty Arrays
-
-Empty arrays are handled gracefully - dependent checks simply won't execute:
-
-```yaml
-checks:
-  fetch-empty:
-    type: command
-    exec: echo '{"items":[]}'
-    transform_js: JSON.parse(output).items
-    forEach: true
-
-  process-item:
-    type: command
-    depends_on: [fetch-empty]
-    exec: echo "This won't run"
-```
-
-### Non-Array Results
-
-If `transform_js` returns a non-array value, it's automatically wrapped in an array:
-
-```yaml
-checks:
-  fetch-single:
-    type: command
-    exec: echo '{"item":{"id":1}}'
-    transform_js: JSON.parse(output).item  # Returns object, not array
-    forEach: true
-
-  process-single:
-    type: command
-    depends_on: [fetch-single]
-    exec: echo "Processing {{ outputs['fetch-single'].id }}"  # Works fine
-```
-
-## Best Practices
-
-1. **Always validate JSON before parsing**: Consider using try-catch in transform_js
-2. **Use descriptive check names**: They become the keys in `outputs`
-3. **Document expected array structure**: Add comments explaining the data format
-4. **Handle empty arrays gracefully**: Dependent checks won't run for empty arrays
-5. **Use `-raw` sparingly**: Only when you need aggregate information
-
-## Common Use Cases
-
-### Processing JIRA Tickets
+## Example
 
 ```yaml
 checks:
   fetch-tickets:
     type: command
-    exec: |
-      curl -s -H "Authorization: Bearer $JIRA_TOKEN" \
-        "https://jira.example.com/rest/api/2/search?jql=project=MYPROJ"
-    transform_js: |
-      JSON.parse(output).issues.map(issue => ({
-        key: issue.key,
-        summary: issue.fields.summary,
-        priority: issue.fields.priority.name,
-        assignee: issue.fields.assignee?.displayName || 'Unassigned'
-      }))
+    exec: echo '{"tickets": []}'
+    transform_js: JSON.parse(output).tickets
     forEach: true
 
   analyze-ticket:
     type: command
     depends_on: [fetch-tickets]
-    exec: |
-      echo "Analyzing {{ outputs['fetch-tickets'].key }}: {{ outputs['fetch-tickets'].summary }}"
-      echo "Priority: {{ outputs['fetch-tickets'].priority }}"
-      echo "Total tickets in batch: {{ outputs['fetch-tickets-raw'] | size }}"
+    exec: echo "TICKET: {{ outputs['fetch-tickets'].key }}"
 ```
 
-### Processing Test Results
+- If `tickets` is `[]`, `analyze-ticket` is effectively skipped (no per‑item execution).
+- If `transform_js` returns `undefined`, the engine raises `forEach/undefined_output` and `analyze-ticket` is skipped due to a failed dependency.
 
-```yaml
-checks:
-  get-test-results:
-    type: command
-    exec: npm test --json
-    transform_js: |
-      const results = JSON.parse(output);
-      results.testResults.flatMap(suite =>
-        suite.assertionResults.filter(test => test.status === 'failed')
-          .map(test => ({
-            suite: suite.name,
-            test: test.title,
-            error: test.failureMessages[0]
-          }))
-      )
-    forEach: true
+## Tips
 
-  report-failure:
-    type: command
-    depends_on: [get-test-results]
-    exec: |
-      echo "❌ Test failure in {{ outputs['get-test-results'].suite }}"
-      echo "   Test: {{ outputs['get-test-results'].test }}"
-      echo "   Error: {{ outputs['get-test-results'].error | truncate: 100 }}"
-```
+- Always `return` from `transform_js`. Missing `return` is the most common cause of `undefined`.
+- Prefer returning arrays directly from `transform_js` (avoid stringifying) to keep types clear and avoid parsing surprises.
 
-### Batch Processing Files
-
-```yaml
-checks:
-  find-large-files:
-    type: command
-    exec: |
-      find . -type f -size +1M -exec stat -c '%s %n' {} \; | head -20
-    transform_js: |
-      output.split('\n').filter(line => line.trim())
-        .map(line => {
-          const [size, ...pathParts] = line.split(' ');
-          return {
-            path: pathParts.join(' '),
-            sizeMB: (parseInt(size) / 1048576).toFixed(2)
-          };
-        })
-    forEach: true
-
-  check-file:
-    type: command
-    depends_on: [find-large-files]
-    exec: |
-      echo "Large file: {{ outputs['find-large-files'].path }} ({{ outputs['find-large-files'].sizeMB }} MB)"
-      echo "Total large files found: {{ outputs['find-large-files-raw'] | size }}"
-```
-
-## See Also
-
-- [Command Provider Documentation](./command-provider.md)
-- [Dependencies Documentation](./dependencies.md)
-- [Liquid Templates Documentation](./liquid-templates.md)

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -1,0 +1,50 @@
+# Timeouts: configuration and behavior
+
+Checks can specify a per‑check timeout. When a timeout is reached, the provider is aborted and the engine records a timeout error and skips direct dependents.
+
+## Configuration
+
+```yaml
+checks:
+  fetch-tickets:
+    type: command
+    timeout: 300  # seconds (command)
+    exec: node scripts/jira/batch-fetch.js "$JQL" --limit $LIMIT
+```
+
+Provider units and defaults:
+
+- `command`:
+  - Units: seconds.
+  - Default: 60s if not specified.
+  - Effect on timeout: issue `command/timeout` with message “Command execution timed out after <N> seconds”. Direct dependents are skipped.
+- `http_client`:
+  - Units: milliseconds.
+  - Default: provider default (see provider docs/test for specifics).
+- `ai`:
+  - Use `ai.timeout` (milliseconds). CLI `--timeout` also maps to AI timeout.
+
+The engine propagates the per‑check timeout into providers in dependency‑aware execution so behavior is consistent even in multi‑check workflows.
+
+## Examples
+
+```yaml
+checks:
+  fetch:
+    type: command
+    timeout: 120
+    exec: curl -s https://example.com/data
+
+  process:
+    type: command
+    depends_on: [fetch]
+    exec: echo "{{ outputs.fetch }}" | jq '.items | length'
+```
+
+If `fetch` exceeds 120s, `process` is skipped with reason `dependency_failed`.
+
+## Notes
+
+- Be mindful of units when switching providers (seconds vs milliseconds).
+- Consider adding `fail_if` conditions for additional guarding (e.g., `fail_if: !output || length(output.items) === 0`).
+

--- a/tests/integration/fail-if-ai-custom-integration.test.ts
+++ b/tests/integration/fail-if-ai-custom-integration.test.ts
@@ -1,0 +1,121 @@
+import { CheckExecutionEngine } from '../../src/check-execution-engine';
+import { VisorConfig } from '../../src/types/config';
+import { CheckProvider, CheckProviderConfig } from '../../src/providers/check-provider.interface';
+import { CheckProviderRegistry } from '../../src/providers/check-provider-registry';
+import { PRInfo } from '../../src/pr-analyzer';
+import { ReviewSummary } from '../../src/reviewer';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { execSync } from 'child_process';
+
+class StubAICustomProvider extends CheckProvider {
+  getName(): string {
+    return 'ai';
+  }
+  getSupportedConfigKeys(): string[] {
+    return ['type', 'prompt', 'schema', 'fail_if'];
+  }
+  getDescription(): string {
+    return 'Stub AI provider for tests (custom schema passthrough)';
+  }
+  async validateConfig(_config: unknown): Promise<boolean> {
+    return true;
+  }
+  async execute(_prInfo: PRInfo, _config: CheckProviderConfig): Promise<ReviewSummary> {
+    // Simulate AI returning a custom schema JSON with an error field
+    return {
+      issues: [],
+      output: { ticket: {}, error: 'Missing data' },
+    } as ReviewSummary;
+  }
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+  getRequirements(): string[] {
+    return [];
+  }
+}
+
+describe('fail_if with AI custom schema (integration)', () => {
+  let engine: CheckExecutionEngine;
+  let tempDir: string;
+  let originalRegistry: CheckProviderRegistry;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'visor-failif-ai-'));
+    execSync('git init -q', { cwd: tempDir });
+    execSync('git config user.email "test@example.com"', { cwd: tempDir });
+    execSync('git config user.name "Test User"', { cwd: tempDir });
+    fs.writeFileSync(path.join(tempDir, 'file.txt'), 'x');
+    execSync('git add .', { cwd: tempDir });
+    execSync('git -c core.hooksPath=/dev/null commit -q -m "init"', { cwd: tempDir });
+
+    // Replace 'ai' provider with stub for deterministic custom schema output
+    originalRegistry = CheckProviderRegistry.getInstance();
+    try {
+      // Unregister built-in ai and register stub
+      (originalRegistry as any).unregister('ai');
+    } catch {}
+    (originalRegistry as any).register(new StubAICustomProvider());
+
+    engine = new CheckExecutionEngine(tempDir);
+  });
+
+  afterEach(() => {
+    // Reset registry to default providers
+    CheckProviderRegistry.clearInstance();
+    // Clean temp dir
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('evaluates fail_if: output.error and skips dependent', async () => {
+    const schemaDir = path.join(tempDir, 'schemas');
+    fs.mkdirSync(schemaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(schemaDir, 'ticket-analysis.json'),
+      JSON.stringify({ type: 'object' })
+    );
+
+    const config: VisorConfig = {
+      version: '1.0',
+      checks: {
+        'analyze-bug': {
+          type: 'ai',
+          prompt: 'Analyze JIRA ticket',
+          schema: './schemas/ticket-analysis.json',
+          fail_if: 'output.error',
+        },
+        'log-results': {
+          type: 'command',
+          depends_on: ['analyze-bug'],
+          exec: 'echo OK',
+        },
+      },
+      output: {
+        pr_comment: { format: 'markdown', group_by: 'check', collapse: false },
+      },
+    };
+
+    const result = await engine.executeChecks({
+      checks: ['analyze-bug', 'log-results'],
+      config,
+      debug: true,
+      workingDirectory: tempDir,
+    });
+
+    // Dependent must be skipped
+    const stats = result.executionStatistics!;
+    const logStats = stats.checks.find(c => c.checkName === 'log-results');
+    expect(logStats).toBeDefined();
+    expect(logStats!.skipped).toBe(true);
+
+    // Fail_if issue should be present on analyze-bug (ruleId ends with _fail_if)
+    const failIfFound = (result.reviewSummary.issues || []).some(
+      i => typeof i.ruleId === 'string' && i.ruleId.endsWith('analyze-bug_fail_if')
+    );
+    expect(failIfFound).toBe(true);
+  });
+});

--- a/tests/integration/fail-if-command-integration.test.ts
+++ b/tests/integration/fail-if-command-integration.test.ts
@@ -1,0 +1,66 @@
+import { CheckExecutionEngine } from '../../src/check-execution-engine';
+import { VisorConfig } from '../../src/types/config';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { execSync } from 'child_process';
+
+describe('fail_if with command provider (integration)', () => {
+  let engine: CheckExecutionEngine;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'visor-failif-cmd-'));
+    execSync('git init -q', { cwd: tempDir });
+    execSync('git config user.email "test@example.com"', { cwd: tempDir });
+    execSync('git config user.name "Test User"', { cwd: tempDir });
+    fs.writeFileSync(path.join(tempDir, 'file.txt'), 'x');
+    execSync('git add .', { cwd: tempDir });
+    execSync('git -c core.hooksPath=/dev/null commit -q -m "init"', { cwd: tempDir });
+
+    engine = new CheckExecutionEngine(tempDir);
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('adds fail_if issue and skips dependent', async () => {
+    const config: VisorConfig = {
+      version: '1.0',
+      checks: {
+        'analyze-bug': {
+          type: 'command',
+          exec: `echo '{"ticket": {}, "error": "Missing data"}'`,
+          fail_if: 'output.error',
+        },
+        'log-results': {
+          type: 'command',
+          depends_on: ['analyze-bug'],
+          exec: 'echo OK',
+        },
+      },
+      output: {
+        pr_comment: { format: 'markdown', group_by: 'check', collapse: false },
+      },
+    };
+
+    const result = await engine.executeChecks({
+      checks: ['analyze-bug', 'log-results'],
+      config,
+      debug: true,
+      workingDirectory: tempDir,
+    });
+
+    const issues = result.reviewSummary.issues || [];
+    const hasFailIf = issues.some(i => (i.ruleId || '').endsWith('analyze-bug_fail_if'));
+    expect(hasFailIf).toBe(true);
+
+    const stats = result.executionStatistics!;
+    const logStats = stats.checks.find(c => c.checkName === 'log-results');
+    expect(logStats).toBeDefined();
+    expect(logStats!.skipped).toBe(true);
+  });
+});


### PR DESCRIPTION
## What’s included
- New docs/fail-if.md — how to declare `fail_if`, evaluation context (`output`, `outputs`, helpers), ruleIds, dependency gating semantics, `forEach` aggregation, and examples.
- New docs/foreach-dependency-propagation.md — validation of `forEach` outputs, undefined vs empty array, and how dependents are handled.
- New docs/timeouts.md — provider-specific timeout units, behavior on timeout, and examples; clarifies `command` (seconds) vs `http_client`/`ai` (milliseconds).
- README: links the new guides under Additional guides.

## Why
Make failure semantics and execution behavior explicit and self-serve, reducing surprises around `fail_if`, `forEach`, and timeouts.

## Screenshots/Previews
N/A (pure docs).

## Follow-ups
- Add diagrams (mermaid) for dependency gating if helpful.
- Tighten ruleId matching for `fail_if` in a future PR and update docs accordingly.
