### PR TITLE
Fix template path resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "build:cli": "ncc build src/index.ts -o dist && cp -r defaults dist/ && node scripts/inject-version.js && echo '#!/usr/bin/env node' | cat - dist/index.js > temp && mv temp dist/index.js && chmod +x dist/index.js",
+    "build:cli": "ncc build src/index.ts -o dist && cp -r defaults dist/ && cp -r output dist/ && node scripts/inject-version.js && echo '#!/usr/bin/env node' | cat - dist/index.js > temp && mv temp dist/index.js && chmod +x dist/index.js",
     "build:sdk": "tsup src/sdk.ts --dts --sourcemap --format esm,cjs --out-dir dist/sdk",
     "build": "npm run build:cli && npm run build:sdk",
     "test": "jest",

--- a/src/check-execution-engine.ts
+++ b/src/check-execution-engine.ts
@@ -2033,7 +2033,7 @@ export class CheckExecutionEngine {
       if (!sanitizedSchema) {
         throw new Error('Invalid schema name');
       }
-      const templatePath = path.join(__dirname, `../output/${sanitizedSchema}/template.liquid`);
+      const templatePath = path.join(__dirname, `output/${sanitizedSchema}/template.liquid`);
       templateContent = await fs.readFile(templatePath, 'utf-8');
       // Only enrich built-in issue-assistant with event/permission context
       if (sanitizedSchema === 'issue-assistant') {

--- a/tests/unit/cli/check-execution-engine.test.ts
+++ b/tests/unit/cli/check-execution-engine.test.ts
@@ -718,7 +718,7 @@ describe('CheckExecutionEngine', () => {
       const templateContent = 'Built-in template: {{ checkName }}';
       const checkConfig = { schema: 'markdown' };
 
-      mockPath.join.mockReturnValue('/app/src/../output/markdown/template.liquid');
+      mockPath.join.mockReturnValue('/app/src/output/markdown/template.liquid');
       mockFs.readFile.mockResolvedValue(templateContent);
       mockLiquidInstance.parseAndRender.mockResolvedValue('Built-in template: security');
 
@@ -730,10 +730,10 @@ describe('CheckExecutionEngine', () => {
 
       expect(mockPath.join).toHaveBeenCalledWith(
         expect.any(String),
-        '../output/markdown/template.liquid'
+        'output/markdown/template.liquid'
       );
       expect(mockFs.readFile).toHaveBeenCalledWith(
-        '/app/src/../output/markdown/template.liquid',
+        '/app/src/output/markdown/template.liquid',
         'utf-8'
       );
       expect(mockLiquidInstance.parseAndRender).toHaveBeenCalledWith(templateContent, {
@@ -747,7 +747,7 @@ describe('CheckExecutionEngine', () => {
       const templateContent = 'Sanitized template';
       const checkConfig = { schema: 'markdown/../../../etc/passwd' };
 
-      mockPath.join.mockReturnValue('/app/src/../output/markdownetcpasswd/template.liquid');
+      mockPath.join.mockReturnValue('/app/src/output/markdownetcpasswd/template.liquid');
       mockFs.readFile.mockResolvedValue(templateContent);
       mockLiquidInstance.parseAndRender.mockResolvedValue('Sanitized template');
 
@@ -760,7 +760,7 @@ describe('CheckExecutionEngine', () => {
       // Should sanitize to 'markdownetcpasswd' and strip malicious path components like '../'
       expect(mockPath.join).toHaveBeenCalledWith(
         expect.any(String),
-        '../output/markdownetcpasswd/template.liquid'
+        'output/markdownetcpasswd/template.liquid'
       );
       expect(result).toBe('Sanitized template');
     });
@@ -942,7 +942,7 @@ describe('CheckExecutionEngine', () => {
     it('should handle file read errors for built-in schema templates', async () => {
       const checkConfig = { schema: 'nonexistent-schema' };
 
-      mockPath.join.mockReturnValue('/app/src/../output/nonexistent-schema/template.liquid');
+      mockPath.join.mockReturnValue('/app/src/output/nonexistent-schema/template.liquid');
       mockFs.readFile.mockRejectedValue(new Error('Template file not found'));
 
       await expect(
@@ -951,10 +951,10 @@ describe('CheckExecutionEngine', () => {
 
       expect(mockPath.join).toHaveBeenCalledWith(
         expect.any(String),
-        '../output/nonexistent-schema/template.liquid'
+        'output/nonexistent-schema/template.liquid'
       );
       expect(mockFs.readFile).toHaveBeenCalledWith(
-        '/app/src/../output/nonexistent-schema/template.liquid',
+        '/app/src/output/nonexistent-schema/template.liquid',
         'utf-8'
       );
     });
@@ -1073,7 +1073,7 @@ describe('CheckExecutionEngine', () => {
       const templateContent = 'Complex schema template';
       const checkConfig = { schema: 'markdown-v2.1_beta#test' };
 
-      mockPath.join.mockReturnValue('/app/src/../output/markdown-v21betatest/template.liquid');
+      mockPath.join.mockReturnValue('/app/src/output/markdown-v21betatest/template.liquid');
       mockFs.readFile.mockResolvedValue(templateContent);
       mockLiquidInstance.parseAndRender.mockResolvedValue('Complex schema template');
 
@@ -1086,7 +1086,7 @@ describe('CheckExecutionEngine', () => {
       // Should sanitize to 'markdown-v21betatest' removing special characters (. _ #)
       expect(mockPath.join).toHaveBeenCalledWith(
         expect.any(String),
-        '../output/markdown-v21betatest/template.liquid'
+        'output/markdown-v21betatest/template.liquid'
       );
       expect(result).toBe('Complex schema template');
     });


### PR DESCRIPTION
## Background
The build process was incorrectly resolving paths to template files when running the CLI, leading to `ENOENT` errors. This occurred because the `ncc` build output changes the effective `__dirname`.

## Changes
- Corrected path construction in `src/check-execution-engine.ts` from `../output/` to `output/` to account for the `ncc` build output structure.
- Updated test assertions in `tests/unit/cli/check-execution-engine.test.ts` to reflect the corrected path resolution.
- Added `cp -r output dist/` to `package.json`'s `build:cli` script to ensure template directories are correctly copied into the `dist` folder during the build.

## Testing
- [ ] Run visor CLI with various schema types (e.g., 'overview', 'issue-assistant') to ensure templates are found.
- [ ] Verify that the build process correctly copies the `output` directory into `dist`.
- [ ] Confirm that the corrected path is used in logs or error messages if templates are still missing for other reasons.
