### PR TITLE
fix: isolate git-checkout worktrees per session

### DIFF
--- a/src/providers/git-checkout-provider.ts
+++ b/src/providers/git-checkout-provider.ts
@@ -185,6 +185,7 @@ export class GitCheckoutProvider extends CheckProvider {
           workingDirectory: resolvedWorkingDirectory,
           clean: checkoutConfig.clean !== false, // Default: true
           workflowId: (context as any)?.workflowId,
+          sessionId: (context as any)?.sessionId || (context as any)?._parentContext?.sessionId,
           fetchDepth: checkoutConfig.fetch_depth,
           cloneTimeoutMs: checkoutConfig.clone_timeout_ms,
         }

--- a/src/utils/worktree-manager.ts
+++ b/src/utils/worktree-manager.ts
@@ -100,19 +100,20 @@ export class WorktreeManager {
   }
 
   /**
-   * Generate a deterministic worktree ID based on repository and ref.
-   * This allows worktrees to be reused when the same repo+ref is requested again.
+   * Generate a worktree ID based on repository, ref, and session.
+   *
+   * When a sessionId is provided, the ID is scoped to that session so each
+   * agent run gets its own isolated worktree. Steps within the same session
+   * that checkout the same repo+ref will reuse the worktree (efficient).
+   *
+   * Without sessionId, falls back to deterministic repo+ref hashing
+   * (legacy behavior).
    */
-  private generateWorktreeId(repository: string, ref: string): string {
+  private generateWorktreeId(repository: string, ref: string, sessionId?: string): string {
     const sanitizedRepo = repository.replace(/[^a-zA-Z0-9-]/g, '-');
     const sanitizedRef = ref.replace(/[^a-zA-Z0-9-]/g, '-');
-    // Use deterministic hash (no Date.now()) so same repo+ref produces same ID
-    // This enables worktree reuse across multiple calls
-    const hash = crypto
-      .createHash('md5')
-      .update(`${repository}:${ref}`)
-      .digest('hex')
-      .substring(0, 8);
+    const hashInput = sessionId ? `${repository}:${ref}:${sessionId}` : `${repository}:${ref}`;
+    const hash = crypto.createHash('md5').update(hashInput).digest('hex').substring(0, 8);
     return `${sanitizedRepo}-${sanitizedRef}-${hash}`;
   }
 
@@ -336,6 +337,7 @@ export class WorktreeManager {
       workingDirectory?: string;
       clean?: boolean;
       workflowId?: string;
+      sessionId?: string;
       fetchDepth?: number;
       cloneTimeoutMs?: number;
     } = {}
@@ -352,8 +354,8 @@ export class WorktreeManager {
       options.cloneTimeoutMs
     );
 
-    // Generate worktree ID and path
-    const worktreeId = this.generateWorktreeId(repository, ref);
+    // Generate worktree ID and path — scoped by sessionId for cross-run isolation
+    const worktreeId = this.generateWorktreeId(repository, ref, options.sessionId);
     let worktreePath = options.workingDirectory || path.join(this.getWorktreesDir(), worktreeId);
 
     // Validate path if user-provided

--- a/tests/unit/worktree-manager.test.ts
+++ b/tests/unit/worktree-manager.test.ts
@@ -219,4 +219,93 @@ describe('WorktreeManager', () => {
     );
     expect(checkoutCall).toBeDefined();
   });
+
+  describe('session-scoped worktree isolation', () => {
+    it('generates different worktree IDs for different sessions with same repo+ref', () => {
+      const manager = WorktreeManager.getInstance();
+      // Access private method via any cast
+      const genId = (manager as any).generateWorktreeId.bind(manager);
+
+      const repo = 'org/repo';
+      const ref = 'main';
+
+      const id1 = genId(repo, ref, 'session-aaa');
+      const id2 = genId(repo, ref, 'session-bbb');
+      const idNoSession = genId(repo, ref);
+
+      // Different sessions produce different IDs
+      expect(id1).not.toBe(id2);
+      // No session produces a different ID than with session
+      expect(idNoSession).not.toBe(id1);
+      expect(idNoSession).not.toBe(id2);
+    });
+
+    it('generates same worktree ID for same session+repo+ref (intra-session reuse)', () => {
+      const manager = WorktreeManager.getInstance();
+      const genId = (manager as any).generateWorktreeId.bind(manager);
+
+      const id1 = genId('org/repo', 'main', 'session-xxx');
+      const id2 = genId('org/repo', 'main', 'session-xxx');
+
+      expect(id1).toBe(id2);
+    });
+
+    it('passes sessionId through to createWorktree and produces session-scoped path', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+      const execMock = commandExecutor.execute as jest.Mock;
+
+      const repo = 'org/repo';
+      const repoUrl = `https://github.com/${repo}.git`;
+      const ref = 'main';
+
+      const manager = WorktreeManager.getInstance();
+      const managerConfig = manager.getConfig();
+
+      // Set up bare repo directory so getOrCreateBareRepo finds it
+      const reposDir = `${managerConfig.base_path}/repos`;
+      fs.mkdirSync(reposDir, { recursive: true });
+      const bareRepoPath = `${reposDir}/${repo.replace(/\//g, '-')}.git`;
+      fs.mkdirSync(bareRepoPath, { recursive: true });
+
+      execMock.mockImplementation(async (cmd: string) => {
+        if (cmd.includes('remote get-url')) {
+          return { stdout: repoUrl, stderr: '', exitCode: 0 };
+        }
+        if (cmd.includes('rev-parse')) {
+          return { stdout: 'abc123\n', stderr: '', exitCode: 0 };
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      });
+
+      // Create worktrees with two different sessions
+      let path1: string | undefined;
+      let path2: string | undefined;
+      try {
+        const wt1 = await manager.createWorktree(repo, repoUrl, ref, { sessionId: 'sess-1' });
+        path1 = wt1.path;
+      } catch {
+        // May fail on fs operations, but we can check the generated path from calls
+      }
+
+      try {
+        const wt2 = await manager.createWorktree(repo, repoUrl, ref, { sessionId: 'sess-2' });
+        path2 = wt2.path;
+      } catch {
+        // Same
+      }
+
+      // If both succeeded, paths should be different
+      if (path1 && path2) {
+        expect(path1).not.toBe(path2);
+      }
+
+      // At minimum, verify the worktree add commands targeted different paths
+      const calls = execMock.mock.calls.map((c: any[]) => c[0] as string);
+      const worktreeAdds = calls.filter((cmd: string) => cmd.includes('worktree add'));
+
+      if (worktreeAdds.length >= 2) {
+        expect(worktreeAdds[0]).not.toBe(worktreeAdds[1]);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Worktree IDs now include `sessionId` in the hash, ensuring each agent run gets its own isolated worktree
- Steps within the same session that checkout the same repo+ref still share the worktree efficiently
- Without `sessionId` (legacy callers), falls back to the previous deterministic `repository:ref` hashing

**Root cause**: `generateWorktreeId` was deterministic based only on `repository:ref`, so every agent run requesting the same repo@ref (e.g. `org/repo@main`) got the exact same worktree path. Commits and branches from previous runs accumulated and leaked into subsequent runs.

## Test plan

- [x] 3 new unit tests in `tests/unit/worktree-manager.test.ts` covering session isolation
- [x] All 7 worktree-manager tests pass
- [x] `npm run build` succeeds
- [ ] Manual verification: two sequential agent runs on same repo should not see each other's commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)