### PR TITLE
fix(slack): persist workspace across thread messages

### DIFF
--- a/tests/integration/slack-socket-workspace.test.ts
+++ b/tests/integration/slack-socket-workspace.test.ts
@@ -1,0 +1,244 @@
+import { createHash } from 'crypto';
+import { SlackSocketRunner } from '../../src/slack/socket-runner';
+import { StateMachineExecutionEngine } from '../../src/state-machine-execution-engine';
+import type { VisorConfig } from '../../src/types/config';
+
+function expectedWorkspaceName(channel: string, threadTs: string): string {
+  const hash = createHash('sha256').update(`${channel}:${threadTs}`).digest('hex').slice(0, 8);
+  return `slack-${hash}`;
+}
+
+describe('Slack socket workspace persistence across thread messages', () => {
+  const baseCfg: VisorConfig = {
+    version: '1.0',
+    slack: { endpoint: '/bots/slack/support', mentions: 'all', threads: 'required' } as any,
+    output: { pr_comment: { format: 'markdown', group_by: 'check', collapse: true } },
+    checks: { ask: { type: 'human-input' as any, on: ['manual'] } },
+  } as any;
+
+  function mkEnv(opts: {
+    type: string;
+    channel: string;
+    ts?: string;
+    thread_ts?: string;
+    text?: string;
+  }) {
+    const { type, channel, thread_ts } = opts;
+    const ts = opts.ts || '1700.123';
+    const text = opts.text || 'Hello bot!';
+    return {
+      type: 'events_api',
+      envelope_id: `env-${channel}-${type}-${ts}`,
+      payload: { event: { type, channel, ts, thread_ts, text } },
+    };
+  }
+
+  test('injects workspace.name from thread identity into cfgForRun', async () => {
+    const engine = new StateMachineExecutionEngine();
+    const runner = new SlackSocketRunner(engine, baseCfg, {
+      appToken: 'xapp-test',
+      endpoint: '/bots/slack/support',
+      mentions: 'all',
+      threads: 'required',
+    });
+
+    let capturedConfig: any = null;
+    const spy = jest
+      .spyOn(StateMachineExecutionEngine.prototype, 'executeChecks')
+      .mockImplementation(async (opts: any) => {
+        capturedConfig = opts.config;
+        return {
+          results: { default: [] },
+          statistics: {
+            totalChecks: 1,
+            checksByGroup: {},
+            issuesBySeverity: { critical: 0, error: 0, warning: 0, info: 0 },
+          },
+        } as any;
+      });
+
+    // DM root message — thread_ts is undefined, so falls back to ts
+    await (runner as any).handleMessage(
+      JSON.stringify(
+        mkEnv({
+          type: 'message',
+          channel: 'D123ABC',
+          ts: '1700000000.123456',
+        })
+      )
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(capturedConfig).toBeDefined();
+    expect(capturedConfig.workspace).toBeDefined();
+    expect(capturedConfig.workspace.name).toBe(
+      expectedWorkspaceName('D123ABC', '1700000000.123456')
+    );
+    expect(capturedConfig.workspace.cleanup_on_exit).toBe(false);
+
+    spy.mockRestore();
+  });
+
+  test('two messages in the same thread get the same workspace name', async () => {
+    const engine = new StateMachineExecutionEngine();
+    const runner = new SlackSocketRunner(engine, baseCfg, {
+      appToken: 'xapp-test',
+      endpoint: '/bots/slack/support',
+      mentions: 'all',
+      threads: 'required',
+    });
+
+    const capturedConfigs: any[] = [];
+    const spy = jest
+      .spyOn(StateMachineExecutionEngine.prototype, 'executeChecks')
+      .mockImplementation(async (opts: any) => {
+        capturedConfigs.push(opts.config);
+        return {
+          results: { default: [] },
+          statistics: {
+            totalChecks: 1,
+            checksByGroup: {},
+            issuesBySeverity: { critical: 0, error: 0, warning: 0, info: 0 },
+          },
+        } as any;
+      });
+
+    // First message: root of thread (no thread_ts, uses ts)
+    await (runner as any).handleMessage(
+      JSON.stringify(
+        mkEnv({
+          type: 'message',
+          channel: 'D999',
+          ts: '1700000000.111111',
+        })
+      )
+    );
+
+    // Second message: reply in same thread (thread_ts = parent's ts)
+    await (runner as any).handleMessage(
+      JSON.stringify(
+        mkEnv({
+          type: 'message',
+          channel: 'D999',
+          ts: '1700000000.222222',
+          thread_ts: '1700000000.111111',
+        })
+      )
+    );
+
+    expect(capturedConfigs.length).toBe(2);
+    // Both should have the same workspace name derived from the thread root ts
+    const expected = expectedWorkspaceName('D999', '1700000000.111111');
+    expect(capturedConfigs[0].workspace.name).toBe(expected);
+    expect(capturedConfigs[1].workspace.name).toBe(expected);
+
+    spy.mockRestore();
+  });
+
+  test('messages in different threads get different workspace names', async () => {
+    const engine = new StateMachineExecutionEngine();
+    const runner = new SlackSocketRunner(engine, baseCfg, {
+      appToken: 'xapp-test',
+      endpoint: '/bots/slack/support',
+      mentions: 'all',
+      threads: 'required',
+    });
+
+    const capturedConfigs: any[] = [];
+    const spy = jest
+      .spyOn(StateMachineExecutionEngine.prototype, 'executeChecks')
+      .mockImplementation(async (opts: any) => {
+        capturedConfigs.push(opts.config);
+        return {
+          results: { default: [] },
+          statistics: {
+            totalChecks: 1,
+            checksByGroup: {},
+            issuesBySeverity: { critical: 0, error: 0, warning: 0, info: 0 },
+          },
+        } as any;
+      });
+
+    // Thread 1
+    await (runner as any).handleMessage(
+      JSON.stringify(
+        mkEnv({
+          type: 'message',
+          channel: 'D999',
+          ts: '1700000000.111111',
+        })
+      )
+    );
+
+    // Thread 2 (different ts = different thread)
+    await (runner as any).handleMessage(
+      JSON.stringify(
+        mkEnv({
+          type: 'message',
+          channel: 'D999',
+          ts: '1700000000.333333',
+        })
+      )
+    );
+
+    expect(capturedConfigs.length).toBe(2);
+    expect(capturedConfigs[0].workspace.name).toBe(
+      expectedWorkspaceName('D999', '1700000000.111111')
+    );
+    expect(capturedConfigs[1].workspace.name).toBe(
+      expectedWorkspaceName('D999', '1700000000.333333')
+    );
+    expect(capturedConfigs[0].workspace.name).not.toBe(capturedConfigs[1].workspace.name);
+
+    spy.mockRestore();
+  });
+
+  test('preserves existing workspace config from cfgForRun', async () => {
+    const cfgWithWorkspace: VisorConfig = {
+      ...baseCfg,
+      workspace: { enabled: true, base_path: '/custom/path' },
+    } as any;
+
+    const engine = new StateMachineExecutionEngine();
+    const runner = new SlackSocketRunner(engine, cfgWithWorkspace, {
+      appToken: 'xapp-test',
+      endpoint: '/bots/slack/support',
+      mentions: 'all',
+      threads: 'required',
+    });
+
+    let capturedConfig: any = null;
+    const spy = jest
+      .spyOn(StateMachineExecutionEngine.prototype, 'executeChecks')
+      .mockImplementation(async (opts: any) => {
+        capturedConfig = opts.config;
+        return {
+          results: { default: [] },
+          statistics: {
+            totalChecks: 1,
+            checksByGroup: {},
+            issuesBySeverity: { critical: 0, error: 0, warning: 0, info: 0 },
+          },
+        } as any;
+      });
+
+    await (runner as any).handleMessage(
+      JSON.stringify(
+        mkEnv({
+          type: 'message',
+          channel: 'D123',
+          ts: '1700.500',
+        })
+      )
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    // Should merge workspace name into existing workspace config
+    expect(capturedConfig.workspace.enabled).toBe(true);
+    expect(capturedConfig.workspace.base_path).toBe('/custom/path');
+    expect(capturedConfig.workspace.name).toBe(expectedWorkspaceName('D123', '1700.500'));
+    expect(capturedConfig.workspace.cleanup_on_exit).toBe(false);
+
+    spy.mockRestore();
+  });
+});

--- a/tests/unit/workspace-manager.test.ts
+++ b/tests/unit/workspace-manager.test.ts
@@ -310,6 +310,324 @@ describe('WorkspaceManager', () => {
     });
   });
 
+  describe('cleanup with cleanupOnExit=false', () => {
+    it('preserves workspace directory but clears in-memory state', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+      commandExecutor.execute.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
+
+      if (!fs.existsSync(testOriginalPath)) {
+        fs.mkdirSync(testOriginalPath, { recursive: true });
+      }
+
+      const manager = WorkspaceManager.getInstance(testSessionId, testOriginalPath, {
+        basePath: testBasePath,
+        cleanupOnExit: false,
+      });
+
+      await manager.initialize();
+      const workspacePath = manager.getWorkspacePath();
+
+      expect(fs.existsSync(workspacePath)).toBe(true);
+
+      await manager.cleanup();
+
+      // Workspace directory should still exist
+      expect(fs.existsSync(workspacePath)).toBe(true);
+      // In-memory state should be cleared
+      expect(manager.getWorkspaceInfo()).toBeNull();
+      expect(manager.listProjects()).toEqual([]);
+
+      fs.rmSync(testOriginalPath, { recursive: true, force: true });
+    });
+
+    it('removes instance from the map', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+      commandExecutor.execute.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
+
+      if (!fs.existsSync(testOriginalPath)) {
+        fs.mkdirSync(testOriginalPath, { recursive: true });
+      }
+
+      const sid = 'persist-session';
+      const manager = WorkspaceManager.getInstance(sid, testOriginalPath, {
+        basePath: testBasePath,
+        cleanupOnExit: false,
+      });
+
+      await manager.initialize();
+      await manager.cleanup();
+
+      // Getting instance again should create a new one (old was removed from map)
+      const manager2 = WorkspaceManager.getInstance(sid, testOriginalPath, {
+        basePath: testBasePath,
+        cleanupOnExit: false,
+      });
+      expect(manager2).not.toBe(manager);
+
+      fs.rmSync(testOriginalPath, { recursive: true, force: true });
+    });
+  });
+
+  describe('initialize with existing workspace (reuse)', () => {
+    it('reuses existing symlink for non-git project', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+      // Not a git repo
+      commandExecutor.execute.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
+
+      if (!fs.existsSync(testOriginalPath)) {
+        fs.mkdirSync(testOriginalPath, { recursive: true });
+      }
+
+      // First initialization
+      const manager1 = WorkspaceManager.getInstance('reuse-session-1', testOriginalPath, {
+        basePath: testBasePath,
+        name: 'shared-workspace',
+        cleanupOnExit: false,
+      });
+
+      const info1 = await manager1.initialize();
+      expect(fs.existsSync(info1.mainProjectPath)).toBe(true);
+
+      // Cleanup in-memory state (simulates end of first Slack message)
+      await manager1.cleanup();
+
+      // Second initialization with same workspace name (simulates second Slack message)
+      const manager2 = WorkspaceManager.getInstance('reuse-session-2', testOriginalPath, {
+        basePath: testBasePath,
+        name: 'shared-workspace',
+        cleanupOnExit: false,
+      });
+
+      const info2 = await manager2.initialize();
+
+      // Should reuse same workspace path
+      expect(info2.workspacePath).toBe(info1.workspacePath);
+      // Symlink should still exist (wasn't recreated)
+      expect(fs.existsSync(info2.mainProjectPath)).toBe(true);
+
+      // Cleanup
+      fs.rmSync(manager2.getWorkspacePath(), { recursive: true, force: true });
+      fs.rmSync(testOriginalPath, { recursive: true, force: true });
+    });
+
+    it('reuses existing git worktree when valid', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+
+      if (!fs.existsSync(testOriginalPath)) {
+        fs.mkdirSync(testOriginalPath, { recursive: true });
+      }
+
+      // First call: isGitRepository(originalPath) = true
+      // Second call: rev-parse HEAD = success
+      // Third call: worktree add = success
+      // Fourth call (on re-init): isGitRepository(originalPath) = true
+      // Fifth call (on re-init): isGitRepository(mainProjectPath) = true (valid existing)
+      commandExecutor.execute
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '.git', stderr: '' }) // isGitRepository(original)
+        .mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123\n', stderr: '' }) // rev-parse HEAD
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '.git', stderr: '' }) // isGitRepository(original) on 2nd init
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '.git', stderr: '' }); // isGitRepository(mainProject) valid
+
+      const manager1 = WorkspaceManager.getInstance('reuse-git-1', testOriginalPath, {
+        basePath: testBasePath,
+        name: 'shared-git-ws',
+        cleanupOnExit: false,
+      });
+
+      await manager1.initialize();
+      const workspacePath = manager1.getWorkspacePath();
+
+      // Simulate creating the mainProjectPath directory (worktree would have created it)
+      const mainProjectPath = path.join(workspacePath, 'test-project');
+      fs.mkdirSync(mainProjectPath, { recursive: true });
+
+      await manager1.cleanup(); // Preserves directory (cleanupOnExit=false)
+
+      // Second initialization
+      const manager2 = WorkspaceManager.getInstance('reuse-git-2', testOriginalPath, {
+        basePath: testBasePath,
+        name: 'shared-git-ws',
+        cleanupOnExit: false,
+      });
+
+      await manager2.initialize();
+
+      // Should NOT have called worktree add again (only 3 git commands initially, then 2 for re-check)
+      // The worktree add command should have been called only once (the 3rd mock)
+      const executeCalls = commandExecutor.execute.mock.calls;
+      const worktreeAddCalls = executeCalls.filter((call: any[]) =>
+        String(call[0]).includes('worktree add')
+      );
+      expect(worktreeAddCalls.length).toBe(1);
+
+      // Cleanup
+      fs.rmSync(workspacePath, { recursive: true, force: true });
+      fs.rmSync(testOriginalPath, { recursive: true, force: true });
+    });
+
+    it('recreates worktree when existing path is invalid', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+
+      if (!fs.existsSync(testOriginalPath)) {
+        fs.mkdirSync(testOriginalPath, { recursive: true });
+      }
+
+      // First init: git repo, HEAD, worktree add
+      // Second init: git repo, pathExists=true, isGitRepository(mainProject)=false, worktree prune, HEAD, worktree add
+      commandExecutor.execute
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '.git', stderr: '' }) // isGitRepository(original)
+        .mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123\n', stderr: '' }) // rev-parse HEAD
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '.git', stderr: '' }) // isGitRepository(original) 2nd
+        .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: '' }) // isGitRepository(mainProject) = INVALID
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree prune
+        .mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123\n', stderr: '' }) // rev-parse HEAD
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // worktree add (recreate)
+
+      const manager1 = WorkspaceManager.getInstance('invalid-wt-1', testOriginalPath, {
+        basePath: testBasePath,
+        name: 'invalid-wt-ws',
+        cleanupOnExit: false,
+      });
+
+      await manager1.initialize();
+      const workspacePath = manager1.getWorkspacePath();
+
+      // Create an invalid directory at mainProjectPath (not a valid git dir)
+      const mainProjectPath = path.join(workspacePath, 'test-project');
+      fs.mkdirSync(mainProjectPath, { recursive: true });
+      // Write a dummy file so it exists but is not a valid git repo
+      fs.writeFileSync(path.join(mainProjectPath, 'dummy'), 'not-git');
+
+      await manager1.cleanup();
+
+      // Second initialization
+      const manager2 = WorkspaceManager.getInstance('invalid-wt-2', testOriginalPath, {
+        basePath: testBasePath,
+        name: 'invalid-wt-ws',
+        cleanupOnExit: false,
+      });
+
+      await manager2.initialize();
+
+      // Should have called worktree add twice (original + recreate after invalid)
+      const executeCalls = commandExecutor.execute.mock.calls;
+      const worktreeAddCalls = executeCalls.filter((call: any[]) =>
+        String(call[0]).includes('worktree add')
+      );
+      expect(worktreeAddCalls.length).toBe(2);
+
+      // Should have called worktree prune
+      const pruneCalls = executeCalls.filter((call: any[]) =>
+        String(call[0]).includes('worktree prune')
+      );
+      expect(pruneCalls.length).toBe(1);
+
+      // Cleanup
+      fs.rmSync(workspacePath, { recursive: true, force: true });
+      fs.rmSync(testOriginalPath, { recursive: true, force: true });
+    });
+  });
+
+  describe('cleanupStale', () => {
+    const staleBasePath = '/tmp/test-visor-stale-workspaces';
+
+    afterEach(() => {
+      if (fs.existsSync(staleBasePath)) {
+        fs.rmSync(staleBasePath, { recursive: true, force: true });
+      }
+    });
+
+    it('removes directories older than maxAge', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+      commandExecutor.execute.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+      // Create base and stale directory
+      fs.mkdirSync(staleBasePath, { recursive: true });
+      const staleDir = path.join(staleBasePath, 'slack-C123-old-thread');
+      fs.mkdirSync(staleDir, { recursive: true });
+
+      // Backdate mtime to 2 days ago
+      const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      fs.utimesSync(staleDir, twoDaysAgo, twoDaysAgo);
+
+      const cleaned = await WorkspaceManager.cleanupStale(staleBasePath, 24 * 60 * 60 * 1000);
+
+      expect(cleaned).toBe(1);
+      expect(fs.existsSync(staleDir)).toBe(false);
+    });
+
+    it('preserves directories newer than maxAge', async () => {
+      // Create base and recent directory
+      fs.mkdirSync(staleBasePath, { recursive: true });
+      const recentDir = path.join(staleBasePath, 'slack-C456-recent-thread');
+      fs.mkdirSync(recentDir, { recursive: true });
+
+      const cleaned = await WorkspaceManager.cleanupStale(staleBasePath, 24 * 60 * 60 * 1000);
+
+      expect(cleaned).toBe(0);
+      expect(fs.existsSync(recentDir)).toBe(true);
+    });
+
+    it('returns 0 when base path does not exist', async () => {
+      const cleaned = await WorkspaceManager.cleanupStale('/tmp/nonexistent-visor-workspaces');
+
+      expect(cleaned).toBe(0);
+    });
+
+    it('handles mixed stale and recent directories', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+      commandExecutor.execute.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+      fs.mkdirSync(staleBasePath, { recursive: true });
+
+      const staleDir = path.join(staleBasePath, 'slack-C123-stale');
+      const recentDir = path.join(staleBasePath, 'slack-C456-recent');
+      fs.mkdirSync(staleDir, { recursive: true });
+      fs.mkdirSync(recentDir, { recursive: true });
+
+      const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      fs.utimesSync(staleDir, twoDaysAgo, twoDaysAgo);
+
+      const cleaned = await WorkspaceManager.cleanupStale(staleBasePath, 24 * 60 * 60 * 1000);
+
+      expect(cleaned).toBe(1);
+      expect(fs.existsSync(staleDir)).toBe(false);
+      expect(fs.existsSync(recentDir)).toBe(true);
+    });
+
+    it('prunes git worktrees in stale directories before removal', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+      commandExecutor.execute.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+      fs.mkdirSync(staleBasePath, { recursive: true });
+
+      const staleDir = path.join(staleBasePath, 'slack-C123-with-worktree');
+      const subDir = path.join(staleDir, 'my-project');
+      fs.mkdirSync(subDir, { recursive: true });
+
+      // Simulate a git worktree .git file
+      fs.writeFileSync(
+        path.join(subDir, '.git'),
+        'gitdir: /home/user/repo/.git/worktrees/my-project'
+      );
+
+      const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      fs.utimesSync(staleDir, twoDaysAgo, twoDaysAgo);
+
+      await WorkspaceManager.cleanupStale(staleBasePath, 24 * 60 * 60 * 1000);
+
+      // Should have called git worktree remove
+      const executeCalls = commandExecutor.execute.mock.calls;
+      const worktreeRemoveCalls = executeCalls.filter((call: any[]) =>
+        String(call[0]).includes('worktree remove')
+      );
+      expect(worktreeRemoveCalls.length).toBe(1);
+      expect(worktreeRemoveCalls[0][0]).toContain('/home/user/repo');
+    });
+  });
+
   describe('repository name extraction', () => {
     it('extracts name from owner/repo format', async () => {
       const { commandExecutor } = require('../../src/utils/command-executor');


### PR DESCRIPTION
## Summary

- **Problem**: Each Slack message in a thread creates a brand new workspace (random `sessionId`), so git checkouts from previous messages are lost. E.g., message 1 checks out `tyk-docs`, message 2 gets a fresh workspace with only `Oel/` — [trace `301652fc`](http://localhost:8001/trace/301652fc922b91002903b9168e8c126b) shows the engineer failing because it can't find the repo.
- **Fix**: Derive a stable workspace name from `channel + thread_ts` so all messages in the same thread share the same workspace directory.
- **Stale cleanup**: Add `cleanupStale()` to remove abandoned workspace directories older than 24 hours, called at socket-runner startup.

## Changes

| File | Change |
|------|--------|
| `src/slack/socket-runner.ts` | Inject `workspace.name` (`slack-{channel}-{thread_ts}`) and `cleanup_on_exit: false` into config before engine run; call `cleanupStale()` at startup |
| `src/utils/workspace-manager.ts` | `initialize()`: reuse existing worktree/symlink if workspace dir already exists; `cleanup()`: respect `cleanupOnExit=false` (skip directory removal, clear in-memory state); add `pathExists()` helper; add `cleanupStale()` static method |
| `tests/unit/workspace-manager.test.ts` | 10 new tests: cleanup with `cleanupOnExit=false`, workspace reuse (symlink, valid worktree, invalid worktree), `cleanupStale()` |
| `tests/integration/slack-socket-workspace.test.ts` | 4 new tests: workspace name injection, same-thread stability, different-thread isolation, existing config preservation |

## Test plan

- [x] 27 unit tests pass (17 existing + 10 new) — `tests/unit/workspace-manager.test.ts`
- [x] 8 workspace init tests pass — `tests/unit/workspace-initialization.test.ts`
- [x] 4 integration tests pass — `tests/integration/slack-socket-workspace.test.ts`
- [x] Existing socket gating/dedupe tests unaffected
- [ ] Manual E2E: send two messages in a Slack thread — first checks out a repo, second can access it

🤖 Generated with [Claude Code](https://claude.com/claude-code)