### PR TITLE
fix: forward trigger args in schedule tool, default workflow

### DIFF
--- a/src/providers/mcp-custom-sse-server.ts
+++ b/src/providers/mcp-custom-sse-server.ts
@@ -834,7 +834,7 @@ export class CustomToolsSSEServer implements CustomMCPServer {
 
             // Execute generic schedule tool - AI provides structured data
             const scheduleArgs: ScheduleToolArgs = {
-              action: (args.action as 'create' | 'list' | 'cancel' | 'pause' | 'resume') || 'list',
+              action: (args.action as ScheduleToolArgs['action']) || 'list',
               // What to do
               reminder_text: args.reminder_text as string | undefined,
               workflow: args.workflow as string | undefined,
@@ -850,6 +850,19 @@ export class CustomToolsSSEServer implements CustomMCPServer {
               original_expression: args.original_expression as string | undefined,
               // For cancel/pause/resume
               schedule_id: args.schedule_id as string | undefined,
+              // For trigger actions
+              trigger_channels: args.trigger_channels as string[] | undefined,
+              trigger_from: args.trigger_from as string[] | undefined,
+              trigger_from_bots: args.trigger_from_bots as boolean | undefined,
+              trigger_contains: args.trigger_contains as string[] | undefined,
+              trigger_match: args.trigger_match as string | undefined,
+              trigger_threads: args.trigger_threads as
+                | 'root_only'
+                | 'thread_only'
+                | 'any'
+                | undefined,
+              trigger_description: args.trigger_description as string | undefined,
+              trigger_id: args.trigger_id as string | undefined,
             };
             const scheduleResult = await handleScheduleAction(scheduleArgs, scheduleContext);
 

--- a/src/scheduler/schedule-tool.ts
+++ b/src/scheduler/schedule-tool.ts
@@ -765,20 +765,14 @@ async function handleCreateTrigger(
   context: ScheduleToolContext,
   store: ScheduleStore
 ): Promise<ScheduleToolResult> {
-  // Validate workflow
-  if (!args.workflow) {
-    return {
-      success: false,
-      message: 'Missing workflow',
-      error: 'Please specify the workflow to run when the trigger fires.',
-    };
-  }
+  // Default workflow to "default" if not specified
+  const workflow = args.workflow || 'default';
 
   // Validate workflow exists if we have available workflows
-  if (context.availableWorkflows && !context.availableWorkflows.includes(args.workflow)) {
+  if (context.availableWorkflows && !context.availableWorkflows.includes(workflow)) {
     return {
       success: false,
-      message: `Workflow "${args.workflow}" not found`,
+      message: `Workflow "${workflow}" not found`,
       error: `Available workflows: ${context.availableWorkflows.slice(0, 5).join(', ')}${context.availableWorkflows.length > 5 ? '...' : ''}`,
     };
   }
@@ -799,7 +793,7 @@ async function handleCreateTrigger(
   }
 
   // Check permissions for the workflow
-  const permissionCheck = checkSchedulePermissions(context, args.workflow);
+  const permissionCheck = checkSchedulePermissions(context, workflow);
   if (!permissionCheck.allowed) {
     return {
       success: false,
@@ -821,14 +815,14 @@ async function handleCreateTrigger(
       contains: args.trigger_contains,
       matchPattern: args.trigger_match,
       threads: args.trigger_threads ?? 'any',
-      workflow: args.workflow,
+      workflow: workflow,
       inputs: args.workflow_inputs,
       status: 'active',
       enabled: true,
     });
 
     logger.info(
-      `[ScheduleTool] Created message trigger ${trigger.id} for user ${context.userId}: workflow="${args.workflow}"`
+      `[ScheduleTool] Created message trigger ${trigger.id} for user ${context.userId}: workflow="${workflow}"`
     );
 
     return {
@@ -991,11 +985,16 @@ export function getScheduleToolDefinition(): CustomToolDefinition {
 
 YOU (the AI) must extract and structure all scheduling parameters. Do NOT pass natural language time expressions - convert them to cron or ISO timestamps.
 
-CRITICAL WORKFLOW RULE:
+CRITICAL WORKFLOW RULE (for 'create' action only):
 - To schedule a WORKFLOW, the user MUST use a '%' prefix (e.g., "schedule %my-workflow daily").
 - If the '%' prefix is present, extract the word following it as the 'workflow' parameter (without the '%').
 - If the '%' prefix is NOT present, the request is a simple text reminder. The ENTIRE user request (excluding the schedule expression) MUST be placed in the 'reminder_text' parameter.
 - DO NOT guess or infer a workflow name from a user's request without the '%' prefix.
+
+WORKFLOW RULE FOR TRIGGERS (create_trigger action):
+- Triggers ALWAYS require a workflow. The '%' prefix rule does NOT apply to triggers.
+- If the user specifies a workflow name (with or without '%'), use it directly.
+- If the user does NOT specify a workflow name, use "default" as the workflow name.
 
 ACTIONS:
 - create: Schedule a new reminder or workflow
@@ -1009,7 +1008,7 @@ Slack messages in specific channels. Use the create_trigger, list_triggers, dele
 actions for this. Message triggers fire workflows based on message content, channel, sender, and thread scope.
 
 TRIGGER ACTIONS:
-- create_trigger: Create a new message trigger (requires workflow + at least one filter). Supports filtering by user IDs (trigger_from), channels, keywords, regex, and thread scope.
+- create_trigger: Create a new message trigger (requires at least one filter; workflow defaults to "default" if not specified). Supports filtering by user IDs (trigger_from), channels, keywords, regex, and thread scope.
 - list_triggers: Show user's message triggers
 - delete_trigger: Remove a trigger by ID
 - update_trigger: Enable/disable a trigger by ID
@@ -1109,6 +1108,9 @@ User: "watch #cicd for messages containing 'failed' and run %handle-cicd"
 User: "trigger on each of my messages in this channel and run %auto-reply" (user ID is U3P2L4XNE)
 → { "action": "create_trigger", "trigger_channels": ["C09V810NY6R"], "trigger_from": ["U3P2L4XNE"], "workflow": "auto-reply" }
 
+User: "trigger on each message in this channel" (no workflow specified — use "default")
+→ { "action": "create_trigger", "trigger_channels": ["C09V810NY6R"], "workflow": "default" }
+
 User: "list my message triggers"
 → { "action": "list_triggers" }
 
@@ -1144,7 +1146,7 @@ User: "disable trigger abc123"
         workflow: {
           type: 'string',
           description:
-            'For create: workflow ID to run. ONLY populate this if the user used the % prefix (e.g., "%my-workflow"). Extract the name without the % symbol. If no % prefix, use reminder_text instead.',
+            'For create: workflow ID to run. ONLY populate this if the user used the % prefix (e.g., "%my-workflow"). Extract the name without the % symbol. If no % prefix, use reminder_text instead. For create_trigger: workflow is REQUIRED — use the workflow name the user specified (% prefix optional), or "default" if not specified.',
         },
         workflow_inputs: {
           type: 'object',

--- a/src/slack/schedule-tool-handler.ts
+++ b/src/slack/schedule-tool-handler.ts
@@ -166,6 +166,15 @@ export async function executeScheduleTool(
     original_expression: args.original_expression as string | undefined,
     // For cancel/pause/resume
     schedule_id: args.schedule_id as string | undefined,
+    // For trigger actions
+    trigger_channels: args.trigger_channels as string[] | undefined,
+    trigger_from: args.trigger_from as string[] | undefined,
+    trigger_from_bots: args.trigger_from_bots as boolean | undefined,
+    trigger_contains: args.trigger_contains as string[] | undefined,
+    trigger_match: args.trigger_match as string | undefined,
+    trigger_threads: args.trigger_threads as 'root_only' | 'thread_only' | 'any' | undefined,
+    trigger_description: args.trigger_description as string | undefined,
+    trigger_id: args.trigger_id as string | undefined,
   };
 
   // If AI didn't provide target, default to current Slack context

--- a/tests/unit/scheduler/schedule-tool-triggers.test.ts
+++ b/tests/unit/scheduler/schedule-tool-triggers.test.ts
@@ -169,17 +169,38 @@ describe('Schedule Tool — Message Trigger Actions', () => {
       );
     });
 
-    it('should fail when workflow is missing', async () => {
+    it('should default workflow to "default" when not specified', async () => {
       const args: ScheduleToolArgs = {
         action: 'create_trigger',
         trigger_channels: ['C0CICD'],
         trigger_contains: ['failed'],
       };
 
+      // With availableWorkflows that don't include "default", it should fail with not found
       const result = await handleScheduleAction(args, makeContext());
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('Missing workflow');
+      expect(result.message).toContain('"default" not found');
+    });
+
+    it('should succeed with default workflow when it exists', async () => {
+      const args: ScheduleToolArgs = {
+        action: 'create_trigger',
+        trigger_channels: ['C0CICD'],
+        trigger_contains: ['failed'],
+      };
+
+      const context = makeContext({
+        availableWorkflows: ['default', 'handle-cicd'],
+      });
+      const result = await handleScheduleAction(args, context);
+
+      expect(result.success).toBe(true);
+      expect(mockStore.createTriggerAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflow: 'default',
+        })
+      );
     });
 
     it('should fail when workflow does not exist', async () => {


### PR DESCRIPTION
## Summary
- **Bug fix**: The schedule tool args mapping in `mcp-custom-sse-server.ts` and `schedule-tool-handler.ts` silently dropped all trigger-related fields (`trigger_channels`, `trigger_from`, `trigger_contains`, `trigger_match`, `trigger_threads`, `trigger_description`, `trigger_id`), causing `create_trigger` to always fail with "missing filters" even when the AI provided them correctly.
- **Default workflow**: Triggers now default to workflow `"default"` when none is specified, instead of hard-failing with "Missing workflow".
- **AI tool description**: Updated to clarify the `%` prefix rule only applies to `create` action (cron-based schedules), not `create_trigger` (message-based triggers).

## Test plan
- [x] Existing schedule-tool-triggers tests updated and passing (22/22)
- [ ] Verify trigger creation works in Slack without `%` prefix
- [ ] Verify trigger creation still works with explicit `%workflow` syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)