### PR TITLE
fix(mcp): propagate custom tools to nested workflows via state machine

### DIFF
--- a/src/providers/workflow-check-provider.ts
+++ b/src/providers/workflow-check-provider.ts
@@ -1039,6 +1039,7 @@ export class WorkflowCheckProvider extends CheckProvider {
       // Carry over optional inputs/outputs if present so callers can consume them
       inputs: (loaded as any).inputs,
       outputs: (loaded as any).outputs,
+      tools: (loaded as any).tools,
     } as WorkflowDefinition;
 
     return workflowDef;

--- a/src/state-machine/workflow-projection.ts
+++ b/src/state-machine/workflow-projection.ts
@@ -66,6 +66,7 @@ export function projectWorkflowToGraph(
   // Create a synthetic config for this workflow
   const config: VisorConfig = {
     checks,
+    tools: workflow.tools,
     version: '1.0',
     output: {
       pr_comment: {

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -105,6 +105,8 @@ export interface WorkflowDefinition {
   inputs?: WorkflowInputParam[];
   /** Output parameters */
   outputs?: WorkflowOutputParam[];
+  /** Custom tools definition used by this workflow */
+  tools?: Record<string, import('./config').CustomToolDefinition>;
   /** Workflow steps - at root level like regular configs */
   steps: Record<string, WorkflowStep>;
 


### PR DESCRIPTION
Fixes an issue where custom tools defined in nested workflows were not properly propagated to the MCP provider, causing `Custom tool not found` errors. This is solved by safely passing the tools property through the nested engine execution context.