### PR TITLE
fix: warn on array schemas missing items in workflow inputs

### DIFF
--- a/src/workflow-registry.ts
+++ b/src/workflow-registry.ts
@@ -288,6 +288,13 @@ export class WorkflowRegistry {
             message: 'Input parameter schema is recommended',
           });
         }
+        if (input.schema?.type === 'array' && !input.schema.items) {
+          warnings.push({
+            path: `inputs[${i}].schema`,
+            message:
+              'Array schema should define "items" (e.g. items: { type: string }). Some LLM providers (Gemini) reject array schemas without items.',
+          });
+        }
       }
     }
 

--- a/tests/unit/workflow-registry.test.ts
+++ b/tests/unit/workflow-registry.test.ts
@@ -156,6 +156,56 @@ describe('WorkflowRegistry', () => {
       );
     });
 
+    it('should warn on array schema without items', () => {
+      const workflow: WorkflowDefinition = {
+        id: 'test-workflow',
+        name: 'Test Workflow',
+        inputs: [
+          {
+            name: 'projects',
+            schema: { type: 'array' },
+          },
+        ],
+        steps: {
+          step1: {
+            type: 'ai',
+            prompt: 'Test',
+          },
+        },
+      };
+
+      const result = registry.validateWorkflow(workflow);
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          path: 'inputs[0].schema',
+          message: expect.stringContaining('items'),
+        })
+      );
+    });
+
+    it('should not warn on array schema with items', () => {
+      const workflow: WorkflowDefinition = {
+        id: 'test-workflow',
+        name: 'Test Workflow',
+        inputs: [
+          {
+            name: 'projects',
+            schema: { type: 'array', items: { type: 'string' } },
+          },
+        ],
+        steps: {
+          step1: {
+            type: 'ai',
+            prompt: 'Test',
+          },
+        },
+      };
+
+      const result = registry.validateWorkflow(workflow);
+      const itemsWarnings = (result.warnings ?? []).filter(w => w.message.includes('items'));
+      expect(itemsWarnings).toEqual([]);
+    });
+
     it('should validate output parameters', () => {
       const workflow: WorkflowDefinition = {
         id: 'test-workflow',


### PR DESCRIPTION
## Summary

- Add validation warning in `validateWorkflow()` when array-type input schemas are missing `items`
- Gemini's API rejects tool declarations with array parameters that lack `items`, causing `INVALID_ARGUMENT` errors at runtime
- Using a warning (not error) to avoid breaking existing workflows with internal array inputs

## Test plan

- [x] Unit tests: 30/30 pass
- [x] Visor integration tests pass (warning doesn't block registration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)