### PR TITLE
feat: add search delegate provider/model config for AI steps

### DIFF
--- a/src/ai-review-service.ts
+++ b/src/ai-review-service.ts
@@ -236,6 +236,10 @@ export interface AIReviewConfig {
   allowBash?: boolean;
   // Advanced bash command execution configuration
   bashConfig?: import('./types/config').BashConfig;
+  // Override provider for search delegate sub-agents
+  search_delegate_provider?: string;
+  // Override model for search delegate sub-agents
+  search_delegate_model?: string;
   // Optional workspace root and allowed folders for ProbeAgent.
   // When provided, these are forwarded to ProbeAgent so tools like search/query
   // operate inside the isolated workspace/projects instead of the Visor repo root.
@@ -1927,6 +1931,14 @@ ${'='.repeat(60)}
       }
       if (this.config.bashConfig !== undefined) {
         (options as any).bashConfig = this.config.bashConfig;
+      }
+
+      // Pass search delegate provider/model overrides to ProbeAgent
+      if (this.config.search_delegate_provider) {
+        (options as any).searchDelegateProvider = this.config.search_delegate_provider;
+      }
+      if (this.config.search_delegate_model) {
+        (options as any).searchDelegateModel = this.config.search_delegate_model;
       }
 
       // Pass completion prompt for post-completion validation/review

--- a/src/generated/config-schema.ts
+++ b/src/generated/config-schema.ts
@@ -958,7 +958,7 @@ export const configSchema = {
           description: 'Arguments/inputs for the workflow',
         },
         overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13766-28360-src_types_config.ts-0-55512%3E%3E',
           description: 'Override specific step configurations in the workflow',
         },
         output_mapping: {
@@ -975,7 +975,7 @@ export const configSchema = {
             'Config file path - alternative to workflow ID (loads a Visor config file as workflow)',
         },
         workflow_overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13766-28360-src_types_config.ts-0-55512%3E%3E',
           description: 'Alias for overrides - workflow step overrides (backward compatibility)',
         },
         ref: {
@@ -1260,6 +1260,15 @@ export const configSchema = {
         allowBash: {
           type: 'boolean',
           description: 'Enable bash command execution (shorthand for bashConfig.enabled)',
+        },
+        search_delegate_provider: {
+          type: 'string',
+          description:
+            "Override provider for search delegate sub-agents (e.g., 'google' for cheaper search)",
+        },
+        search_delegate_model: {
+          type: 'string',
+          description: "Override model for search delegate sub-agents (e.g., 'gemini-2.0-flash')",
         },
         bashConfig: {
           $ref: '#/definitions/BashConfig',
@@ -1677,7 +1686,7 @@ export const configSchema = {
           description: 'Custom output name (defaults to workflow name)',
         },
         overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-13766-28360-src_types_config.ts-0-55512%3E%3E',
           description: 'Step overrides',
         },
         output_mapping: {
@@ -1692,14 +1701,14 @@ export const configSchema = {
         '^x-': {},
       },
     },
-    'Record<string,Partial<interface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265>>':
+    'Record<string,Partial<interface-src_types_config.ts-13766-28360-src_types_config.ts-0-55512>>':
       {
         type: 'object',
         additionalProperties: {
-          $ref: '#/definitions/Partial%3Cinterface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265%3E',
+          $ref: '#/definitions/Partial%3Cinterface-src_types_config.ts-13766-28360-src_types_config.ts-0-55512%3E',
         },
       },
-    'Partial<interface-src_types_config.ts-13519-28113-src_types_config.ts-0-55265>': {
+    'Partial<interface-src_types_config.ts-13766-28360-src_types_config.ts-0-55512>': {
       type: 'object',
       additionalProperties: false,
     },

--- a/src/providers/ai-check-provider.ts
+++ b/src/providers/ai-check-provider.ts
@@ -855,6 +855,12 @@ export class AICheckProvider extends CheckProvider {
       if (aiAny.bashConfig !== undefined) {
         aiConfig.bashConfig = aiAny.bashConfig as import('../types/config').BashConfig;
       }
+      if (aiAny.search_delegate_provider !== undefined) {
+        aiConfig.search_delegate_provider = aiAny.search_delegate_provider as string;
+      }
+      if (aiAny.search_delegate_model !== undefined) {
+        aiConfig.search_delegate_model = aiAny.search_delegate_model as string;
+      }
       if (aiAny.completion_prompt !== undefined) {
         aiConfig.completionPrompt = aiAny.completion_prompt as string;
       }
@@ -2317,6 +2323,8 @@ export class AICheckProvider extends CheckProvider {
       'ai.disableTools',
       'ai.allowBash',
       'ai.bashConfig',
+      'ai.search_delegate_provider',
+      'ai.search_delegate_model',
       'ai_model',
       'ai_provider',
       'ai_mcp_servers',

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -378,6 +378,10 @@ export interface AIProviderConfig {
   disableTools?: boolean;
   /** Enable bash command execution (shorthand for bashConfig.enabled) */
   allowBash?: boolean;
+  /** Override provider for search delegate sub-agents (e.g., 'google' for cheaper search) */
+  search_delegate_provider?: string;
+  /** Override model for search delegate sub-agents (e.g., 'gemini-2.0-flash') */
+  search_delegate_model?: string;
   /** Advanced bash command execution configuration */
   bashConfig?: BashConfig;
   /** Completion prompt for post-completion validation/review (runs after attempt_completion) */


### PR DESCRIPTION
## Summary

- Adds `search_delegate_provider` and `search_delegate_model` options to the AI step config, allowing workflows to use a cheaper/faster model (e.g., Gemini Flash) for search delegate sub-agents while keeping the main agent on a more capable model
- Wires through: YAML config → `AICheckProvider` → `AIReviewConfig` → ProbeAgent's `searchDelegateProvider`/`searchDelegateModel` options

## Usage

```yaml
steps:
  explore-code:
    type: ai
    ai:
      model: "gemini-2.5-pro"
      search_delegate_provider: "google"
      search_delegate_model: "gemini-2.0-flash"
```

Depends on: probelabs/probe#481

## Test plan

- [x] Build succeeds
- [x] All 52 ai-check-provider unit tests pass
- [x] All 117 YAML tests pass
- [ ] Manual test with a workflow using `search_delegate_provider`/`search_delegate_model`

🤖 Generated with [Claude Code](https://claude.com/claude-code)