### PR TITLE
Fix: prevent duplicated issue comment content when dynamic group posts multiple responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -762,8 +762,30 @@ async function handleIssueEvent(
     if (Object.keys(results).length > 0) {
       let commentBody = '';
 
+      // Collapse dynamic group: if multiple dynamic responses exist in a single run,
+      // take only the last non-empty one to avoid duplicated old+new answers.
+      const resultsToUse: typeof results = { ...results } as any;
+      try {
+        const dyn = (resultsToUse as any)['dynamic'] as
+          | Array<{
+              checkName: string;
+              content?: string;
+            }>
+          | undefined;
+        if (Array.isArray(dyn) && dyn.length > 1) {
+          const nonEmpty = dyn.filter(d => d.content && String(d.content).trim().length > 0);
+          if (nonEmpty.length > 0) {
+            // Keep only the last non-empty dynamic item
+            (resultsToUse as any)['dynamic'] = [nonEmpty[nonEmpty.length - 1]] as any;
+          } else {
+            // All empty: keep the last item (empty) to preserve intent
+            (resultsToUse as any)['dynamic'] = [dyn[dyn.length - 1]] as any;
+          }
+        }
+      } catch {}
+
       // Directly use check content without adding extra headers
-      for (const checks of Object.values(results)) {
+      for (const checks of Object.values(resultsToUse)) {
         for (const check of checks) {
           if (check.content && check.content.trim()) {
             commentBody += `${check.content}\n\n`;

--- a/tests/integration/issue-double-content-detection.test.ts
+++ b/tests/integration/issue-double-content-detection.test.ts
@@ -1,0 +1,131 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Minimal Octokit REST mock to capture posted comment body
+const issuesCreateComment = jest.fn();
+const issuesListComments = jest.fn().mockResolvedValue({ data: [] });
+const pullsGet = jest.fn().mockResolvedValue({ data: { head: { sha: 'deadbeefcafebabe' } } });
+const pullsListFiles = jest.fn().mockResolvedValue({
+  data: [{ filename: 'x', status: 'modified', additions: 1, deletions: 0, changes: 1 }],
+});
+
+jest.mock('@octokit/rest', () => {
+  return {
+    Octokit: jest.fn().mockImplementation(() => ({
+      rest: {
+        issues: { createComment: issuesCreateComment, listComments: issuesListComments },
+        pulls: { get: pullsGet, listFiles: pullsListFiles },
+        checks: { create: jest.fn(), update: jest.fn() },
+      },
+    })),
+  };
+});
+
+describe('Issue assistant double-content detection (issues opened)', () => {
+  beforeEach(() => {
+    issuesCreateComment.mockReset();
+    issuesListComments.mockClear();
+    pullsGet.mockClear();
+    pullsListFiles.mockClear();
+
+    // Clean env used by action run()
+    delete process.env.GITHUB_EVENT_NAME;
+    delete process.env.GITHUB_EVENT_PATH;
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.GITHUB_REPOSITORY_OWNER;
+    delete process.env['INPUT_GITHUB-TOKEN'];
+    delete process.env['INPUT_OWNER'];
+    delete process.env['INPUT_REPO'];
+    delete process.env['INPUT_CONFIG-PATH'];
+    delete process.env['INPUT_CREATE-CHECK'];
+    delete process.env['INPUT_COMMENT-ON-PR'];
+    delete process.env['INPUT_DEBUG'];
+  });
+
+  const writeTmp = (name: string, data: any) => {
+    const p = path.join(process.cwd(), name);
+    fs.writeFileSync(p, typeof data === 'string' ? data : JSON.stringify(data));
+    return p;
+  };
+
+  // This config intentionally produces two assistant-style outputs in the same run.
+  // With current behavior, both get concatenated into the single issue comment.
+  // We assert that only one assistant response appears (i.e., deduped/collapsed),
+  // so this test should fail until the posting logic is fixed.
+  const makeConfig = () => `
+version: "1.0"
+checks:
+  assistant-initial:
+    type: ai
+    ai_provider: mock
+    schema: issue-assistant
+    group: dynamic
+    on: [issue_opened]
+    prompt: |
+      Return ONE JSON object for issue-assistant.
+      text: ### Assistant Reply
+      intent: issue_triage
+
+  assistant-refined:
+    type: ai
+    ai_provider: mock
+    schema: issue-assistant
+    group: dynamic
+    depends_on: [assistant-initial]
+    on: [issue_opened]
+    prompt: |
+      Return ONE JSON object for issue-assistant.
+      text: ### Assistant Reply
+      intent: issue_triage
+
+output:
+  pr_comment:
+    format: markdown
+    group_by: check
+`;
+
+  it('posts only the refined answer (no duplicate old+new content)', async () => {
+    const cfgPath = writeTmp('.tmp-double-content.yaml', makeConfig());
+    const event = {
+      action: 'opened',
+      issue: { number: 77, state: 'open' },
+      repository: { full_name: 'acme/widgets' },
+      sender: { login: 'reporter' },
+    } as any;
+    const eventPath = writeTmp('.tmp-issues-opened-double.json', event);
+
+    process.env.GITHUB_EVENT_NAME = 'issues';
+    process.env.GITHUB_EVENT_PATH = eventPath;
+    process.env.GITHUB_REPOSITORY = 'acme/widgets';
+    process.env.GITHUB_REPOSITORY_OWNER = 'acme';
+    process.env['INPUT_GITHUB-TOKEN'] = 'test-token';
+    process.env['INPUT_OWNER'] = 'acme';
+    process.env['INPUT_REPO'] = 'widgets';
+    process.env['INPUT_CONFIG-PATH'] = cfgPath;
+    process.env['INPUT_CREATE-CHECK'] = 'false';
+    process.env['INPUT_COMMENT-ON-PR'] = 'false';
+    process.env['INPUT_DEBUG'] = 'true';
+
+    jest.resetModules();
+    const { run } = await import('../../src/index');
+    await run();
+
+    // Exactly one comment is posted
+    expect(issuesCreateComment).toHaveBeenCalledTimes(1);
+    const call = issuesCreateComment.mock.calls[0][0];
+    const body: string = call.body;
+    // Debug: persist body for local inspection
+    fs.mkdirSync('tmp', { recursive: true });
+    fs.writeFileSync('tmp/issue-double-content-body.md', body, 'utf8');
+
+    // Desired behavior: Only a single assistant response should appear.
+    // Current bug: both initial and refined outputs are concatenated. In the
+    // mock path the provider sometimes returns a minimal JSON like {"issues":[]}.
+    // Assert that only one such block exists.
+    const jsonBlockCount = (body.match(/\{\s*\"issues\"\s*:\s*\[\]\s*\}/g) || []).length;
+    expect(jsonBlockCount).toBe(1);
+
+    fs.unlinkSync(cfgPath);
+    fs.unlinkSync(eventPath);
+  });
+});


### PR DESCRIPTION
This PR fixes an issue where, with fact validation enabled, an initial assistant reply and a refined reply could both be concatenated into a single issue comment (double content).

Key changes
- Collapse dynamic group results on issues: keep only the last non‑empty dynamic response when composing the final issue comment body (src/index.ts).
- Add an integration test that reproduces two dynamic assistant outputs in a single issues run and asserts the posted comment contains only one (tests/integration/issue-double-content-detection.test.ts).

Why this is safe
- Mirrors the PR-path collapse safeguards we already apply in reviewer.ts (last‑wins semantics) but scoped to issue comments.
- Preserves default behavior for non‑dynamic groups.

Validation
- New test passes locally.
- Existing fact-validation gate test continues to pass: tests/integration/issue-posting-fact-gate.test.ts.

Notes
- No changes to prompts or schemas; this targets only the posting/aggregation step for issues.