### PR TITLE
feat: support ai_bash_config_js for dynamic bash permissions

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -546,6 +546,21 @@ export interface CheckConfig {
    * ```
    */
   ai_custom_tools_js?: string;
+  /**
+   * JavaScript expression to dynamically compute bash configuration for this AI check.
+   * Expression has access to: outputs, inputs, pr, files, env, memory
+   * Must return a BashConfig object with optional 'allow' and 'deny' string arrays.
+   *
+   * Example:
+   * ```
+   * const config = {};
+   * const bashConfig = outputs['build-config']?.bash_config || {};
+   * if (bashConfig.allow) config.allow = bashConfig.allow;
+   * if (bashConfig.deny) config.deny = bashConfig.deny;
+   * return config;
+   * ```
+   */
+  ai_bash_config_js?: string;
   /** Claude Code configuration (for claude-code type checks) */
   claude_code?: ClaudeCodeConfig;
   /** Environment variables for this check */


### PR DESCRIPTION
## Summary

- Add `ai_bash_config_js` field to the `CheckConfig` type in `src/types/config.ts`, enabling users to define a JavaScript expression that dynamically computes bash command permissions (allow/deny lists) at runtime.
- Add `evaluateBashConfigJs` private method to `AICheckProvider` in `src/providers/ai-check-provider.ts`, which evaluates the expression in a sandboxed context with access to `outputs`, `inputs`, `pr`, `files`, `env`, and `memory` — following the same pattern as the existing `ai_mcp_servers_js` feature.
- Integrate the evaluation into `executeWithConfig`: dynamic bash config is merged with any static `bashConfig` (dynamic augments static, arrays are concatenated), with validation that filters non-string entries from allow/deny arrays.

## Test plan

- [ ] Verify a check with `ai_bash_config_js` returning `{ allow: [...] }` correctly merges with existing static `bashConfig.allow`
- [ ] Verify a check with `ai_bash_config_js` returning `{ deny: [...] }` correctly merges with existing static `bashConfig.deny`
- [ ] Verify that non-string entries in allow/deny arrays are filtered out
- [ ] Verify that an invalid expression (throws error) logs a warning and does not break the check execution
- [ ] Verify that when `ai_bash_config_js` returns a non-object (e.g., array, string), a warning is logged and no config is applied
- [ ] Verify the sandbox context includes all expected variables (`outputs`, `inputs`, `pr`, `files`, `env`, `memory`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)