### PR TITLE
feat: implement Slack App Home tab

### DIFF
--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -332,6 +332,31 @@ export class SlackClient {
     },
   };
 
+  public readonly views = {
+    publish: async ({
+      user_id,
+      view,
+    }: {
+      user_id: string;
+      view: Record<string, unknown>;
+    }): Promise<{ ok: boolean; error?: string }> => {
+      try {
+        const resp: any = await this.api('views.publish', { user_id, view });
+        if (!resp || resp.ok !== true) {
+          const err = (resp && resp.error) || 'unknown_error';
+          console.warn(`Slack views.publish failed (non-fatal): ${err}`);
+          return { ok: false, error: err };
+        }
+        return { ok: true };
+      } catch (e) {
+        console.warn(
+          `Slack views.publish threw (non-fatal): ${e instanceof Error ? e.message : String(e)}`
+        );
+        return { ok: false, error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+  };
+
   getWebClient(): any {
     return {
       conversations: {

--- a/src/slack/socket-runner.ts
+++ b/src/slack/socket-runner.ts
@@ -9,13 +9,13 @@ import { RateLimiter, type RateLimitConfig } from './rate-limiter';
 import type { SlackBotConfig } from '../types/bot';
 import { withActiveSpan, getVisorRunAttributes } from '../telemetry/trace-helpers';
 import { Scheduler } from '../scheduler/scheduler';
-import { ScheduleStore } from '../scheduler/schedule-store';
+import { ScheduleStore, type Schedule } from '../scheduler/schedule-store';
 import { createHash } from 'crypto';
 import { createSlackOutputAdapter } from './slack-output-adapter';
 import { WorkspaceManager } from '../utils/workspace-manager';
 import { MessageTriggerEvaluator, type MatchedTrigger } from '../scheduler/message-trigger';
 import type { SlackMessageTrigger } from '../types/config';
-import { toSlackMessageTrigger } from '../scheduler/store/types';
+import { toSlackMessageTrigger, type MessageTrigger } from '../scheduler/store/types';
 
 type SlackSocketConfig = {
   appToken?: string; // xapp- token
@@ -391,6 +391,12 @@ export class SlackSocketRunner {
     try {
       await this.ensureClient();
     } catch {}
+
+    // Handle app_home_opened — publish Home tab view and return early
+    if (type === 'app_home_opened') {
+      await this.publishAppHome(String(ev.user || ''));
+      return;
+    }
 
     // Ignore edited/changed events to prevent loops (allow file_share — users can share attachments)
     if (
@@ -869,6 +875,187 @@ export class SlackSocketRunner {
     );
 
     logger.info(`[SlackSocket] Message trigger '${id}' workflow completed`);
+  }
+
+  /**
+   * Publish the App Home tab for the given user.
+   * Shows the user's schedules, message triggers, and available workflows.
+   */
+  private async publishAppHome(userId: string): Promise<void> {
+    if (!userId || !this.client) return;
+    try {
+      const userInfo = await this.fetchUserInfo(userId);
+
+      // Fetch user's schedules and triggers from the store (best-effort)
+      let schedules: Schedule[] = [];
+      let triggers: MessageTrigger[] = [];
+      try {
+        const store = ScheduleStore.getInstance();
+        if (store.isInitialized()) {
+          schedules = await store.getByCreatorAsync(userId);
+          triggers = await store.getTriggersByCreatorAsync(userId);
+        }
+      } catch (err) {
+        logger.warn(
+          `[SlackSocket] Failed to fetch schedules/triggers for Home tab: ${err instanceof Error ? err.message : err}`
+        );
+      }
+
+      // Get available workflows
+      let workflows: { id: string; name: string; description?: string }[] = [];
+      try {
+        const { WorkflowRegistry } = await import('../workflow-registry');
+        const registry = WorkflowRegistry.getInstance();
+        workflows = registry
+          .list()
+          .map(w => ({ id: w.id, name: w.name, description: w.description }));
+      } catch (err) {
+        logger.warn(
+          `[SlackSocket] Failed to fetch workflows for Home tab: ${err instanceof Error ? err.message : err}`
+        );
+      }
+
+      const blocks = this.buildHomeBlocks(userInfo, schedules, triggers, workflows);
+
+      await this.client.views.publish({
+        user_id: userId,
+        view: { type: 'home', blocks },
+      });
+    } catch (err) {
+      logger.error(
+        `[SlackSocket] app_home_opened failed: ${err instanceof Error ? err.message : err}`
+      );
+    }
+  }
+
+  /**
+   * Build Slack Block Kit blocks for the App Home tab.
+   * Exposed as a separate method for testability.
+   */
+  buildHomeBlocks(
+    userInfo: { realName?: string; name?: string } | null,
+    schedules: Schedule[],
+    triggers: MessageTrigger[],
+    workflows: { id: string; name: string; description?: string }[]
+  ): unknown[] {
+    const blocks: unknown[] = [];
+
+    // Header
+    const greeting = userInfo?.realName || userInfo?.name || 'there';
+    blocks.push({
+      type: 'header',
+      text: { type: 'plain_text', text: `Hi, ${greeting}!` },
+    });
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: "Here's an overview of your Visor activity." },
+    });
+    blocks.push({ type: 'divider' });
+
+    // --- Schedules section ---
+    blocks.push({
+      type: 'header',
+      text: { type: 'plain_text', text: 'Your Schedules' },
+    });
+
+    const activeSchedules = schedules.filter(s => s.status === 'active' || s.status === 'paused');
+    if (activeSchedules.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '_No active schedules. Message the bot to create one._' },
+      });
+    } else {
+      for (const s of activeSchedules.slice(0, 15)) {
+        const statusIcon = s.status === 'paused' ? ':double_vertical_bar:' : ':clock1:';
+        const desc = s.originalExpression || s.workflow || s.id;
+        const nextRun = s.nextRunAt
+          ? `<!date^${Math.floor(s.nextRunAt / 1000)}^{date_short_pretty} at {time}|${new Date(s.nextRunAt).toISOString()}>`
+          : 'N/A';
+        const recurring = s.isRecurring ? `\`${s.schedule}\`` : 'one-time';
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `${statusIcon} *${desc}*\n${recurring} · Next: ${nextRun} · Status: \`${s.status}\``,
+          },
+        });
+      }
+      if (activeSchedules.length > 15) {
+        blocks.push({
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: `_…and ${activeSchedules.length - 15} more_` }],
+        });
+      }
+    }
+    blocks.push({ type: 'divider' });
+
+    // --- Triggers section ---
+    blocks.push({
+      type: 'header',
+      text: { type: 'plain_text', text: 'Your Message Triggers' },
+    });
+
+    const activeTriggers = triggers.filter(t => t.status === 'active');
+    if (activeTriggers.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '_No active message triggers._' },
+      });
+    } else {
+      for (const t of activeTriggers.slice(0, 10)) {
+        const enabledIcon = t.enabled ? ':large_green_circle:' : ':white_circle:';
+        const desc = t.description || t.workflow;
+        const filters: string[] = [];
+        if (t.channels?.length) filters.push(`channels: ${t.channels.join(', ')}`);
+        if (t.contains?.length) filters.push(`contains: ${t.contains.join(', ')}`);
+        if (t.matchPattern) filters.push(`pattern: \`${t.matchPattern}\``);
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `${enabledIcon} *${desc}*\n${filters.join(' · ') || 'no filters'} → \`${t.workflow}\``,
+          },
+        });
+      }
+      if (activeTriggers.length > 10) {
+        blocks.push({
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: `_…and ${activeTriggers.length - 10} more_` }],
+        });
+      }
+    }
+    blocks.push({ type: 'divider' });
+
+    // --- Workflows section ---
+    blocks.push({
+      type: 'header',
+      text: { type: 'plain_text', text: 'Available Workflows' },
+    });
+
+    if (workflows.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '_No workflows registered._' },
+      });
+    } else {
+      for (const w of workflows.slice(0, 15)) {
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${w.name || w.id}*${w.description ? `\n${w.description}` : ''}`,
+          },
+        });
+      }
+      if (workflows.length > 15) {
+        blocks.push({
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: `_…and ${workflows.length - 15} more_` }],
+        });
+      }
+    }
+
+    return blocks;
   }
 
   /**

--- a/tests/unit/slack-app-home.test.ts
+++ b/tests/unit/slack-app-home.test.ts
@@ -1,0 +1,338 @@
+import { SlackSocketRunner } from '../../src/slack/socket-runner';
+import { SlackClient } from '../../src/slack/client';
+import type { Schedule } from '../../src/scheduler/schedule-store';
+import type { MessageTrigger } from '../../src/scheduler/store/types';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Minimal schedule factory
+function makeSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: 'sched-1',
+    creatorId: 'U123',
+    timezone: 'UTC',
+    schedule: '0 9 * * 1',
+    isRecurring: true,
+    originalExpression: 'every Monday at 9am',
+    workflow: 'weekly-report',
+    status: 'active',
+    createdAt: Date.now(),
+    runCount: 0,
+    failureCount: 0,
+    nextRunAt: Date.now() + 86400000,
+    ...overrides,
+  };
+}
+
+// Minimal trigger factory
+function makeTrigger(overrides: Partial<MessageTrigger> = {}): MessageTrigger {
+  return {
+    id: 'trig-1',
+    creatorId: 'U123',
+    workflow: 'on-message-handler',
+    fromBots: false,
+    threads: 'any',
+    status: 'active',
+    enabled: true,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('SlackSocketRunner.buildHomeBlocks', () => {
+  let runner: SlackSocketRunner;
+
+  beforeEach(() => {
+    // Create runner with minimal config — constructor requires appToken
+    const mockEngine: any = {};
+    const cfg: any = { checks: {} };
+    runner = new SlackSocketRunner(mockEngine, cfg, {
+      appToken: 'xapp-test-token',
+    });
+  });
+
+  test('renders greeting with user real name', () => {
+    const blocks = runner.buildHomeBlocks({ realName: 'Alice', name: 'alice' }, [], [], []);
+    const header = blocks[0] as any;
+    expect(header.type).toBe('header');
+    expect(header.text.text).toBe('Hi, Alice!');
+  });
+
+  test('renders greeting with username fallback', () => {
+    const blocks = runner.buildHomeBlocks({ name: 'bob' }, [], [], []);
+    const header = blocks[0] as any;
+    expect(header.text.text).toBe('Hi, bob!');
+  });
+
+  test('renders greeting with "there" when no user info', () => {
+    const blocks = runner.buildHomeBlocks(null, [], [], []);
+    const header = blocks[0] as any;
+    expect(header.text.text).toBe('Hi, there!');
+  });
+
+  test('empty state shows placeholder messages for all sections', () => {
+    const blocks = runner.buildHomeBlocks(null, [], [], []);
+
+    // Find section blocks with mrkdwn text
+    const sectionTexts = blocks
+      .filter((b: any) => b.type === 'section' && b.text?.type === 'mrkdwn')
+      .map((b: any) => b.text.text);
+
+    expect(sectionTexts).toContain('_No active schedules. Message the bot to create one._');
+    expect(sectionTexts).toContain('_No active message triggers._');
+    expect(sectionTexts).toContain('_No workflows registered._');
+  });
+
+  test('renders active schedules with status icons and details', () => {
+    const schedules = [
+      makeSchedule({ status: 'active', originalExpression: 'every Monday at 9am' }),
+      makeSchedule({
+        id: 'sched-2',
+        status: 'paused',
+        originalExpression: 'daily cleanup',
+        isRecurring: false,
+      }),
+    ];
+    const blocks = runner.buildHomeBlocks(null, schedules, [], []);
+
+    const scheduleSections = blocks.filter(
+      (b: any) =>
+        b.type === 'section' && b.text?.type === 'mrkdwn' && b.text.text.includes('every Monday')
+    );
+    expect(scheduleSections.length).toBe(1);
+    expect((scheduleSections[0] as any).text.text).toContain(':clock1:');
+    expect((scheduleSections[0] as any).text.text).toContain('`0 9 * * 1`');
+
+    const pausedSections = blocks.filter(
+      (b: any) =>
+        b.type === 'section' && b.text?.type === 'mrkdwn' && b.text.text.includes('daily cleanup')
+    );
+    expect(pausedSections.length).toBe(1);
+    expect((pausedSections[0] as any).text.text).toContain(':double_vertical_bar:');
+    expect((pausedSections[0] as any).text.text).toContain('one-time');
+  });
+
+  test('filters out completed/failed schedules', () => {
+    const schedules = [
+      makeSchedule({ status: 'completed', originalExpression: 'completed-task' }),
+      makeSchedule({ status: 'failed', originalExpression: 'failed-task' }),
+    ];
+    const blocks = runner.buildHomeBlocks(null, schedules, [], []);
+
+    const texts = blocks
+      .filter((b: any) => b.type === 'section' && b.text?.type === 'mrkdwn')
+      .map((b: any) => b.text.text)
+      .join('\n');
+
+    expect(texts).not.toContain('completed-task');
+    expect(texts).not.toContain('failed-task');
+    expect(texts).toContain('_No active schedules');
+  });
+
+  test('truncates at 15 schedules and shows overflow', () => {
+    const schedules = Array.from({ length: 20 }, (_, i) =>
+      makeSchedule({ id: `sched-${i}`, originalExpression: `task-${i}` })
+    );
+    const blocks = runner.buildHomeBlocks(null, schedules, [], []);
+
+    // Count rendered schedule sections (contain :clock1:)
+    const rendered = blocks.filter(
+      (b: any) => b.type === 'section' && b.text?.text?.includes(':clock1:')
+    );
+    expect(rendered.length).toBe(15);
+
+    // Check overflow context block
+    const overflow = blocks.find(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('…and 5 more')
+    );
+    expect(overflow).toBeDefined();
+  });
+
+  test('renders active triggers with filter info', () => {
+    const triggers = [
+      makeTrigger({
+        description: 'Deploy trigger',
+        channels: ['C123', 'C456'],
+        contains: ['deploy', 'ship'],
+        matchPattern: 'deploy \\w+',
+        workflow: 'deploy-workflow',
+      }),
+    ];
+    const blocks = runner.buildHomeBlocks(null, [], triggers, []);
+
+    const triggerSections = blocks.filter(
+      (b: any) =>
+        b.type === 'section' && b.text?.type === 'mrkdwn' && b.text.text.includes('Deploy trigger')
+    );
+    expect(triggerSections.length).toBe(1);
+    const text = (triggerSections[0] as any).text.text;
+    expect(text).toContain(':large_green_circle:');
+    expect(text).toContain('channels: C123, C456');
+    expect(text).toContain('contains: deploy, ship');
+    expect(text).toContain('pattern: `deploy \\w+`');
+    expect(text).toContain('`deploy-workflow`');
+  });
+
+  test('renders disabled trigger with white circle', () => {
+    const triggers = [makeTrigger({ enabled: false, workflow: 'disabled-wf' })];
+    const blocks = runner.buildHomeBlocks(null, [], triggers, []);
+
+    const triggerSections = blocks.filter(
+      (b: any) => b.type === 'section' && b.text?.text?.includes(':white_circle:')
+    );
+    expect(triggerSections.length).toBe(1);
+  });
+
+  test('filters out non-active triggers', () => {
+    const triggers = [
+      makeTrigger({ status: 'paused', description: 'paused-trigger' }),
+      makeTrigger({ status: 'deleted', description: 'deleted-trigger' }),
+    ];
+    const blocks = runner.buildHomeBlocks(null, [], triggers, []);
+
+    const texts = blocks
+      .filter((b: any) => b.type === 'section' && b.text?.type === 'mrkdwn')
+      .map((b: any) => b.text.text)
+      .join('\n');
+
+    expect(texts).not.toContain('paused-trigger');
+    expect(texts).not.toContain('deleted-trigger');
+    expect(texts).toContain('_No active message triggers._');
+  });
+
+  test('truncates at 10 triggers and shows overflow', () => {
+    const triggers = Array.from({ length: 13 }, (_, i) =>
+      makeTrigger({ id: `trig-${i}`, description: `trigger-${i}` })
+    );
+    const blocks = runner.buildHomeBlocks(null, [], triggers, []);
+
+    const rendered = blocks.filter(
+      (b: any) => b.type === 'section' && b.text?.text?.includes(':large_green_circle:')
+    );
+    expect(rendered.length).toBe(10);
+
+    const overflow = blocks.find(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('…and 3 more')
+    );
+    expect(overflow).toBeDefined();
+  });
+
+  test('renders workflows with name and description', () => {
+    const workflows = [
+      { id: 'wf-1', name: 'Deploy', description: 'Deploy to production' },
+      { id: 'wf-2', name: 'Test', description: undefined },
+    ];
+    const blocks = runner.buildHomeBlocks(null, [], [], workflows);
+
+    const wfSections = blocks.filter(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('*Deploy*')
+    );
+    expect(wfSections.length).toBe(1);
+    expect((wfSections[0] as any).text.text).toContain('Deploy to production');
+
+    const testSections = blocks.filter(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('*Test*')
+    );
+    expect(testSections.length).toBe(1);
+    // No description line
+    expect((testSections[0] as any).text.text).toBe('*Test*');
+  });
+
+  test('truncates at 15 workflows and shows overflow', () => {
+    const workflows = Array.from({ length: 18 }, (_, i) => ({
+      id: `wf-${i}`,
+      name: `Workflow ${i}`,
+    }));
+    const blocks = runner.buildHomeBlocks(null, [], [], workflows);
+
+    const rendered = blocks.filter(
+      (b: any) => b.type === 'section' && b.text?.text?.startsWith('*Workflow ')
+    );
+    expect(rendered.length).toBe(15);
+
+    const overflow = blocks.find(
+      (b: any) => b.type === 'context' && b.elements?.[0]?.text?.includes('…and 3 more')
+    );
+    expect(overflow).toBeDefined();
+  });
+
+  test('uses workflow id as fallback when name is empty', () => {
+    const workflows = [{ id: 'my-workflow', name: '', description: 'desc' }];
+    const blocks = runner.buildHomeBlocks(null, [], [], workflows);
+
+    const wfSections = blocks.filter(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('*my-workflow*')
+    );
+    expect(wfSections.length).toBe(1);
+  });
+
+  test('schedule without nextRunAt shows N/A', () => {
+    const schedules = [makeSchedule({ nextRunAt: undefined })];
+    const blocks = runner.buildHomeBlocks(null, schedules, [], []);
+
+    const sched = blocks.find(
+      (b: any) => b.type === 'section' && b.text?.text?.includes('Next: N/A')
+    );
+    expect(sched).toBeDefined();
+  });
+});
+
+describe('SlackClient.views.publish', () => {
+  let client: SlackClient;
+
+  beforeEach(() => {
+    client = new SlackClient('xoxb-test-token');
+    mockFetch.mockReset();
+  });
+
+  test('calls views.publish API with user_id and view', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ ok: true }),
+    });
+
+    const result = await client.views.publish({
+      user_id: 'U123',
+      view: { type: 'home', blocks: [{ type: 'divider' }] },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://slack.com/api/views.publish',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          user_id: 'U123',
+          view: { type: 'home', blocks: [{ type: 'divider' }] },
+        }),
+      })
+    );
+  });
+
+  test('returns error on API failure', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ ok: false, error: 'invalid_blocks' }),
+    });
+
+    const result = await client.views.publish({
+      user_id: 'U123',
+      view: { type: 'home', blocks: [] },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('invalid_blocks');
+  });
+
+  test('returns error on network exception', async () => {
+    mockFetch.mockRejectedValue(new Error('network timeout'));
+
+    const result = await client.views.publish({
+      user_id: 'U123',
+      view: { type: 'home', blocks: [] },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('network timeout');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `views.publish` method to `SlackClient` for publishing App Home views
- Handle `app_home_opened` events in `SlackSocketRunner` to render a personalized Home tab
- Display user's schedules (active/paused with next run, cron expression, status), message triggers (with filter criteria, enabled/disabled status), and available workflows (name, description)
- Truncate long lists (15 schedules, 10 triggers, 15 workflows) with overflow indicators
- Only show the requesting user's data (no cross-user visibility, no rate limit info)

## Test plan
- [x] 18 new unit tests in `tests/unit/slack-app-home.test.ts` covering:
  - Greeting rendering with real name, username fallback, and null user
  - Empty state placeholders for all three sections
  - Schedule rendering with status icons, cron/one-time, next run time
  - Trigger rendering with filter info, enabled/disabled icons
  - Workflow rendering with name, description, id fallback
  - Overflow truncation for all sections
  - `views.publish` API success, error, and network exception paths
- [x] `npm run build` passes with no type errors
- [x] Full test suite passes (114 tests, 0 failures)
- [ ] Manual: run `visor --slack`, open app Home tab in Slack, verify content renders

### Slack App Configuration Required
1. **App Home** → Toggle "Home Tab" ON
2. **Event Subscriptions** → Subscribe to `app_home_opened` bot event

No additional OAuth scopes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)