### PR TITLE
fix: rename bashConfig fields to match probe's disableDefaultAllow/Deny

### DIFF
--- a/docs/ai-configuration.md
+++ b/docs/ai-configuration.md
@@ -489,8 +489,8 @@ steps:
       provider: anthropic
       allowBash: true
       bashConfig:
-        noDefaultAllow: true  # Disable default safe command list
-        noDefaultDeny: false  # Keep default dangerous command blocklist
+        disableDefaultAllow: true  # Disable default safe command list
+        disableDefaultDeny: false  # Keep default dangerous command blocklist
         allow: ['specific-command-1', 'specific-command-2']
 ```
 
@@ -499,8 +499,8 @@ steps:
 - **`allowBash`** (boolean): Simple toggle to enable bash command execution. Default: `false`
 - **`allow`** (string[]): Additional permitted command patterns (e.g., `['ls', 'git status']`)
 - **`deny`** (string[]): Additional blocked command patterns (e.g., `['rm -rf', 'sudo']`)
-- **`noDefaultAllow`** (boolean): Disable default safe command list (~235 commands). Default: `false`
-- **`noDefaultDeny`** (boolean): Disable default dangerous command blocklist (~191 patterns). Default: `false`
+- **`disableDefaultAllow`** (boolean): Disable default safe command list (~235 commands). Default: `false`
+- **`disableDefaultDeny`** (boolean): Disable default dangerous command blocklist (~191 patterns). Default: `false`
 - **`timeout`** (number): Execution timeout in milliseconds. Default: varies by ProbeAgent
 - **`workingDirectory`** (string): Base directory for command execution
 

--- a/examples/ai-with-bash.yaml
+++ b/examples/ai-with-bash.yaml
@@ -96,8 +96,8 @@ steps:
       provider: anthropic
       allowBash: true
       bashConfig:
-        noDefaultAllow: true  # Disable default safe commands
-        noDefaultDeny: false  # Keep dangerous command blocklist
+        disableDefaultAllow: true  # Disable default safe commands
+        disableDefaultDeny: false  # Keep dangerous command blocklist
         allow:
           - 'custom-tool analyze'
           - 'custom-tool report'

--- a/src/generated/config-schema.ts
+++ b/src/generated/config-schema.ts
@@ -958,7 +958,7 @@ export const configSchema = {
           description: 'Arguments/inputs for the workflow',
         },
         overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13509-28103-src_types_config.ts-0-55255%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265%3E%3E',
           description: 'Override specific step configurations in the workflow',
         },
         output_mapping: {
@@ -975,7 +975,7 @@ export const configSchema = {
             'Config file path - alternative to workflow ID (loads a Visor config file as workflow)',
         },
         workflow_overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13509-28103-src_types_config.ts-0-55255%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265%3E%3E',
           description: 'Alias for overrides - workflow step overrides (backward compatibility)',
         },
         ref: {
@@ -1407,11 +1407,11 @@ export const configSchema = {
           },
           description: "Array of blocked command patterns (e.g., ['rm -rf', 'sudo'])",
         },
-        noDefaultAllow: {
+        disableDefaultAllow: {
           type: 'boolean',
           description: 'Disable default safe command list (use with caution)',
         },
-        noDefaultDeny: {
+        disableDefaultDeny: {
           type: 'boolean',
           description: 'Disable default dangerous command blocklist (use with extreme caution)',
         },
@@ -1677,7 +1677,7 @@ export const configSchema = {
           description: 'Custom output name (defaults to workflow name)',
         },
         overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13509-28103-src_types_config.ts-0-55255%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265%3E%3E',
           description: 'Step overrides',
         },
         output_mapping: {
@@ -1692,14 +1692,14 @@ export const configSchema = {
         '^x-': {},
       },
     },
-    'Record<string,Partial<interface-src_types_config.ts-13509-28103-src_types_config.ts-0-55255>>':
+    'Record<string,Partial<interface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265>>':
       {
         type: 'object',
         additionalProperties: {
-          $ref: '#/definitions/Partial%3Cinterface-src_types_config.ts-13509-28103-src_types_config.ts-0-55255%3E',
+          $ref: '#/definitions/Partial%3Cinterface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265%3E',
         },
       },
-    'Partial<interface-src_types_config.ts-13509-28103-src_types_config.ts-0-55255>': {
+    'Partial<interface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265>': {
       type: 'object',
       additionalProperties: false,
     },

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -318,9 +318,9 @@ export interface BashConfig {
   /** Array of blocked command patterns (e.g., ['rm -rf', 'sudo']) */
   deny?: string[];
   /** Disable default safe command list (use with caution) */
-  noDefaultAllow?: boolean;
+  disableDefaultAllow?: boolean;
   /** Disable default dangerous command blocklist (use with extreme caution) */
-  noDefaultDeny?: boolean;
+  disableDefaultDeny?: boolean;
   /** Execution timeout in milliseconds */
   timeout?: number;
   /** Default working directory for command execution */


### PR DESCRIPTION
## Summary

- Rename `noDefaultAllow` → `disableDefaultAllow` and `noDefaultDeny` → `disableDefaultDeny` in `BashConfig`
- Aligns visor's field names with probe's expected names — no mapping needed, bashConfig passes straight through

## Files changed

- `src/types/config.ts` — BashConfig interface field rename
- `src/generated/config-schema.ts` — regenerated from types
- `docs/ai-configuration.md` — updated field names in docs
- `examples/ai-with-bash.yaml` — updated field names in example

## Test plan

- [x] All 114 existing tests pass (pre-commit hook)
- [ ] Verify `disableDefaultAllow: true` in workflow YAML disables probe's default allow list

🤖 Generated with [Claude Code](https://claude.com/claude-code)