### PR TITLE
fix: return JSON-RPC -32602 for workflow input validation errors

### DIFF
--- a/src/providers/mcp-custom-sse-server.ts
+++ b/src/providers/mcp-custom-sse-server.ts
@@ -919,12 +919,22 @@ export class CustomToolsSSEServer implements CustomMCPServer {
         `[CustomToolsSSEServer:${this.sessionId}] Tool execution failed: ${toolName} - ${errorMsg}`
       );
 
+      // Default to internal error
+      let errorCode = -32603;
+      let errorMessage = 'Internal error';
+
+      // Check for specific, user-facing errors like input validation
+      if (errorMsg.startsWith('Invalid workflow inputs:')) {
+        errorCode = -32602; // JSON-RPC standard for Invalid Parameters
+        errorMessage = 'Invalid tool parameters';
+      }
+
       return {
         jsonrpc: '2.0',
         id,
         error: {
-          code: -32603,
-          message: 'Internal error',
+          code: errorCode,
+          message: errorMessage,
           data: {
             tool: toolName,
             error: errorMsg,


### PR DESCRIPTION
## Summary

- When a tool call fails with an `Invalid workflow inputs:` error, the MCP server now returns JSON-RPC error code `-32602` (Invalid Params) instead of the generic `-32603` (Internal Error)
- This allows calling agents to distinguish input validation failures from internal errors and potentially self-heal by correcting their parameters
- The original detailed error message is preserved in the `data.error` field for debugging

## Changes

- `src/providers/mcp-custom-sse-server.ts`: Modified the `handleToolCall` catch block to check for `'Invalid workflow inputs:'` prefix in error messages and return the appropriate JSON-RPC error code

## Test plan

- [x] Existing unit tests pass (`tests/unit/mcp-custom-sse-server.test.ts` — 17/17 passing)
- [ ] Verify that workflow tools with invalid inputs now return `-32602` error code
- [ ] Verify that other tool failures still return `-32603` error code
- [ ] Verify the original error message is still included in `data.error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)