### PR TITLE
fix(mcp): add workflow inputs to Liquid template context

### DIFF
--- a/src/providers/mcp-check-provider.ts
+++ b/src/providers/mcp-check-provider.ts
@@ -308,6 +308,7 @@ export class McpCheckProvider extends CheckProvider {
         outputs: this.buildOutputContext(dependencyResults),
         args: sessionInfo?.args || {},
         env: this.getSafeEnvironmentVariables(),
+        inputs: (config as any).workflowInputs || sessionInfo?.workflowInputs || {},
       };
 
       // Render method arguments if needed


### PR DESCRIPTION
## Summary

The MCP check provider was missing `inputs` in its Liquid template context for `methodArgs` rendering. This caused `{{ inputs.* }}` expressions to resolve to empty strings when used in MCP step `methodArgs`.

Both the script provider and AI provider already include `workflowInputs` as `inputs` in their template contexts — the MCP provider was the only one missing it.

## What changed

- Added `inputs` field to the `templateContext` object in `mcp-check-provider.ts`, using the same pattern as `script-check-provider.ts`:
  ```typescript
  inputs: (config as any).workflowInputs || sessionInfo?.workflowInputs || {},
  ```

## Reproduction

Any workflow with a `type: mcp` step using `{{ inputs.* }}` in `methodArgs` would get empty values. For example, a Slack search workflow:

```yaml
steps:
  search-messages:
    type: mcp
    transport: custom
    method: search_messages
    methodArgs:
      query: "{{ inputs.query }}"  # Always resolved to ""
```

## Test plan

- [x] All 63 existing tests pass
- [x] Verified fix with real Slack API: `query: "gateway"` now correctly resolves in methodArgs