### PR TITLE
fix(cli): eliminate table-format hang on large outputs

### DIFF
--- a/tests/unit/cli/output-formatters.test.ts
+++ b/tests/unit/cli/output-formatters.test.ts
@@ -548,5 +548,60 @@ describe('OutputFormatters', () => {
       // Table should truncate long messages - just check it doesn't crash
       expect(tableResult).toBeDefined();
     });
+
+    // Note: heavy truncation paths are exercised indirectly in other tests. Keep this suite fast.
+
+    it('should break single long words to prevent wrap-ansi slow path', () => {
+      const longWord = 'A'.repeat(200);
+      const res = {
+        ...mockAnalysisResult,
+        reviewSummary: {
+          issues: [
+            {
+              file: 'src/file.ts',
+              line: 1,
+              endLine: undefined,
+              ruleId: 'style/longword',
+              message: longWord,
+              severity: 'warning' as const,
+              category: 'style' as const,
+            },
+          ],
+        },
+      };
+      const out = OutputFormatters.formatAsTable(res, { groupByCategory: true });
+      expect(out).toBeTruthy();
+      // It shouldn't include the entire 2000-char sequence in one line
+      expect(out.includes(longWord)).toBe(false);
+    });
+
+    it('should format sizable code replacements without hanging', () => {
+      const longLine = 'const a = 1; //' + 'x'.repeat(60);
+      const code = Array.from({ length: 20 }, () => longLine).join('\n');
+      const res = {
+        ...mockAnalysisResult,
+        reviewSummary: {
+          issues: [
+            {
+              file: 'src/file.ts',
+              line: 2,
+              endLine: undefined,
+              ruleId: 'style/huge-replacement',
+              message: 'Refactor needed',
+              severity: 'info' as const,
+              category: 'style' as const,
+              replacement: code,
+            },
+          ],
+        },
+      };
+      const out = OutputFormatters.formatAsTable(res, {
+        groupByCategory: true,
+        showDetails: true,
+      });
+      expect(out).toContain('Code fix:');
+      // Ensure we don't dump an enormous block
+      expect(out.length).toBeLessThan(9000);
+    });
   });
 });


### PR DESCRIPTION
This PR addresses a rare but frustrating stall that occurred at the '▶ Formatting results as table' phase when results contained very large or unwrapped strings (e.g., big AI/custom-schema payloads or long code replacements).

Key changes
- Pre-wrap long strings and break overlong words before passing to cli-table3 to avoid wrap-ansi's slow path.
- Truncate excessively large cell content with a clear marker (… [truncated]). Configurable via .
- Limit code replacement blocks to a bounded number of lines (, default 120) and soft-wrap code lines to a safe width.
- Disable cli-table3  and rely on our deterministic wrapping to keep rendering predictable and fast.

Tests
- Added focused unit tests for OutputFormatters covering long-word splitting and sizable code replacements without performance regressions. Kept them light to preserve suite runtime.

Why it hung
cli-table3 delegates wrapping to wrap-ansi/string-width. When fed very long, unbroken strings or huge multi-line payloads, it can spend a long time computing widths/wrapping. By pre-wrapping and truncating, we avoid the pathological path and keep output responsive.

Follow-ups (separate PRs proposed)
- Add a formatting-time budget with a graceful fallback to a summary-only table when limits are exceeded.
- Make truncation limits configurable in the Visor config (in addition to env vars) and document them in the docs site.

Closes: potential hangs after dependency-aware execution when formatting with table output.
