### PR TITLE
fix: create unique comments for dynamic group instead of updating

### DIFF
--- a/src/frontends/github-frontend.ts
+++ b/src/frontends/github-frontend.ts
@@ -548,6 +548,13 @@ ${end}`);
   }
 
   private commentIdForGroup(ctx: FrontendContext, group: string): string {
+    // For "dynamic" group, each run creates a new comment (not updated across runs)
+    // This is used for assistants that respond to issue comments where each
+    // response should be a separate comment rather than updating a previous one.
+    // Within a single run, the comment ID stays stable so updates work correctly.
+    if (group === 'dynamic') {
+      return `visor-thread-dynamic-${ctx.run.runId}`;
+    }
     // Stable per-PR per-group ID (does not include commit SHA)
     const r = ctx.run;
     const base = r.repo && r.pr ? `${r.repo.owner}/${r.repo.name}#${r.pr}` : r.runId;


### PR DESCRIPTION
## Summary

- Fixed bug where `dynamic` group comments (used by issue/comment assistants) were incorrectly updating previous comments instead of creating new ones
- Changed `commentIdForGroup` to use the unique `runId` (UUID) for dynamic groups, ensuring each event trigger creates a separate comment
- Added test to verify dynamic group creates separate comments per run

## Problem

When a GitHub issue received followup comments, each response from the `comment-assistant` (which uses `group: dynamic`) was updating the previous comment instead of creating a new one. This was because the comment ID generated was `visor-thread-dynamic-owner/repo#issue` which remained the same across runs.

## Solution

For `group === 'dynamic'`, the `commentIdForGroup` method now uses `ctx.run.runId` which is a UUID unique per event trigger. This ensures:
- Each event trigger creates a new comment
- Updates within the same run still work correctly (same runId)

## Test plan

- [x] Added unit test: "Dynamic group creates separate comments per run (not updated across runs)"
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)