### PR TITLE
fix: preserve spaces in GitHub label names

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -299,5 +299,5 @@ steps:
 
 Notes:
 - Requires `GITHUB_TOKEN` (or `github-token` Action input) and `GITHUB_REPOSITORY` in environment.
-- Use Liquid `safe_label` / `safe_label_list` to constrain labels to `[A-Za-z0-9:/]`.
-- Provider errors surface as issues (e.g., `github/missing_token`, `github/op_failed`) and won’t abort the whole run.
+- Use Liquid `safe_label` / `safe_label_list` to constrain labels to `[A-Za-z0-9:/\- ]` (alphanumerics, colon, slash, hyphen, and space).
+- Provider errors surface as issues (e.g., `github/missing_token`, `github/op_failed`) and won't abort the whole run.

--- a/docs/github-ops.md
+++ b/docs/github-ops.md
@@ -46,7 +46,7 @@ These issues are visible in tables/markdown output and will not abort the whole 
 
 To prevent injection and ensure GitHub‑compatible labels, use Liquid filters:
 
-- `safe_label` — keeps only `[A-Za-z0-9:/]`, collapses repeated `/`.
+- `safe_label` — keeps only `[A-Za-z0-9:/\- ]` (alphanumerics, colon, slash, hyphen, and space), collapses repeated `/`, and trims whitespace.
 - `safe_label_list` — applies `safe_label` to arrays and removes empty values.
 
 Examples:

--- a/src/liquid-extensions.ts
+++ b/src/liquid-extensions.ts
@@ -14,15 +14,18 @@ import {
 import { MemoryStore } from './memory-store';
 
 /**
- * Sanitize label strings to only allow [A-Za-z0-9:/] characters
+ * Sanitize label strings to only allow [A-Za-z0-9:/\- ] characters (including spaces and hyphens)
  * @param value - Label value to sanitize
  * @returns Sanitized label string
  */
 export function sanitizeLabel(value: unknown): string {
   if (value == null) return '';
   const s = String(value);
-  // Keep only alphanumerics, colon, slash; collapse repeated slashes
-  return s.replace(/[^A-Za-z0-9:\/]/g, '').replace(/\/{2,}/g, '/');
+  // Keep only alphanumerics, colon, slash, hyphen, and space; collapse repeated slashes and trim
+  return s
+    .replace(/[^A-Za-z0-9:\/\- ]/g, '')
+    .replace(/\/{2,}/g, '/')
+    .trim();
 }
 
 /**

--- a/tests/unit/liquid-extensions.test.ts
+++ b/tests/unit/liquid-extensions.test.ts
@@ -344,4 +344,77 @@ No file included
       expect(result).toBe('[Error: Unable to serialize to JSON]');
     });
   });
+
+  describe('safe_label filter', () => {
+    it('should preserve spaces in label names', async () => {
+      const liquid = createExtendedLiquid();
+
+      const template = '{{ label | safe_label }}';
+      const context = { label: 'good first issue' };
+      const result = await liquid.parseAndRender(template, context);
+
+      expect(result).toBe('good first issue');
+    });
+
+    it('should preserve hyphens in label names', async () => {
+      const liquid = createExtendedLiquid();
+
+      const template = '{{ label | safe_label }}';
+      const context = { label: 'needs-review' };
+      const result = await liquid.parseAndRender(template, context);
+
+      expect(result).toBe('needs-review');
+    });
+
+    it('should preserve colons and slashes in label names', async () => {
+      const liquid = createExtendedLiquid();
+
+      const template = '{{ label | safe_label }}';
+      const context = { label: 'review/effort:high' };
+      const result = await liquid.parseAndRender(template, context);
+
+      expect(result).toBe('review/effort:high');
+    });
+
+    it('should remove special characters but keep spaces', async () => {
+      const liquid = createExtendedLiquid();
+
+      const template = '{{ label | safe_label }}';
+      const context = { label: 'needs review!' };
+      const result = await liquid.parseAndRender(template, context);
+
+      expect(result).toBe('needs review');
+    });
+
+    it('should trim leading and trailing whitespace', async () => {
+      const liquid = createExtendedLiquid();
+
+      const template = '{{ label | safe_label }}';
+      const context = { label: '  good first issue  ' };
+      const result = await liquid.parseAndRender(template, context);
+
+      expect(result).toBe('good first issue');
+    });
+
+    it('should handle empty/null values', async () => {
+      const liquid = createExtendedLiquid();
+
+      const template = '{{ label | safe_label }}';
+      const result1 = await liquid.parseAndRender(template, { label: '' });
+      const result2 = await liquid.parseAndRender(template, { label: null });
+
+      expect(result1).toBe('');
+      expect(result2).toBe('');
+    });
+
+    it('should collapse repeated slashes', async () => {
+      const liquid = createExtendedLiquid();
+
+      const template = '{{ label | safe_label }}';
+      const context = { label: 'review//effort///high' };
+      const result = await liquid.parseAndRender(template, context);
+
+      expect(result).toBe('review/effort/high');
+    });
+  });
 });

--- a/tests/unit/providers/github-ops-provider.test.ts
+++ b/tests/unit/providers/github-ops-provider.test.ts
@@ -96,4 +96,26 @@ describe('GitHubOpsProvider - empty value handling', () => {
       body: 'hello',
     });
   });
+
+  it('preserves spaces in label names like "good first issue"', async () => {
+    const provider = new GitHubOpsProvider();
+    const pr = makePr(10);
+    const cfg: any = {
+      type: 'github',
+      op: 'labels.add',
+      values: ['good first issue', 'enhancement', 'ui/ux'],
+    };
+
+    await provider.execute(pr, cfg);
+
+    const { Octokit } = await import('@octokit/rest');
+    const mockApi = (Octokit as any).__mock;
+    expect(mockApi.addLabels).toHaveBeenCalledTimes(1);
+    expect(mockApi.addLabels).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      issue_number: 10,
+      labels: ['good first issue', 'enhancement', 'ui/ux'],
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a bug where the `safe_label` Liquid filter was removing spaces from GitHub label names, causing multi-word labels like "good first issue" to become "goodfirstissue".

## Problem

The `sanitizeLabel` function was using a regex `[^A-Za-z0-9:\/]` that removed all characters except alphanumerics, colons, and slashes. This meant that spaces in label names were being stripped out, breaking common multi-word GitHub labels.

## Solution

Updated the `sanitizeLabel` function to:
- Allow spaces and hyphens: `[^A-Za-z0-9:\/\- ]`
- Trim leading/trailing whitespace
- Continue to collapse repeated slashes as before

## Changes

- **src/liquid-extensions.ts**: Updated regex to preserve spaces and hyphens
- **docs/github-ops.md**: Updated documentation to reflect new allowed characters
- **docs/configuration.md**: Updated documentation to reflect new allowed characters
- **tests/unit/liquid-extensions.test.ts**: Added 7 comprehensive tests for safe_label filter
- **tests/unit/providers/github-ops-provider.test.ts**: Added test for preserving spaces in labels

## Test Results

All tests pass ✅

The fix ensures labels like:
- "good first issue" ✅ (was "goodfirstissue" ❌)
- "needs review" ✅ (was "needsreview" ❌)
- "ui/ux" ✅ (unchanged)
- "review/effort:high" ✅ (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)