### PR TITLE
feat: add session cloning mode for AI session reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,11 @@ Learn more: [docs/claude-code.md](docs/claude-code.md)
 
 ## 🔄 AI Session Reuse
 
-Reuse context between dependent AI checks for smarter follow‑ups.
+Reuse conversation context between dependent AI checks for smarter follow‑ups.
+
+**Two modes available:**
+- **`clone` (default)**: Independent copy of history for parallel follow-ups
+- **`append`**: Shared conversation thread for sequential multi-turn dialogue
 
 Example:
 ```yaml
@@ -424,7 +428,12 @@ checks:
   remediation:
     type: ai
     depends_on: [security]
+    reuse_ai_session: true  # Clones history by default
+  verify:
+    type: ai
+    depends_on: [remediation]
     reuse_ai_session: true
+    session_mode: append    # Shares history for full conversation
 ```
 
 Learn more: [docs/advanced-ai.md](docs/advanced-ai.md)

--- a/docs/advanced-ai.md
+++ b/docs/advanced-ai.md
@@ -1,19 +1,36 @@
 ## 🧠 Advanced AI Features
 
 ### AI Session Reuse
-Use `reuse_ai_session: true` on dependent checks to continue the same conversation context with the AI across checks. This improves follow‑ups and consistency.
+Use `reuse_ai_session: true` on dependent checks to continue conversation context with the AI across checks. This improves follow‑ups and consistency.
+
+**Session Modes:**
+- **`clone` (default)**: Creates a copy of the conversation history. Each check gets an independent session with the same starting context. Changes made by one check don't affect others.
+- **`append`**: Shares the same conversation thread. All checks append to a single shared history, creating a true multi-turn conversation.
 
 ```yaml
 checks:
   security:
     type: ai
     prompt: "Analyze code for security vulnerabilities..."
+
   security-remediation:
     type: ai
     prompt: "Based on our security analysis, provide remediation guidance."
     depends_on: [security]
     reuse_ai_session: true
+    # session_mode: clone (default - independent copy of history)
+
+  security-verify:
+    type: ai
+    prompt: "Verify the remediation suggestions are complete."
+    depends_on: [security-remediation]
+    reuse_ai_session: true
+    session_mode: append  # Share history - sees full conversation
 ```
+
+**When to use each mode:**
+- Use **`clone`** (default) when you want parallel follow-ups that don't interfere with each other
+- Use **`append`** when you want sequential conversation where each check builds on previous responses
 
 ### XML-Formatted Analysis
 Visor uses structured XML formatting when sending data to AI providers, enabling precise and context-aware analysis for both pull requests and issues.

--- a/src/config.ts
+++ b/src/config.ts
@@ -674,6 +674,26 @@ export class ConfigManager {
       }
     }
 
+    // Validate session_mode configuration
+    if (checkConfig.session_mode !== undefined) {
+      if (checkConfig.session_mode !== 'clone' && checkConfig.session_mode !== 'append') {
+        errors.push({
+          field: `checks.${checkName}.session_mode`,
+          message: `Invalid session_mode value for "${checkName}": must be 'clone' or 'append'`,
+          value: checkConfig.session_mode,
+        });
+      }
+
+      // session_mode only makes sense with reuse_ai_session
+      if (!checkConfig.reuse_ai_session) {
+        errors.push({
+          field: `checks.${checkName}.session_mode`,
+          message: `Check "${checkName}" has session_mode but no reuse_ai_session. session_mode requires reuse_ai_session to be set.`,
+          value: checkConfig.session_mode,
+        });
+      }
+    }
+
     // Validate tags configuration
     if (checkConfig.tags !== undefined) {
       if (!Array.isArray(checkConfig.tags)) {

--- a/src/generated/config-schema.ts
+++ b/src/generated/config-schema.ts
@@ -242,6 +242,12 @@ export const configSchema = {
           description:
             'Check name to reuse AI session from, or true to use first dependency (only works with depends_on)',
         },
+        session_mode: {
+          type: 'string',
+          enum: ['clone', 'append'],
+          description:
+            "How to reuse AI session: 'clone' (default, copy history) or 'append' (share history)",
+        },
         fail_if: {
           type: 'string',
           description: 'Simple fail condition - fails check if expression evaluates to true',

--- a/src/providers/ai-check-provider.ts
+++ b/src/providers/ai-check-provider.ts
@@ -551,9 +551,12 @@ export class AICheckProvider extends CheckProvider {
 
       // Check if we should use session reuse
       if (sessionInfo?.reuseSession && sessionInfo.parentSessionId) {
+        // Get session_mode from config, default to 'clone'
+        const sessionMode = (config.session_mode as 'clone' | 'append') || 'clone';
+
         if (aiConfig.debug) {
           console.error(
-            `🔄 Debug: Using session reuse with parent session: ${sessionInfo.parentSessionId}`
+            `🔄 Debug: Using session reuse with parent session: ${sessionInfo.parentSessionId} (mode: ${sessionMode})`
           );
         }
         result = await service.executeReviewWithSessionReuse(
@@ -561,7 +564,8 @@ export class AICheckProvider extends CheckProvider {
           processedPrompt,
           sessionInfo.parentSessionId,
           schema,
-          config.checkName
+          config.checkName,
+          sessionMode
         );
       } else {
         if (aiConfig.debug) {

--- a/src/session-registry.ts
+++ b/src/session-registry.ts
@@ -101,6 +101,60 @@ export class SessionRegistry {
   }
 
   /**
+   * Clone a session with a new session ID
+   * Creates a new ProbeAgent with a copy of the conversation history
+   */
+  public async cloneSession(
+    sourceSessionId: string,
+    newSessionId: string
+  ): Promise<ProbeAgent | undefined> {
+    const sourceAgent = this.sessions.get(sourceSessionId);
+    if (!sourceAgent) {
+      console.error(`⚠️  Cannot clone session: ${sourceSessionId} not found`);
+      return undefined;
+    }
+
+    try {
+      // Access the conversation history from the source agent
+      // ProbeAgent stores history in a private field, we need to access it via 'any'
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sourceHistory = (sourceAgent as any).conversationHistory || [];
+
+      // Create a new agent with the same configuration
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sourceOptions = (sourceAgent as any).options || {};
+
+      // Import ProbeAgent dynamically to create new instance
+      const { ProbeAgent: ProbeAgentClass } = await import('@probelabs/probe');
+
+      const clonedAgent = new ProbeAgentClass({
+        ...sourceOptions,
+        sessionId: newSessionId,
+      });
+
+      // Copy the conversation history to the cloned agent
+
+      if (sourceHistory.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (clonedAgent as any).conversationHistory = [...sourceHistory];
+        console.error(
+          `📋 Cloned session ${sourceSessionId} → ${newSessionId} (${sourceHistory.length} messages)`
+        );
+      } else {
+        console.error(`📋 Cloned session ${sourceSessionId} → ${newSessionId} (no history)`);
+      }
+
+      // Register the cloned session
+      this.registerSession(newSessionId, clonedAgent);
+
+      return clonedAgent;
+    } catch (error) {
+      console.error(`⚠️  Failed to clone session ${sourceSessionId}: ${error}`);
+      return undefined;
+    }
+  }
+
+  /**
    * Register process exit handlers to cleanup sessions on exit
    */
   private registerExitHandlers(): void {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -342,6 +342,8 @@ export interface CheckConfig {
   if?: string;
   /** Check name to reuse AI session from, or true to use first dependency (only works with depends_on) */
   reuse_ai_session?: string | boolean;
+  /** How to reuse AI session: 'clone' (default, copy history) or 'append' (share history) */
+  session_mode?: 'clone' | 'append';
   /** Simple fail condition - fails check if expression evaluates to true */
   fail_if?: string;
   /** Check-specific failure conditions - optional (deprecated, use fail_if) */


### PR DESCRIPTION
## Summary
Changes AI session reuse default behavior from appending to shared history to cloning (creating independent copies). This prevents unintended history pollution across parallel checks while maintaining context.

## Changes

### New Behavior
- **`session_mode: clone` (default)**: Creates independent copy of conversation history
- **`session_mode: append`**: Shares conversation thread (previous behavior)

### Implementation Details
- Added `session_mode` config field (`'clone' | 'append'`)
- Implemented `SessionRegistry.cloneSession()` method that copies conversation history
- Updated `AIReviewService.executeReviewWithSessionReuse()` with mode parameter
- Added config validation for `session_mode`
- Updated documentation with usage examples and best practices
- Added comprehensive tests for both modes (13 tests, all passing ✓)

## Use Cases

**Clone mode (default)**: Use when you want parallel follow-up checks that don't interfere with each other
```yaml
checks:
  security:
    type: ai
    prompt: "Find security issues"
  
  fix-sql:
    type: ai
    depends_on: [security]
    reuse_ai_session: true  # Clones history by default
    prompt: "Fix SQL injection issues"
  
  fix-xss:
    type: ai
    depends_on: [security]
    reuse_ai_session: true  # Independent clone
    prompt: "Fix XSS issues"
```

**Append mode**: Use when you want sequential multi-turn conversations where each check builds on previous responses
```yaml
checks:
  analyze:
    type: ai
    prompt: "Analyze authentication code"
  
  suggest:
    type: ai
    depends_on: [analyze]
    reuse_ai_session: true
    session_mode: append
    prompt: "Suggest improvements"
  
  verify:
    type: ai
    depends_on: [suggest]
    reuse_ai_session: true
    session_mode: append
    prompt: "Are these sufficient?"
```

## Testing
All tests pass including:
- Session cloning with default behavior
- Explicit clone mode
- Append mode for shared history
- Error handling for clone failures
- Backward compatibility for existing tests

## Documentation
Updated:
- `README.md` with examples of both modes
- `docs/advanced-ai.md` with detailed explanation and use cases
- Config validation with helpful error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)