### PR TITLE
chore: update @probelabs/probe to v0.6.0-rc262

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@opentelemetry/sdk-node": "^0.203.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.30.1",
-        "@probelabs/probe": "^0.6.0-rc260",
+        "@probelabs/probe": "^0.6.0-rc262",
         "@types/commander": "^2.12.0",
         "@types/uuid": "^10.0.0",
         "acorn": "^8.16.0",
@@ -6394,9 +6394,9 @@
       }
     },
     "node_modules/@probelabs/probe": {
-      "version": "0.6.0-rc260",
-      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc260.tgz",
-      "integrity": "sha512-ZlbLgbs+n2/t9MoCUBG7LBaTtGo0JF25mLNoQjFMmrEc8cyB6XCjhVKBMdovBBR1YK4kwl9C8H/cKaeOhtQGQA==",
+      "version": "0.6.0-rc262",
+      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc262.tgz",
+      "integrity": "sha512-5oPk22WKYjlJ4LkmK3pW9WPIIdvJh+RcjdwpEGjv9/yTxlmBosKl68L4z09+abd123wTpEb4IT7zNp+0Bxb/Hg==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@opentelemetry/sdk-node": "^0.203.0",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/semantic-conventions": "^1.30.1",
-    "@probelabs/probe": "^0.6.0-rc260",
+    "@probelabs/probe": "^0.6.0-rc262",
     "@types/commander": "^2.12.0",
     "@types/uuid": "^10.0.0",
     "acorn": "^8.16.0",


### PR DESCRIPTION
## Summary
- Updates `@probelabs/probe` from `0.6.0-rc260` to `0.6.0-rc262`
- Fixes critical bug where `edit`/`create` tool calls inside unclosed `<thinking>` tags were silently dropped (probelabs/probe#459)
- `removeThinkingTags()` now accepts a `validTools` parameter so dynamically-added tools are recognized when parsing AI responses with unclosed thinking blocks (common with Gemini 2.5 Pro)

## Test plan
- [x] All 63 existing tests pass
- [x] Verified fix by inspecting the updated `removeThinkingTags` signature and `processXmlWithThinkingAndRecovery` forwarding in rc262 source

🤖 Generated with [Claude Code](https://claude.com/claude-code)