### PR TITLE
Fix YAML parse error in memory-exec-js.yaml

### DIFF
--- a/examples/memory-exec-js.yaml
+++ b/examples/memory-exec-js.yaml
@@ -13,17 +13,17 @@ checks:
   # Simulate multiple validation checks
   check-security:
     type: command
-    exec: echo '{"issues": 3, "severity": "high"}'
+    exec: 'echo ''{"issues": 3, "severity": "high"}'''
     transform_js: "JSON.parse(output.trim())"
 
   check-performance:
     type: command
-    exec: echo '{"issues": 7, "severity": "medium"}'
+    exec: 'echo ''{"issues": 7, "severity": "medium"}'''
     transform_js: "JSON.parse(output.trim())"
 
   check-style:
     type: command
-    exec: echo '{"issues": 15, "severity": "low"}'
+    exec: 'echo ''{"issues": 15, "severity": "low"}'''
     transform_js: "JSON.parse(output.trim())"
 
   # Use exec_js to aggregate and analyze results


### PR DESCRIPTION
## Background
The `examples/memory-exec-js.yaml` file was failing YAML parsing due to incorrect escaping of single quotes within the `exec` commands. The colons in the JSON strings were being misinterpreted as YAML mapping syntax.

## Changes
- Modified `examples/memory-exec-js.yaml`:
  - Escaped single quotes in the `exec` field for `check-security` from `'echo '...'` to `'echo ''...''`.
  - Escaped single quotes in the `exec` field for `check-performance` from `'echo '...'` to `'echo ''...''`.
  - Escaped single quotes in the `exec` field for `check-style` from `'echo '...'` to `'echo ''...''`.
This ensures the entire JSON string is treated as a literal value by the YAML parser.

## Testing
- [ ] Verify `examples/memory-exec-js.yaml` parses correctly with PyYAML.
- [ ] Verify `examples/memory-exec-js.yaml` parses correctly with js-yaml.
