### PR TITLE
fix: filter out system-level issues from user-facing output

### DIFF
--- a/src/github-check-service.ts
+++ b/src/github-check-service.ts
@@ -153,11 +153,16 @@ export class GitHubCheckService {
         executionError
       );
 
+      // Filter out system-level issues (fail_if conditions, internal errors)
+      // These should not appear as annotations but affect the check conclusion
+      let filteredIssues = reviewIssues.filter(
+        issue => !(issue.file === 'system' && issue.line === 0)
+      );
+
       // Filter annotations to only include files changed in this commit
       // This prevents old annotations from previous commits showing up in the Files tab
-      let filteredIssues = reviewIssues;
       if (filesChangedInCommit && filesChangedInCommit.length > 0) {
-        filteredIssues = reviewIssues.filter(issue =>
+        filteredIssues = filteredIssues.filter(issue =>
           filesChangedInCommit.some(changedFile => issue.file === changedFile)
         );
       }

--- a/src/output-formatters.ts
+++ b/src/output-formatters.ts
@@ -67,8 +67,11 @@ export class OutputFormatters {
     const { showDetails = false, groupByCategory = true } = options;
     let output = '';
 
-    // Calculate metrics from issues once at the top
-    const issues = result.reviewSummary.issues || [];
+    // Filter out system-level issues (fail_if conditions, internal errors)
+    // These should not appear in user-facing output
+    const issues = (result.reviewSummary.issues || []).filter(
+      issue => !(issue.file === 'system' && issue.line === 0)
+    );
     const totalIssues = issues.length;
     const criticalIssues = issues.filter(i => i.severity === 'critical').length;
 
@@ -264,8 +267,10 @@ export class OutputFormatters {
    * Format analysis results as JSON
    */
   static formatAsJSON(result: AnalysisResult, options: OutputFormatterOptions = {}): string {
-    // Calculate metrics from issues
-    const issues = result.reviewSummary.issues;
+    // Filter out system-level issues (fail_if conditions, internal errors)
+    const issues = result.reviewSummary.issues.filter(
+      issue => !(issue.file === 'system' && issue.line === 0)
+    );
     const totalIssues = calculateTotalIssues(issues);
     const criticalIssues = calculateCriticalIssues(issues);
 
@@ -303,8 +308,10 @@ export class OutputFormatters {
    * Format analysis results as SARIF 2.1.0
    */
   static formatAsSarif(result: AnalysisResult, _options: OutputFormatterOptions = {}): string {
-    // Get issues from result
-    const issues = result.reviewSummary.issues;
+    // Filter out system-level issues (fail_if conditions, internal errors)
+    const issues = result.reviewSummary.issues.filter(
+      issue => !(issue.file === 'system' && issue.line === 0)
+    );
 
     // Generate unique rule definitions for each issue category
     const rules: Array<{
@@ -440,8 +447,10 @@ export class OutputFormatters {
     const { showDetails = false, groupByCategory = true } = options;
     let output = '';
 
-    // Calculate metrics from issues
-    const issues = result.reviewSummary.issues;
+    // Filter out system-level issues (fail_if conditions, internal errors)
+    const issues = result.reviewSummary.issues.filter(
+      issue => !(issue.file === 'system' && issue.line === 0)
+    );
     const totalIssues = calculateTotalIssues(issues);
     const criticalIssues = calculateCriticalIssues(issues);
 


### PR DESCRIPTION
## Summary

Fixes the issue where internal system messages like "Global failure condition met" were appearing as GitHub annotations and in CLI output.

System-level issues (`file: 'system'`, `line: 0`) are internal status indicators used by fail_if conditions to determine check pass/fail status. They should not be visible to users.

## Changes

Added filtering in all output paths to exclude system-level issues:
- GitHub check annotations (github-check-service.ts:156)
- CLI table output (output-formatters.ts:72)
- JSON output (output-formatters.ts:271)
- SARIF output (output-formatters.ts:312)
- Markdown output (output-formatters.ts:451)

## Behavior

**Before:** Users saw "🟠 Error system:0 Global failure condition met" in GitHub checks and CLI output

**After:** System messages are filtered out. The fail_if conditions still affect check conclusion (pass/fail) but don't create visible annotations.

## Test plan

- Verify no system:0 annotations appear in GitHub checks
- Confirm fail_if conditions still cause checks to fail
- Test all output formats (table, json, markdown, sarif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)