### PR TITLE
fix: use dotenv override to ensure .env takes precedence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@octokit/auth-app": "^8.1.0",
         "@octokit/core": "^7.0.3",
         "@octokit/rest": "^22.0.0",
-        "@probelabs/probe": "^0.6.0-rc173",
+        "@probelabs/probe": "^0.6.0-rc196",
         "@types/commander": "^2.12.0",
         "@types/uuid": "^10.0.0",
         "ajv": "^8.17.1",
@@ -5942,9 +5942,9 @@
       }
     },
     "node_modules/@probelabs/maid": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@probelabs/maid/-/maid-0.0.21.tgz",
-      "integrity": "sha512-H3EA2tDjWsAPgXZAwfHrNoEXnHmQFS9+JGDK/YpeiF3g3FxPgnWBgtgYPgtNuETQsEXxR1RzDgQVJL2JHWRRHw==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@probelabs/maid/-/maid-0.0.22.tgz",
+      "integrity": "sha512-FYcyyP4BlVrHQmBznXFPpMbvUqFI6wbecHUUe4S+yIeDvJ8W4bP0ndZ0cMoc2p7hekWYAG4RtlohQBr8e4TKOg==",
       "license": "ISC",
       "dependencies": {
         "@types/dagre": "^0.7.53",
@@ -5960,9 +5960,9 @@
       }
     },
     "node_modules/@probelabs/probe": {
-      "version": "0.6.0-rc173",
-      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc173.tgz",
-      "integrity": "sha512-dNgA1vR9ESzg0uliUOhGpgLUrPhYv/Ch3ND1HHet0WqnI+yRR6BLi4RpLJcfluIO63nOMzvfmnRmWG2DEvZDqw==",
+      "version": "0.6.0-rc196",
+      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc196.tgz",
+      "integrity": "sha512-kSYFqeltqHHcnbNSSOpZfGvCDKMUNrdeLzRXGPwvLPiXM8TOz/USd6WGD5IoA1IsB5L9VHxCSaorwZt1YUgeSw==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -5972,7 +5972,7 @@
         "@ai-sdk/openai": "^2.0.10",
         "@anthropic-ai/claude-agent-sdk": "^0.1.46",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@probelabs/maid": "^0.0.21",
+        "@probelabs/maid": "^0.0.22",
         "adm-zip": "^0.5.16",
         "ai": "^5.0.0",
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@octokit/auth-app": "^8.1.0",
     "@octokit/core": "^7.0.3",
     "@octokit/rest": "^22.0.0",
-    "@probelabs/probe": "^0.6.0-rc173",
+    "@probelabs/probe": "^0.6.0-rc196",
     "@types/commander": "^2.12.0",
     "@types/uuid": "^10.0.0",
     "ajv": "^8.17.1",

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
-// Load environment variables from .env file
-import 'dotenv/config';
+// Load environment variables from .env file (override existing to allow .env to take precedence)
+import * as dotenv from 'dotenv';
+dotenv.config({ override: true, quiet: true });
 
 import { CLI } from './cli';
 import { ConfigManager } from './config';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,9 @@
 // GitHub event objects have complex dynamic structures that are difficult to fully type
 // Using 'any' for these objects is acceptable as they come from external GitHub webhooks
 
-// Load environment variables from .env file
-import 'dotenv/config';
+// Load environment variables from .env file (override existing to allow .env to take precedence)
+import * as dotenv from 'dotenv';
+dotenv.config({ override: true, quiet: true });
 
 import { Octokit } from '@octokit/rest';
 import { createAppAuth } from '@octokit/auth-app';


### PR DESCRIPTION
## Summary
- Fix .env file values being silently ignored when env vars already exist in shell
- Update @probelabs/probe to 0.6.0-rc196

## Problem
When environment variables like `GOOGLE_API_KEY` are already set in the shell (even as empty strings), dotenv's default behavior is to NOT override them. This causes .env file values to be silently ignored, leading to confusing "No API key configured" errors even when keys are properly set in .env files.

## Solution
Changed from `import 'dotenv/config'` to explicit `dotenv.config({ override: true, quiet: true })`:
- `override: true` - ensures .env file values take precedence over existing env vars
- `quiet: true` - suppresses dotenv's stdout output which was breaking JSON parsing in tests

## Test plan
- [x] Tests pass
- [x] Verified .env loading works when running visor from project directory with existing empty env vars

🤖 Generated with [Claude Code](https://claude.ai/code)