### PR TITLE
feat: add ai_bash_config_js for dynamic skill-based bash permissions

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -546,6 +546,21 @@ export interface CheckConfig {
    * ```
    */
   ai_custom_tools_js?: string;
+  /**
+   * JavaScript expression to dynamically compute bash configuration for this AI check.
+   * Expression has access to: outputs, inputs, pr, files, env, memory
+   * Must return a BashConfig object with optional 'allow' and 'deny' string arrays.
+   *
+   * Example:
+   * ```
+   * const config = {};
+   * const bashConfig = outputs['build-config']?.bash_config || {};
+   * if (bashConfig.allow) config.allow = bashConfig.allow;
+   * if (bashConfig.deny) config.deny = bashConfig.deny;
+   * return config;
+   * ```
+   */
+  ai_bash_config_js?: string;
   /** Claude Code configuration (for claude-code type checks) */
   claude_code?: ClaudeCodeConfig;
   /** Environment variables for this check */


### PR DESCRIPTION
## Summary
- Adds `ai_bash_config_js` field to `CheckConfig` type for dynamically computing bash command permissions via JavaScript expressions
- Adds `evaluateBashConfigJs()` method to `AICheckProvider` using secure sandbox evaluation (same pattern as `evaluateMcpServersJs`)
- Integrates dynamic bash config merging in `executeWithConfig()` - dynamic config augments static `bashConfig` (allow/deny arrays are concatenated)

This enables workflows (like visor-ee's assistant) to aggregate `allowed_commands` from active skill definitions and inject them as bash permissions at runtime.

## Related PRs
- **visor-ee**: https://github.com/probelabs/visor-ee/pull/4
- **probelabs-assistant**: https://github.com/probelabs/probelabs-assistant/pull/8

## Test plan
- [ ] Verify TypeScript build passes (`npm run build`)
- [ ] Verify `evaluateBashConfigJs` correctly evaluates expressions in secure sandbox
- [ ] Verify merging logic: dynamic allow/deny arrays concatenate with static bashConfig
- [ ] Verify error handling: invalid expressions return empty config without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)