### PR TITLE
Embed raw error messages in MCP responses for self-healing

### DIFF
--- a/src/providers/mcp-custom-sse-server.ts
+++ b/src/providers/mcp-custom-sse-server.ts
@@ -463,16 +463,16 @@ export class CustomToolsSSEServer implements CustomMCPServer {
         `[CustomToolsSSEServer:${this.sessionId}] Tool execution failed: ${toolName} - ${errorMsg}`
       );
 
+      const isValidationError = errorMsg.startsWith('Invalid workflow inputs:');
+
       return {
         jsonrpc: '2.0',
         id,
         error: {
-          code: -32603,
-          message: 'Internal error',
-          data: {
-            tool: toolName,
-            error: errorMsg,
-          },
+          code: isValidationError ? -32602 : -32603,
+          message: isValidationError
+            ? `Invalid tool parameters: ${errorMsg}`
+            : `Internal error during tool execution: ${errorMsg}`,
         },
       };
     }


### PR DESCRIPTION
## Summary
- Validation errors (`Invalid workflow inputs:`) now return error code `-32602` with message `"Invalid tool parameters: <raw_error>"`
- All other tool execution errors return `-32603` with message `"Internal error during tool execution: <raw_error>"`
- Removed the `data` object from error responses — the raw error is now embedded directly in the `message` field
- Added new test case for the `-32602` validation error path; updated existing tests to assert against the new message formats

## Test plan
- [x] All 18 unit tests in `mcp-custom-sse-server.test.ts` pass
- [ ] Verify agentic loop can parse error messages and self-correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)