### PR TITLE
Fix MCP provider config schema validation

### DIFF
--- a/dist/generated/config-schema.json
+++ b/dist/generated/config-schema.json
@@ -374,6 +374,17 @@
         "sessionId": {
           "type": "string",
           "description": "Session ID for HTTP transport (optional, server may generate one)"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Command arguments (for stdio transport in MCP checks)"
+        },
+        "workingDirectory": {
+          "type": "string",
+          "description": "Working directory (for stdio transport in MCP checks)"
         }
       },
       "additionalProperties": false,

--- a/src/generated/config-schema.ts
+++ b/src/generated/config-schema.ts
@@ -368,6 +368,17 @@ export const configSchema = {
           type: 'string',
           description: 'Session ID for HTTP transport (optional, server may generate one)',
         },
+        args: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+          description: 'Command arguments (for stdio transport in MCP checks)',
+        },
+        workingDirectory: {
+          type: 'string',
+          description: 'Working directory (for stdio transport in MCP checks)',
+        },
       },
       additionalProperties: false,
       description: 'Configuration for a single check',

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -415,6 +415,10 @@ export interface CheckConfig {
   argsTransform?: string;
   /** Session ID for HTTP transport (optional, server may generate one) */
   sessionId?: string;
+  /** Command arguments (for stdio transport in MCP checks) */
+  args?: string[];
+  /** Working directory (for stdio transport in MCP checks) */
+  workingDirectory?: string;
   /**
    * Human input provider specific options (optional, only used when type === 'human-input').
    */


### PR DESCRIPTION
## Summary
- Fixed missing MCP-specific fields in config schema causing validation warnings
- Added `args` and `workingDirectory` fields to CheckConfig interface
- Updated generated TypeScript and JSON schemas

## Changes
- `src/types/config.ts`: Added `args?: string[]` and `workingDirectory?: string` to CheckConfig
- `src/generated/config-schema.ts`: Regenerated schema with new fields
- `dist/generated/config-schema.json`: Updated JSON schema (manually, as generator had issues)

## Problem
When using MCP provider with stdio transport, users would see warnings:
```
⚠  Config warning [checks.probeSearch.args]: Unknown key 'args' will be ignored
```

These fields were already supported by `McpCheckProvider` but missing from the config type definition and validation schema.

## Test plan
- [x] Build succeeds without TypeScript errors
- [x] Config validation no longer warns about `args` and `workingDirectory`
- [x] MCP stdio transport works correctly with command arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)