### PR TITLE
fix: filter out system-level issues from GitHub comments

### DIFF
--- a/src/check-execution-engine.ts
+++ b/src/check-execution-engine.ts
@@ -1677,8 +1677,13 @@ export class CheckExecutionEngine {
     }
 
     // Prepare template data
+    // Filter out system-level issues (fail_if conditions, internal errors) which should not appear in output
+    const filteredIssues = (reviewSummary.issues || []).filter(
+      issue => !(issue.file === 'system' && issue.line === 0)
+    );
+
     const templateData = {
-      issues: reviewSummary.issues || [],
+      issues: filteredIssues,
       checkName: checkName,
     };
 


### PR DESCRIPTION
## Summary
Fixes the issue where internal system records (like "🟠 Error system:0 Global failure condition met") were being posted to GitHub issues and PR comments.

## Problem
Internal failure condition tracking records with `file: 'system'` and `line: 0` were being included in the Liquid template output, causing them to appear in GitHub comments as visible errors. These system-level issues are meant for internal failure tracking and check conclusions only, not for user-facing output.

## Solution
Added filtering in `src/check-execution-engine.ts` to exclude system-level issues (`file === 'system' && line === 0`) before rendering Liquid templates. This matches the existing filtering behavior already present in `github-check-service.ts` for GitHub Check Run annotations.

## Changes
- **File**: `src/check-execution-engine.ts:1674-1677`
- Filter out issues where `file === 'system' && line === 0` before passing them to template rendering
- System-level failure condition messages will no longer appear in GitHub issue/PR comments
- Internal failure tracking and check conclusions remain unaffected

## Test Plan
- [x] Ran existing test suite - all tests pass
- [x] Verified filtering logic matches github-check-service.ts implementation
- [x] Built successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)