### PR TITLE
feat: notify active Slack threads on graceful shutdown

### DIFF
--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -1380,6 +1380,8 @@ export async function main(): Promise<void> {
       console.log('✅ Slack Socket Mode is running. Press Ctrl+C to exit.');
 
       // Start config file watcher if --watch is enabled
+      let configWatcher: { stop(): void } | undefined;
+      let configWatchStore: { shutdown(): Promise<void> } | undefined;
       if ((options as any).watch) {
         if (!options.configPath) {
           console.error('❌ --watch requires --config <path>');
@@ -1403,23 +1405,31 @@ export async function main(): Promise<void> {
           });
           const watcher = new ConfigWatcher(options.configPath, reloader);
           watcher.start();
+          configWatcher = watcher;
+          configWatchStore = watchStore;
           logger.info('Config watching enabled');
-
-          // Clean up watcher resources on process shutdown, then re-raise
-          // the signal so the default handler (or other listeners) can terminate.
-          const onSignal = (sig: NodeJS.Signals) => {
-            watcher.stop();
-            watchStore.shutdown().catch(() => {});
-            process.removeListener('SIGINT', onSignal);
-            process.removeListener('SIGTERM', onSignal);
-            process.kill(process.pid, sig);
-          };
-          process.on('SIGINT', onSignal);
-          process.on('SIGTERM', onSignal);
         } catch (watchErr: unknown) {
           logger.warn(`Config watch setup failed (Slack mode continues without it): ${watchErr}`);
         }
       }
+
+      // Graceful shutdown: notify active threads before exiting
+      let shuttingDown = false;
+      const onShutdown = async (sig: NodeJS.Signals) => {
+        if (shuttingDown) return;
+        shuttingDown = true;
+        logger.info(`[Slack] Received ${sig}, shutting down gracefully…`);
+        if (configWatcher) configWatcher.stop();
+        if (configWatchStore) configWatchStore.shutdown().catch(() => {});
+        await runner.stop();
+        process.exit(0);
+      };
+      process.on('SIGINT', sig => {
+        onShutdown(sig);
+      });
+      process.on('SIGTERM', sig => {
+        onShutdown(sig);
+      });
 
       process.stdin.resume();
       return;

--- a/src/slack/socket-runner.ts
+++ b/src/slack/socket-runner.ts
@@ -56,6 +56,7 @@ export class SlackSocketRunner {
   private retryCount = 0;
   private genericScheduler?: Scheduler;
   private messageTriggerEvaluator?: MessageTriggerEvaluator;
+  private activeThreads = new Set<string>();
 
   constructor(engine: StateMachineExecutionEngine, cfg: VisorConfig, opts: SlackSocketConfig) {
     const app = opts.appToken || process.env.SLACK_APP_TOKEN || '';
@@ -637,6 +638,10 @@ export class SlackSocketRunner {
     } catch {}
 
     logger.info('[SlackSocket] Dispatching engine run for Slack event');
+    const trackChannel = String(ev.channel || '');
+    const trackThreadTs = String(ev.thread_ts || ev.ts || ev.event_ts || '');
+    const threadKey =
+      trackChannel && trackThreadTs ? this.trackThread(trackChannel, trackThreadTs) : '';
     try {
       // Rate limiting (optional)
       const userId = String(ev.user || 'unknown');
@@ -730,6 +735,8 @@ export class SlackSocketRunner {
       logger.error(
         `[SlackSocket] Engine execution failed: ${e instanceof Error ? e.message : String(e)}`
       );
+    } finally {
+      if (threadKey) this.untrackThread(threadKey);
     }
   }
 
@@ -744,137 +751,191 @@ export class SlackSocketRunner {
     const threadTs = ev.thread_ts ? String(ev.thread_ts) : undefined;
     const user = String(ev.user || 'unknown');
 
+    const replyTs = threadTs || ts;
+    const threadKey = channel && replyTs ? this.trackThread(channel, replyTs) : '';
+
     logger.info(
       `[SlackSocket] Message trigger '${id}' matched → workflow="${trigger.workflow}" channel=${channel} ts=${ts}`
     );
 
-    // Verify workflow exists
-    const allChecks = Object.keys(this.cfg.checks || {});
-    if (!allChecks.includes(trigger.workflow)) {
-      logger.error(
-        `[SlackSocket] Message trigger '${id}': workflow "${trigger.workflow}" not found in configuration`
-      );
-      return;
-    }
-
-    // Build conversation context (for thread replies, fetch full thread)
-    let conversationContext: any = undefined;
     try {
-      const isThreadReply = !!threadTs && threadTs !== ts;
-      if (isThreadReply) {
-        const adapter = this.getSlackAdapter();
-        if (adapter && channel && threadTs) {
-          const cleanedText = String(ev.text || '')
-            .replace(/<@[A-Z0-9]+>/g, '')
-            .trim();
-          conversationContext = await adapter.fetchConversation(channel, threadTs, {
-            ts,
-            user,
-            text: cleanedText || String(ev.text || ''),
-            timestamp: Date.now(),
-            files: Array.isArray(ev.files) ? ev.files : undefined,
-          });
-        }
+      // Verify workflow exists
+      const allChecks = Object.keys(this.cfg.checks || {});
+      if (!allChecks.includes(trigger.workflow)) {
+        logger.error(
+          `[SlackSocket] Message trigger '${id}': workflow "${trigger.workflow}" not found in configuration`
+        );
+        return;
       }
-    } catch (err) {
-      logger.warn(
-        `[SlackSocket] Message trigger '${id}': conversation context fetch failed: ${err instanceof Error ? err.message : err}`
-      );
-    }
 
-    // Build synthetic webhook payload
-    const triggerPayload = {
-      ...payload,
-      trigger: {
-        id,
-        type: 'on_message',
-        workflow: trigger.workflow,
-      },
-      ...(conversationContext ? { slack_conversation: conversationContext } : {}),
-    };
-
-    const webhookData = new Map<string, unknown>();
-    webhookData.set(this.endpoint, triggerPayload);
-
-    // Clone config for this run with Slack frontend
-    const cfgForRun: VisorConfig = (() => {
+      // Build conversation context (for thread replies, fetch full thread)
+      let conversationContext: any = undefined;
       try {
-        const cfg = JSON.parse(JSON.stringify(this.cfg));
-        const fronts = Array.isArray(cfg.frontends) ? cfg.frontends : [];
-        if (!fronts.some((f: any) => f && f.name === 'slack')) fronts.push({ name: 'slack' });
-        cfg.frontends = fronts;
-        return cfg;
-      } catch {
-        return this.cfg;
+        const isThreadReply = !!threadTs && threadTs !== ts;
+        if (isThreadReply) {
+          const adapter = this.getSlackAdapter();
+          if (adapter && channel && threadTs) {
+            const cleanedText = String(ev.text || '')
+              .replace(/<@[A-Z0-9]+>/g, '')
+              .trim();
+            conversationContext = await adapter.fetchConversation(channel, threadTs, {
+              ts,
+              user,
+              text: cleanedText || String(ev.text || ''),
+              timestamp: Date.now(),
+              files: Array.isArray(ev.files) ? ev.files : undefined,
+            });
+          }
+        }
+      } catch (err) {
+        logger.warn(
+          `[SlackSocket] Message trigger '${id}': conversation context fetch failed: ${err instanceof Error ? err.message : err}`
+        );
       }
-    })();
 
-    // Derive stable workspace name from thread identity
-    const wsThreadTs = threadTs || ts;
-    if (channel && wsThreadTs) {
-      const hash = createHash('sha256')
-        .update(`${channel}:${wsThreadTs}`)
-        .digest('hex')
-        .slice(0, 8);
-      const workspaceName = `slack-trigger-${hash}`;
-      if (!(cfgForRun as any).workspace) {
-        (cfgForRun as any).workspace = {};
+      // Build synthetic webhook payload
+      const triggerPayload = {
+        ...payload,
+        trigger: {
+          id,
+          type: 'on_message',
+          workflow: trigger.workflow,
+        },
+        ...(conversationContext ? { slack_conversation: conversationContext } : {}),
+      };
+
+      const webhookData = new Map<string, unknown>();
+      webhookData.set(this.endpoint, triggerPayload);
+
+      // Clone config for this run with Slack frontend
+      const cfgForRun: VisorConfig = (() => {
+        try {
+          const cfg = JSON.parse(JSON.stringify(this.cfg));
+          const fronts = Array.isArray(cfg.frontends) ? cfg.frontends : [];
+          if (!fronts.some((f: any) => f && f.name === 'slack')) fronts.push({ name: 'slack' });
+          cfg.frontends = fronts;
+          return cfg;
+        } catch {
+          return this.cfg;
+        }
+      })();
+
+      // Derive stable workspace name from thread identity
+      const wsThreadTs = threadTs || ts;
+      if (channel && wsThreadTs) {
+        const hash = createHash('sha256')
+          .update(`${channel}:${wsThreadTs}`)
+          .digest('hex')
+          .slice(0, 8);
+        const workspaceName = `slack-trigger-${hash}`;
+        if (!(cfgForRun as any).workspace) {
+          (cfgForRun as any).workspace = {};
+        }
+        (cfgForRun as any).workspace.name = workspaceName;
+        (cfgForRun as any).workspace.cleanup_on_exit = false;
       }
-      (cfgForRun as any).workspace.name = workspaceName;
-      (cfgForRun as any).workspace.cleanup_on_exit = false;
+
+      // Create a dedicated engine instance for this trigger
+      const runEngine = new StateMachineExecutionEngine();
+      await this.ensureClient();
+      try {
+        const parentCtx: any = (this.engine as any).getExecutionContext?.() || {};
+        const prevCtx: any = (runEngine as any).getExecutionContext?.() || {};
+        (runEngine as any).setExecutionContext?.({
+          ...parentCtx,
+          ...prevCtx,
+          slack: this.client || parentCtx.slack,
+          slackClient: this.client || parentCtx.slackClient,
+        });
+      } catch {}
+
+      // Refresh GitHub credentials
+      try {
+        const { refreshGitHubCredentials } = await import('../github-auth');
+        await refreshGitHubCredentials();
+      } catch {}
+
+      await withActiveSpan(
+        'visor.run',
+        {
+          ...getVisorRunAttributes(),
+          'visor.run.source': 'slack_message_trigger',
+          'visor.trigger.id': id,
+          'visor.trigger.workflow': trigger.workflow,
+          'slack.channel_id': channel,
+          'slack.thread_ts': threadTs || ts,
+          'slack.user_id': user,
+        },
+        async () => {
+          await runEngine.executeChecks({
+            checks: [trigger.workflow],
+            showDetails: true,
+            outputFormat: 'json',
+            config: cfgForRun,
+            webhookContext: { webhookData, eventType: 'slack_message' },
+            debug: process.env.VISOR_DEBUG === 'true',
+            inputs: trigger.inputs,
+          } as any);
+        }
+      );
+
+      logger.info(`[SlackSocket] Message trigger '${id}' workflow completed`);
+    } finally {
+      if (threadKey) this.untrackThread(threadKey);
     }
+  }
 
-    // Create a dedicated engine instance for this trigger
-    const runEngine = new StateMachineExecutionEngine();
-    await this.ensureClient();
+  private trackThread(channel: string, threadTs: string): string {
+    const key = `${channel}:${threadTs}`;
+    this.activeThreads.add(key);
+    return key;
+  }
+
+  private untrackThread(key: string): void {
+    this.activeThreads.delete(key);
+  }
+
+  /**
+   * Send a best-effort shutdown notice to all active Slack threads.
+   * Bounded by timeoutMs so we never block process exit indefinitely.
+   */
+  async notifyActiveThreadsOfShutdown(timeoutMs = 5000): Promise<void> {
+    if (this.activeThreads.size === 0 || !this.client) return;
+
+    const msg =
+      ':warning: The bot was restarted. Your request was interrupted and could not be completed. Please retry by sending your message again.';
+
+    const promises = [...this.activeThreads].map(key => {
+      const [channel, threadTs] = key.split(':');
+      return this.client!.chat.postMessage({ channel, thread_ts: threadTs, text: msg }).catch(
+        err => {
+          logger.warn(
+            `[SlackSocket] Failed to notify thread ${key} of shutdown: ${err instanceof Error ? err.message : err}`
+          );
+        }
+      );
+    });
+
     try {
-      const parentCtx: any = (this.engine as any).getExecutionContext?.() || {};
-      const prevCtx: any = (runEngine as any).getExecutionContext?.() || {};
-      (runEngine as any).setExecutionContext?.({
-        ...parentCtx,
-        ...prevCtx,
-        slack: this.client || parentCtx.slack,
-        slackClient: this.client || parentCtx.slackClient,
-      });
-    } catch {}
-
-    // Refresh GitHub credentials
-    try {
-      const { refreshGitHubCredentials } = await import('../github-auth');
-      await refreshGitHubCredentials();
-    } catch {}
-
-    await withActiveSpan(
-      'visor.run',
-      {
-        ...getVisorRunAttributes(),
-        'visor.run.source': 'slack_message_trigger',
-        'visor.trigger.id': id,
-        'visor.trigger.workflow': trigger.workflow,
-        'slack.channel_id': channel,
-        'slack.thread_ts': threadTs || ts,
-        'slack.user_id': user,
-      },
-      async () => {
-        await runEngine.executeChecks({
-          checks: [trigger.workflow],
-          showDetails: true,
-          outputFormat: 'json',
-          config: cfgForRun,
-          webhookContext: { webhookData, eventType: 'slack_message' },
-          debug: process.env.VISOR_DEBUG === 'true',
-          inputs: trigger.inputs,
-        } as any);
-      }
-    );
-
-    logger.info(`[SlackSocket] Message trigger '${id}' workflow completed`);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      await Promise.race([
+        Promise.allSettled(promises),
+        new Promise<void>(resolve => {
+          timer = setTimeout(resolve, timeoutMs);
+        }),
+      ]);
+      if (timer) clearTimeout(timer);
+    } catch {
+      // best effort
+    }
   }
 
   /**
    * Stop the socket runner and clean up resources
    */
   async stop(): Promise<void> {
+    // Notify active threads before tearing down
+    await this.notifyActiveThreadsOfShutdown();
     // Stop background GitHub App token refresh
     try {
       const { stopTokenRefreshTimer } = await import('../github-auth');

--- a/tests/unit/slack-socket-shutdown.test.ts
+++ b/tests/unit/slack-socket-shutdown.test.ts
@@ -1,0 +1,134 @@
+import { SlackSocketRunner } from '../../src/slack/socket-runner';
+import { StateMachineExecutionEngine } from '../../src/state-machine-execution-engine';
+import type { VisorConfig } from '../../src/types/config';
+
+describe('SlackSocketRunner graceful shutdown', () => {
+  const cfg: VisorConfig = {
+    version: '1.0',
+    output: { pr_comment: { format: 'markdown', group_by: 'check', collapse: true } },
+    checks: { echo: { type: 'noop' as any } },
+  } as any;
+
+  function makeRunner(): SlackSocketRunner {
+    const engine = new StateMachineExecutionEngine();
+    return new SlackSocketRunner(engine, cfg, {
+      appToken: 'xapp-test',
+      endpoint: '/bots/slack/support',
+      mentions: 'all',
+      threads: 'any',
+    });
+  }
+
+  function mockClient(runner: SlackSocketRunner): jest.Mock {
+    const postMessage = jest.fn().mockResolvedValue({ ok: true });
+    (runner as any).client = { chat: { postMessage } } as any;
+    return postMessage;
+  }
+
+  test('sends shutdown message to tracked threads', async () => {
+    const runner = makeRunner();
+    const postMessage = mockClient(runner);
+
+    // Simulate tracking two threads
+    (runner as any).trackThread('C1', '1700.1');
+    (runner as any).trackThread('C2', '1700.2');
+
+    await runner.notifyActiveThreadsOfShutdown();
+
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'C1',
+        thread_ts: '1700.1',
+        text: expect.stringContaining('restarted'),
+      })
+    );
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'C2',
+        thread_ts: '1700.2',
+        text: expect.stringContaining('retry'),
+      })
+    );
+  });
+
+  test('does not send message to untracked (completed) threads', async () => {
+    const runner = makeRunner();
+    const postMessage = mockClient(runner);
+
+    const key = (runner as any).trackThread('C1', '1700.1');
+    (runner as any).untrackThread(key);
+
+    await runner.notifyActiveThreadsOfShutdown();
+
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  test('no-op when no active threads', async () => {
+    const runner = makeRunner();
+    const postMessage = mockClient(runner);
+
+    await runner.notifyActiveThreadsOfShutdown();
+
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  test('no-op when no client', async () => {
+    const runner = makeRunner();
+    // client is not set (default)
+
+    (runner as any).trackThread('C1', '1700.1');
+
+    // Should not throw
+    await runner.notifyActiveThreadsOfShutdown();
+  });
+
+  test('timeout prevents blocking on slow postMessage', async () => {
+    jest.useFakeTimers();
+    try {
+      const runner = makeRunner();
+      const postMessage = jest
+        .fn()
+        .mockImplementation(() => new Promise(resolve => setTimeout(resolve, 60000)));
+      (runner as any).client = { chat: { postMessage } } as any;
+
+      (runner as any).trackThread('C1', '1700.1');
+
+      const p = runner.notifyActiveThreadsOfShutdown(200);
+      jest.advanceTimersByTime(200);
+      await p;
+
+      expect(postMessage).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('failure in one thread does not prevent notifying others', async () => {
+    const runner = makeRunner();
+    const postMessage = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('channel_not_found'))
+      .mockResolvedValueOnce({ ok: true });
+    (runner as any).client = { chat: { postMessage } } as any;
+
+    (runner as any).trackThread('C1', '1700.1');
+    (runner as any).trackThread('C2', '1700.2');
+
+    // Should not throw
+    await runner.notifyActiveThreadsOfShutdown();
+
+    expect(postMessage).toHaveBeenCalledTimes(2);
+  });
+
+  test('message does not mention product name', async () => {
+    const runner = makeRunner();
+    const postMessage = mockClient(runner);
+
+    (runner as any).trackThread('C1', '1700.1');
+    await runner.notifyActiveThreadsOfShutdown();
+
+    const sentText = postMessage.mock.calls[0][0].text as string;
+    expect(sentText.toLowerCase()).not.toContain('visor');
+  });
+});


### PR DESCRIPTION
## Summary
- Tracks active Slack threads (direct mentions + message triggers) during engine execution
- On SIGTERM/SIGINT, sends a best-effort shutdown notice to each in-flight thread before closing, so users know to retry
- Consolidates signal handling in `cli-main.ts` (config watcher cleanup + runner.stop() in a single handler)

## Changes
- **`src/slack/socket-runner.ts`**: Added `activeThreads` Set with `trackThread`/`untrackThread` helpers, `notifyActiveThreadsOfShutdown()` method (bounded by 5s timeout), and calls it from `stop()`
- **`src/cli-main.ts`**: Added unified SIGINT/SIGTERM handler for Slack mode that cleans up config watcher + calls `runner.stop()`
- **`tests/unit/slack-socket-shutdown.test.ts`**: 7 tests covering tracked/untracked threads, no-op cases, timeout behavior, partial failures, and product-name neutrality

## Test plan
- [x] `npx jest --testPathPatterns="slack-socket-shutdown" --no-coverage` — 7/7 passing
- [x] Pre-commit hooks pass (114/114 integration tests)
- [ ] Manual: `visor --slack --config .visor.yaml`, trigger a request, kill with SIGTERM, verify message appears in thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)