### PR TITLE
feat: add model/provider override for intent router

### DIFF
--- a/defaults/assistant.yaml
+++ b/defaults/assistant.yaml
@@ -318,6 +318,18 @@ inputs:
     schema:
       type: boolean
 
+  - name: router_model
+    required: false
+    description: Override AI model for intent routing (e.g., gemini-3-flash-preview for cheaper/faster classification)
+    schema:
+      type: string
+
+  - name: router_provider
+    required: false
+    description: Override AI provider for intent routing (google, anthropic, openai)
+    schema:
+      type: string
+
 # =========================================================================
 # Outputs
 # =========================================================================
@@ -375,6 +387,8 @@ steps:
       tags:
         expression: "inputs.tags || []"
       routing_instructions: "{{ inputs.routing_instructions }}"
+      model: "{{ inputs.router_model }}"
+      provider: "{{ inputs.router_provider }}"
 
   # -------------------------------------------------------------------------
   # Step 2: Build dynamic configuration for the AI step

--- a/defaults/intent-router.yaml
+++ b/defaults/intent-router.yaml
@@ -89,6 +89,18 @@ inputs:
     schema:
       type: string
 
+  - name: model
+    required: false
+    description: Override AI model for classification (e.g., gemini-3-flash-preview)
+    schema:
+      type: string
+
+  - name: provider
+    required: false
+    description: Override AI provider for classification (google, anthropic, openai)
+    schema:
+      type: string
+
 outputs:
   - name: intent
     description: Selected intent ID
@@ -134,6 +146,8 @@ steps:
       - "true"
     guarantee: "output?.intent != null"
     ai:
+      model: "{{ inputs.model }}"
+      provider: "{{ inputs.provider }}"
       skip_code_context: true
       skip_slack_context: false
       disableTools: true

--- a/src/providers/ai-check-provider.ts
+++ b/src/providers/ai-check-provider.ts
@@ -807,7 +807,19 @@ export class AICheckProvider extends CheckProvider {
         aiConfig.apiKey = aiAny.apiKey as string;
       }
       if (aiAny.model !== undefined) {
-        aiConfig.model = aiAny.model as string;
+        let modelVal = String(aiAny.model);
+        if (modelVal.includes('{{')) {
+          try {
+            const rendered = await this.liquidEngine.parseAndRender(modelVal, {
+              inputs: (config as any).workflowInputs || {},
+              env: process.env,
+            });
+            modelVal = rendered.trim();
+          } catch {}
+        }
+        if (modelVal) {
+          aiConfig.model = modelVal;
+        }
       }
       if (aiAny.timeout !== undefined) {
         aiConfig.timeout = aiAny.timeout as number;
@@ -817,12 +829,19 @@ export class AICheckProvider extends CheckProvider {
         aiConfig.maxIterations = Number(raw);
       }
       if (aiAny.provider !== undefined) {
-        aiConfig.provider = aiAny.provider as
-          | 'google'
-          | 'anthropic'
-          | 'openai'
-          | 'bedrock'
-          | 'mock';
+        let providerVal = String(aiAny.provider);
+        if (providerVal.includes('{{')) {
+          try {
+            const rendered = await this.liquidEngine.parseAndRender(providerVal, {
+              inputs: (config as any).workflowInputs || {},
+              env: process.env,
+            });
+            providerVal = rendered.trim();
+          } catch {}
+        }
+        if (providerVal) {
+          aiConfig.provider = providerVal as 'google' | 'anthropic' | 'openai' | 'bedrock' | 'mock';
+        }
       }
       if (aiAny.debug !== undefined) {
         aiConfig.debug = aiAny.debug as boolean;


### PR DESCRIPTION
## Summary

- Add `model` and `provider` inputs to the intent-router workflow, allowing users to use a cheaper/faster model for intent classification
- Add `router_model` and `router_provider` inputs to the assistant workflow that pass through to the intent router
- Support Liquid template interpolation (`{{ inputs.* }}`) in `ai.model` and `ai.provider` fields — previously these were read as raw strings only
- Gracefully falls back to defaults when not specified (empty string is treated as unset)

## Usage

In your assistant config (e.g., `tyk-assistant.yaml`):

```yaml
workflow: assistant
args:
  router_model: "gemini-3-flash-preview"
  router_provider: "google"
```

Or directly in a custom workflow using intent-router:

```yaml
route-intent:
  type: workflow
  workflow: intent-router
  args:
    question: "{{ inputs.question }}"
    model: "gemini-3-flash-preview"
    provider: "google"
```

The `ai.model` and `ai.provider` fields now also support Liquid interpolation in any AI step:

```yaml
steps:
  my-step:
    type: ai
    ai:
      model: "{{ inputs.model }}"
      provider: "{{ inputs.provider }}"
```

## Test plan

- [x] Build succeeds
- [x] All 52 ai-check-provider unit tests pass
- [x] All 117 YAML tests pass (including all intent-router and assistant tests)
- [x] Verified empty/missing inputs fall back to defaults correctly
- [ ] Manual test with `router_model: gemini-3-flash-preview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)