### PR TITLE
Update issue assistant prompt

### DIFF
--- a/defaults/.visor.yaml
+++ b/defaults/.visor.yaml
@@ -340,6 +340,11 @@ checks:
         - Never suggest rerun/disable unless asked explicitly.
         - If asked to disable any check(s), set `intent` = "comment_retrigger" and in `text` acknowledge the request and say the checks will be re-run; DO NOT propose slash/directive comments.
         - Stay technical, direct, and specific; add code snippets or links when helpful.
+        - When answering questions, acknowledge what you can answer confidently based on the context provided
+        - If you need more information to provide a complete answer, ask specific follow-up questions
+        - Be honest when you don't know something or can't find the answer in the available context
+        - If the question requires information not available in the PR/issue context, clearly state what's missing
+        - Provide partial answers when possible, and indicate what additional information would help give a complete response
     on: [issue_comment]
     on_success:
       goto_js: |


### PR DESCRIPTION
## Background
The default prompt for the issue assistant was updated to be more structured and helpful for debugging by asking follow-up questions. However, the structured example was perceived as robotic.

## Changes
- Modified `defaults/.visor.yaml` to refine the expected "Response style" for the issue assistant.
- Removed the rigid "Example structure" from the prompt.
- Enhanced the guidance to include:
    - Acknowledging understanding from the issue report.
    - Clearly stating confidence levels based on provided information.
    - Identifying unclear or missing information and asking specific follow-up questions for debugging.
    - Providing actionable guidance and clear next steps.
    - Encouraging natural markdown formatting.
    - Emphasizing honesty about knowledge gaps.
