### PR TITLE
fix(defaults): value_js sandbox error on apply-issue-labels; add issue-triage labels test

### DIFF
--- a/defaults/visor.tests.yaml
+++ b/defaults/visor.tests.yaml
@@ -102,6 +102,31 @@ tests:
             contains:
               - "Bug: crashes on search edge case"
 
+    - name: issue-triage-labels
+      description: |
+        Minimal issue triage path to validate label application from issue-assistant output.
+        This specifically exercises the apply-issue-labels value_js to catch sandbox errors.
+      event: issue_opened
+      fixture: gh.issue_open.minimal
+      mocks:
+        issue-assistant:
+          text: |
+            Thanks for the report — we will triage shortly.
+          intent: issue_triage
+          labels: [bug, priority/medium]
+      expect:
+        calls:
+          - step: issue-assistant
+            exactly: 1
+          - step: apply-issue-labels
+            exactly: 1
+          - provider: github
+            op: labels.add
+            at_least: 1
+            args:
+              contains:
+                - bug
+
     - name: pr-review-e2e-flow
       description: |
         End-to-end PR lifecycle covering multiple external events:

--- a/defaults/visor.yaml
+++ b/defaults/visor.yaml
@@ -489,16 +489,16 @@ steps:
     op: labels.add
     value_js: |
       try {
-        const labels = Array.isArray(outputs['issue-assistant']?.labels)
-          ? outputs['issue-assistant'].labels
-          : [];
+        var ai = outputs && outputs['issue-assistant'] ? outputs['issue-assistant'] : {};
+        var labels = Array.isArray(ai && ai.labels) ? ai.labels : [];
         // Sanitize labels: keep [A-Za-z0-9:/\- ] (alphanumerics, colon, slash, hyphen, and space), collapse repeated '/'
         return labels
-          .map(v => String(v ?? ''))
-          .map(s => s.replace(/[^A-Za-z0-9:\/\- ]/g, '').replace(/\/{2,}/g, '/').trim())
+          .map(function(v) { return String(v == null ? '' : v); })
+          .map(function(s) { return s.replace(/[^A-Za-z0-9:\/\- ]/g, '').replace(/\/{2,}/g, '/').trim(); })
           .filter(Boolean);
-      } catch (error) {
-        log('Error processing issue labels:', error);
+      } catch (e) {
+        // Avoid shadowing/resolution quirks with identifier name "error" in sandboxed environments
+        log('Error processing issue labels:', e);
         return [];
       }
 


### PR DESCRIPTION
Fixes sandbox_runner_error: "error is not defined" when posting Issue Assistant comments with label application.

- Fix: rename catch identifier and use ES5-safe guards in `apply-issue-labels.value_js` to avoid identifier resolution quirks inside the sandbox.
- Test: add `issue-triage-labels` case in `defaults/visor.tests.yaml` to exercise the issue_opened → apply labels path and catch regressions.
- Verified: `npm run test:yaml` passes locally; simulated issue path shows `labels.add` without value_js errors.