### PR TITLE
fix: map noDefaultAllow/noDefaultDeny to probe's field names

### DIFF
--- a/src/ai-review-service.ts
+++ b/src/ai-review-service.ts
@@ -1926,7 +1926,13 @@ ${'='.repeat(60)}
         (options as any).enableBash = this.config.allowBash;
       }
       if (this.config.bashConfig !== undefined) {
-        (options as any).bashConfig = this.config.bashConfig;
+        // Map visor field names to probe's expected field names
+        const { noDefaultAllow, noDefaultDeny, ...restBashConfig } = this.config.bashConfig;
+        (options as any).bashConfig = {
+          ...restBashConfig,
+          ...(noDefaultAllow !== undefined && { disableDefaultAllow: noDefaultAllow }),
+          ...(noDefaultDeny !== undefined && { disableDefaultDeny: noDefaultDeny }),
+        };
       }
 
       // Pass completion prompt for post-completion validation/review


### PR DESCRIPTION
## Summary

- Map visor's `noDefaultAllow`/`noDefaultDeny` bashConfig fields to probe's expected `disableDefaultAllow`/`disableDefaultDeny` when passing config to ProbeAgent
- Without this, workflow YAML using visor's field names (`noDefaultAllow: true`) had no effect since probe only reads `disableDefaultAllow`

## Test plan

- [x] All 114 existing tests pass
- [ ] Verify engineer workflow with `noDefaultAllow: true` correctly disables the default allow list in probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)