### PR TITLE
fix: restrict tool usage in completion_prompt to prevent redundant exploration

### DIFF
--- a/defaults/assistant.yaml
+++ b/defaults/assistant.yaml
@@ -734,6 +734,15 @@ steps:
         5. If a tool returned an error or empty result, acknowledge it honestly
         6. Never claim success if you only PLANNED to do something but didn't execute it
 
+        Tool usage policy for this validation step:
+        7. Do NOT call code exploration tools (code-talk, search, delegate) unless
+           you found a SPECIFIC factual claim in your response that is unsupported
+           by any tool output in the conversation history above
+        8. If the conversation already contains tool results that answer the question,
+           use those results — do NOT re-explore the same codebase topics
+        9. Only call a tool if you can state exactly which claim needs verification
+           and why existing tool results are insufficient
+
         If you find discrepancies:
         - Correct your response to reflect what actually happened
         - If you couldn't complete an action, explain why and what the user can do


### PR DESCRIPTION
## Problem

Trace `3233041f4f04376815a8c2d1e457e77d` showed the `completion_prompt` validation phase
triggering **5 additional explore-code sub-workflow cycles** (904s wasted, 15 minutes).

The `completion_prompt` runs as an agentic session with up to 5 tool-call iterations
(`completionMaxIterations = 5` in probe). With unrestricted tool access, the AI kept
calling code-explorer to "double-check" answers that were already supported by tool
results in the conversation history — then produced a worse, incomplete response.

## Fix

Add explicit tool usage policy to the `generate-response` completion_prompt:
- Do NOT call exploration tools unless a specific claim is unsupported by existing results
- If conversation already has tool results, use them — don't re-explore
- Only call tools when you can state exactly which claim needs verification

Tools remain available for legitimate cases (e.g., an action was claimed but no tool
call exists, or confidence is low with missing data).

## Test plan
- [x] 114 YAML workflow tests pass
- [x] Build succeeds