### PR TITLE
fix: extract text field from JSON output when template rendering fails

### DIFF
--- a/src/state-machine/dispatch/template-renderer.ts
+++ b/src/state-machine/dispatch/template-renderer.ts
@@ -58,10 +58,24 @@ export async function renderTemplateContent(
       greedy: false,
     });
 
+    // Ensure output is an object, not a JSON string
+    // If output is a string that looks like JSON, parse it
+    let output = (reviewSummary as any).output;
+    if (typeof output === 'string') {
+      const trimmed = output.trim();
+      if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+        try {
+          output = JSON.parse(trimmed);
+        } catch {
+          // Not valid JSON, keep as string
+        }
+      }
+    }
+
     const templateData: Record<string, unknown> = {
       issues: reviewSummary.issues || [],
       checkName: checkId,
-      output: (reviewSummary as any).output,
+      output,
     };
 
     const rendered = await liquid.parseAndRender(templateContent, templateData);

--- a/src/state-machine/states/level-dispatch.ts
+++ b/src/state-machine/states/level-dispatch.ts
@@ -2891,14 +2891,28 @@ async function renderTemplateContent(
       greedy: false,
     });
 
+    // Ensure output is an object, not a JSON string
+    // If output is a string that looks like JSON, parse it
+    let output = (reviewSummary as any).output;
+    if (typeof output === 'string') {
+      const trimmed = output.trim();
+      if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+        try {
+          output = JSON.parse(trimmed);
+        } catch {
+          // Not valid JSON, keep as string
+        }
+      }
+    }
+
     const templateData: Record<string, unknown> = {
       issues: reviewSummary.issues || [],
       checkName: checkId,
-      output: (reviewSummary as any).output,
+      output,
     };
 
     logger.debug(
-      `[LevelDispatch] Rendering template for ${checkId} with output keys: ${(reviewSummary as any).output ? Object.keys((reviewSummary as any).output).join(', ') : 'none'}`
+      `[LevelDispatch] Rendering template for ${checkId} with output keys: ${output && typeof output === 'object' ? Object.keys(output).join(', ') : 'none'}`
     );
 
     const rendered = await liquid.parseAndRender(templateContent, templateData);

--- a/src/utils/json-text-extractor.ts
+++ b/src/utils/json-text-extractor.ts
@@ -7,6 +7,77 @@
  */
 
 /**
+ * Extract text/response/message field from malformed JSON-like string using regex.
+ * Handles cases where AI returns incomplete JSON like:
+ * {"text": "content here...\n\n## More content" (missing closing brace)
+ *
+ * @param content - The malformed JSON-like string
+ * @returns The extracted text content, or undefined if not found
+ */
+function extractTextFieldFromMalformedJson(content: string): string | undefined {
+  // Try to match "text", "response", or "message" field at the start of JSON
+  // Pattern: {"text": "..." or { "text": "..." (with optional whitespace)
+  // The value can be a quoted string that we need to extract
+
+  // First, try to find a field like "text": "value" or "text": value
+  // We look for the field name followed by : and then extract everything after
+  const fieldPatterns = [
+    /^\s*\{\s*"text"\s*:\s*"/i,
+    /^\s*\{\s*"response"\s*:\s*"/i,
+    /^\s*\{\s*"message"\s*:\s*"/i,
+  ];
+
+  for (const pattern of fieldPatterns) {
+    const match = pattern.exec(content);
+    if (match) {
+      // Found a field, extract the value starting after the opening quote
+      const valueStart = match[0].length;
+      const remaining = content.substring(valueStart);
+
+      // Try to find the end of the string value by looking for unescaped quotes
+      // Handle escaped quotes (\") within the string
+      let value = '';
+      let i = 0;
+      while (i < remaining.length) {
+        const char = remaining[i];
+        if (char === '\\' && i + 1 < remaining.length) {
+          // Escape sequence - handle common ones
+          const nextChar = remaining[i + 1];
+          if (nextChar === 'n') {
+            value += '\n';
+          } else if (nextChar === 'r') {
+            value += '\r';
+          } else if (nextChar === 't') {
+            value += '\t';
+          } else if (nextChar === '"') {
+            value += '"';
+          } else if (nextChar === '\\') {
+            value += '\\';
+          } else {
+            // Unknown escape, keep as-is
+            value += char + nextChar;
+          }
+          i += 2;
+        } else if (char === '"') {
+          // End of string value (unescaped quote)
+          break;
+        } else {
+          value += char;
+          i++;
+        }
+      }
+
+      // If we extracted something meaningful, return it
+      if (value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * Extract text from a JSON-like object or JSON string.
  * If the input is a string that looks like JSON with a text/response/message field,
  * extracts and returns that field. Otherwise returns the original content.
@@ -32,7 +103,13 @@ export function extractTextFromJson(content: unknown): string | undefined {
     try {
       parsed = JSON.parse(trimmed);
     } catch {
-      // Not valid JSON, return as-is
+      // JSON parsing failed - try to extract text field using regex
+      // This handles malformed JSON like: {"text": "content...\n\n## More content" (missing closing brace)
+      const extracted = extractTextFieldFromMalformedJson(trimmed);
+      if (extracted) {
+        return extracted;
+      }
+      // Couldn't extract, return as-is
       return trimmed.length > 0 ? trimmed : undefined;
     }
   }

--- a/tests/unit/json-text-extractor.test.ts
+++ b/tests/unit/json-text-extractor.test.ts
@@ -1,0 +1,129 @@
+import { extractTextFromJson } from '../../src/utils/json-text-extractor';
+
+describe('extractTextFromJson', () => {
+  describe('valid JSON', () => {
+    it('extracts text field from valid JSON string', () => {
+      const json = '{"text": "Hello world", "tags": {"label": "feature"}}';
+      expect(extractTextFromJson(json)).toBe('Hello world');
+    });
+
+    it('extracts response field from valid JSON string', () => {
+      const json = '{"response": "Hello world"}';
+      expect(extractTextFromJson(json)).toBe('Hello world');
+    });
+
+    it('extracts message field from valid JSON string', () => {
+      const json = '{"message": "Hello world"}';
+      expect(extractTextFromJson(json)).toBe('Hello world');
+    });
+
+    it('extracts text field from object', () => {
+      const obj = { text: 'Hello world', tags: { label: 'feature' } };
+      expect(extractTextFromJson(obj)).toBe('Hello world');
+    });
+
+    it('prefers text over response over message', () => {
+      const json = '{"text": "txt", "response": "resp", "message": "msg"}';
+      expect(extractTextFromJson(json)).toBe('txt');
+    });
+  });
+
+  describe('malformed JSON', () => {
+    it('extracts text from JSON missing closing brace', () => {
+      const malformed = '{\n"text": "This PR introduces support for mTLS modes...';
+      expect(extractTextFromJson(malformed)).toBe('This PR introduces support for mTLS modes...');
+    });
+
+    it('extracts text from JSON with markdown content and missing closing brace', () => {
+      const malformed = `{
+"text": "This PR introduces support for two distinct Mutual TLS (mTLS) modes.
+
+## Files Changed Analysis
+
+The changes are centered around the product configuration...`;
+      const result = extractTextFromJson(malformed);
+      expect(result).toContain('This PR introduces support for two distinct Mutual TLS');
+      expect(result).toContain('## Files Changed Analysis');
+      expect(result).not.toContain('{');
+      expect(result).not.toContain('"text":');
+    });
+
+    it('extracts text with escaped newlines', () => {
+      const malformed = '{"text": "Line 1\\nLine 2\\nLine 3';
+      expect(extractTextFromJson(malformed)).toBe('Line 1\nLine 2\nLine 3');
+    });
+
+    it('extracts text with escaped quotes', () => {
+      const malformed = '{"text": "She said \\"hello\\"';
+      expect(extractTextFromJson(malformed)).toBe('She said "hello"');
+    });
+
+    it('extracts response field from malformed JSON', () => {
+      const malformed = '{"response": "Some response content';
+      expect(extractTextFromJson(malformed)).toBe('Some response content');
+    });
+
+    it('extracts message field from malformed JSON', () => {
+      const malformed = '{"message": "Some message content';
+      expect(extractTextFromJson(malformed)).toBe('Some message content');
+    });
+
+    it('handles whitespace variations', () => {
+      const malformed = '{  "text"  :  "Content here';
+      expect(extractTextFromJson(malformed)).toBe('Content here');
+    });
+  });
+
+  describe('non-JSON content', () => {
+    it('returns plain text as-is', () => {
+      expect(extractTextFromJson('Hello world')).toBe('Hello world');
+    });
+
+    it('returns markdown as-is', () => {
+      const markdown = '## Title\n\nSome content';
+      expect(extractTextFromJson(markdown)).toBe('## Title\n\nSome content');
+    });
+
+    it('returns undefined for null', () => {
+      expect(extractTextFromJson(null)).toBeUndefined();
+    });
+
+    it('returns undefined for undefined', () => {
+      expect(extractTextFromJson(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for empty string', () => {
+      expect(extractTextFromJson('')).toBeUndefined();
+    });
+
+    it('returns undefined for whitespace-only string', () => {
+      expect(extractTextFromJson('   ')).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles JSON array (returns original - no text field)', () => {
+      // Arrays don't have text/response/message fields, return original
+      const json = '[1, 2, 3]';
+      expect(extractTextFromJson(json)).toBe('[1, 2, 3]');
+    });
+
+    it('handles object without text/response/message fields (returns original)', () => {
+      // When there's no text field to extract, return original JSON string as fallback
+      const json = '{"foo": "bar"}';
+      expect(extractTextFromJson(json)).toBe('{"foo": "bar"}');
+    });
+
+    it('handles empty text field (returns original)', () => {
+      // Empty text field means we can't extract meaningful content, return original
+      const json = '{"text": ""}';
+      expect(extractTextFromJson(json)).toBe('{"text": ""}');
+    });
+
+    it('handles whitespace-only text field (returns original)', () => {
+      // Whitespace-only text field means we can't extract meaningful content, return original
+      const json = '{"text": "   "}';
+      expect(extractTextFromJson(json)).toBe('{"text": "   "}');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add fallback mechanism to extract text content from AI responses when template rendering fails to unwrap JSON
- Handle malformed/truncated JSON responses (e.g., missing closing brace) using regex-based extraction
- Parse JSON string outputs to objects in template context before passing to Liquid templates

## Problem

AI providers sometimes return JSON-structured responses with `text`, `response`, or `message` fields, but:
1. The JSON can be truncated/malformed (missing closing brace)
2. The output may be passed as a JSON string instead of a parsed object to templates

This caused template rendering to fail or output raw JSON instead of the intended text content.

## Changes

- `src/utils/json-text-extractor.ts` - New utility with `extractTextFromJson()` function that handles:
  - Valid JSON parsing with text/response/message field extraction
  - Regex-based extraction from malformed JSON (handles escape sequences)
  - Graceful fallback to original content when no extraction is possible

- `src/state-machine/dispatch/template-renderer.ts` & `src/state-machine/states/level-dispatch.ts` - Added JSON string parsing before template rendering

- `tests/unit/json-text-extractor.test.ts` - Comprehensive test coverage for the new utility

## Test plan

- [x] Unit tests pass for all JSON extraction scenarios
- [x] Full test suite passes
- [x] Handles valid JSON with text/response/message fields
- [x] Handles malformed JSON with missing closing brace
- [x] Handles escaped characters (newlines, quotes)
- [x] Falls back gracefully for non-JSON content

🤖 Generated with [Claude Code](https://claude.com/claude-code)