### PR TITLE
feat: add OAuth2 client_credentials auth and base_url support to http_client provider

### DIFF
--- a/src/providers/http-client-provider.ts
+++ b/src/providers/http-client-provider.ts
@@ -7,6 +7,7 @@ import { createExtendedLiquid } from '../liquid-extensions';
 import { EnvironmentResolver } from '../utils/env-resolver';
 import { createSecureSandbox, compileAndRun } from '../utils/sandbox';
 import { buildProviderTemplateContext } from '../utils/template-context';
+import { OAuth2TokenCache, AuthConfig } from '../utils/oauth2-token-cache';
 import Sandbox from '@nyariv/sandboxjs';
 import { logger } from '../logger';
 import * as fs from 'fs';
@@ -48,14 +49,17 @@ export class HttpClientProvider extends CheckProvider {
       return false;
     }
 
-    // Must have URL specified
-    if (typeof cfg.url !== 'string' || !cfg.url) {
+    // Must have either `url` or `base_url` specified
+    const hasUrl = typeof cfg.url === 'string' && cfg.url;
+    const hasBaseUrl = typeof cfg.base_url === 'string' && cfg.base_url;
+
+    if (!hasUrl && !hasBaseUrl) {
       return false;
     }
 
-    // Validate URL format
+    // Validate URL format (check whichever is provided)
     try {
-      new URL(cfg.url as string);
+      new URL((hasUrl ? cfg.url : cfg.base_url) as string);
       return true;
     } catch {
       return false;
@@ -68,13 +72,35 @@ export class HttpClientProvider extends CheckProvider {
     dependencyResults?: Map<string, ReviewSummary>,
     context?: import('./check-provider.interface').ExecutionContext
   ): Promise<ReviewSummary> {
-    const url = config.url as string;
+    const baseUrl = config.base_url as string | undefined;
+    const rawPath = config.path as string | undefined;
+    const pathParams = (config.params as Record<string, string>) || {};
+    const queryParams = (config.query as Record<string, string>) || {};
+    const authConfig = config.auth as AuthConfig | undefined;
+
+    // Build URL: either direct `url` or `base_url` + `path` with param substitution
+    let url: string;
+    if (baseUrl && rawPath) {
+      // Substitute {param} placeholders in path
+      let resolvedPath = rawPath;
+      for (const [key, value] of Object.entries(pathParams)) {
+        resolvedPath = resolvedPath.replace(`{${key}}`, encodeURIComponent(value));
+      }
+      url = `${baseUrl.replace(/\/+$/, '')}/${resolvedPath.replace(/^\/+/, '')}`;
+      // Append query parameters
+      if (Object.keys(queryParams).length > 0) {
+        const qs = new URLSearchParams(queryParams).toString();
+        url += `${url.includes('?') ? '&' : '?'}${qs}`;
+      }
+    } else {
+      url = config.url as string;
+    }
+
     const method = (config.method as string) || 'GET';
     const headers = (config.headers as Record<string, string>) || {};
     const timeout = (config.timeout as number) || 30000;
     const transform = config.transform as string | undefined;
     const transformJs = config.transform_js as string | undefined;
-    const bodyTemplate = config.body as string | undefined;
     const outputFileTemplate = config.output_file as string | undefined;
     const skipIfExists = config.skip_if_exists !== false; // Default true for caching
 
@@ -104,9 +130,13 @@ export class HttpClientProvider extends CheckProvider {
         resolvedUrlForErrors = renderedUrl; // Update after Liquid rendering
       }
 
-      // Prepare request body if provided
+      // Prepare request body — supports both Liquid template strings and JSON objects
       let requestBody: string | undefined;
-      if (bodyTemplate) {
+      const rawBody = config.body;
+      const bodyTemplate = typeof rawBody === 'string' ? rawBody : undefined;
+      if (rawBody && typeof rawBody === 'object') {
+        requestBody = JSON.stringify(rawBody);
+      } else if (bodyTemplate) {
         // First resolve shell-style environment variables
         let resolvedBody = String(EnvironmentResolver.resolveValue(bodyTemplate));
         // Then render Liquid templates if present
@@ -133,6 +163,13 @@ export class HttpClientProvider extends CheckProvider {
               : resolvedValue;
           logger.verbose(`[http_client] ${key}: ${maskedValue}`);
         }
+      }
+
+      // Inject OAuth2 Bearer token if auth config is provided
+      if (authConfig?.type === 'oauth2_client_credentials') {
+        const tokenCache = OAuth2TokenCache.getInstance();
+        const token = await tokenCache.getToken(authConfig);
+        resolvedHeaders['Authorization'] = `Bearer ${token}`;
       }
 
       // Resolve output_file path if specified
@@ -490,6 +527,11 @@ export class HttpClientProvider extends CheckProvider {
     return [
       'type',
       'url',
+      'base_url',
+      'path',
+      'params',
+      'query',
+      'auth',
       'method',
       'headers',
       'body',

--- a/src/utils/oauth2-token-cache.ts
+++ b/src/utils/oauth2-token-cache.ts
@@ -1,0 +1,170 @@
+import { logger } from '../logger';
+import { EnvironmentResolver } from './env-resolver';
+
+/**
+ * OAuth2 client_credentials auth configuration
+ */
+export interface OAuth2ClientCredentialsConfig {
+  type: 'oauth2_client_credentials';
+  /** OAuth2 token endpoint URL */
+  token_url: string;
+  /** OAuth2 client ID (supports ${ENV_VAR} syntax) */
+  client_id: string;
+  /** OAuth2 client secret (supports ${ENV_VAR} syntax) */
+  client_secret: string;
+  /** Optional scopes to request */
+  scopes?: string[];
+  /** Buffer in seconds before expiry to trigger refresh (default: 300 = 5 min) */
+  token_ttl_buffer?: number;
+}
+
+/**
+ * Generic auth configuration — extensible for future auth types
+ */
+export type AuthConfig = OAuth2ClientCredentialsConfig;
+
+interface CachedToken {
+  access_token: string;
+  expires_at: number; // Unix timestamp in ms
+  /** In-flight refresh promise to prevent concurrent token fetches */
+  refreshPromise?: Promise<string>;
+}
+
+/**
+ * Singleton cache for OAuth2 tokens.
+ *
+ * - Keyed by hash(token_url + client_id) to support multiple providers
+ * - Lazy refresh: only fetches when expired or near-expiry
+ * - Deduplicates concurrent requests: if two calls hit with an expired token,
+ *   both await the same fetch promise
+ */
+export class OAuth2TokenCache {
+  private static instance: OAuth2TokenCache;
+  private cache = new Map<string, CachedToken>();
+
+  static getInstance(): OAuth2TokenCache {
+    if (!OAuth2TokenCache.instance) {
+      OAuth2TokenCache.instance = new OAuth2TokenCache();
+    }
+    return OAuth2TokenCache.instance;
+  }
+
+  /** Visible for testing */
+  static resetInstance(): void {
+    OAuth2TokenCache.instance = undefined as unknown as OAuth2TokenCache;
+  }
+
+  /**
+   * Get a valid Bearer token for the given config.
+   * Returns a cached token if still valid, otherwise fetches a new one.
+   */
+  async getToken(config: OAuth2ClientCredentialsConfig): Promise<string> {
+    const clientId = String(EnvironmentResolver.resolveValue(config.client_id));
+    const clientSecret = String(EnvironmentResolver.resolveValue(config.client_secret));
+    const tokenUrl = String(EnvironmentResolver.resolveValue(config.token_url));
+    const bufferMs = (config.token_ttl_buffer ?? 300) * 1000;
+
+    const cacheKey = `${tokenUrl}|${clientId}`;
+    const cached = this.cache.get(cacheKey);
+
+    // Return cached token if still valid (with buffer)
+    if (cached && cached.expires_at - bufferMs > Date.now()) {
+      logger.verbose('[oauth2] Using cached token');
+      return cached.access_token;
+    }
+
+    // If another request is already refreshing, await it
+    if (cached?.refreshPromise) {
+      logger.verbose('[oauth2] Awaiting in-flight token refresh');
+      return cached.refreshPromise;
+    }
+
+    // Fetch a new token
+    const refreshPromise = this.fetchToken(tokenUrl, clientId, clientSecret, config.scopes);
+
+    // Store the promise so concurrent callers share it
+    if (cached) {
+      cached.refreshPromise = refreshPromise;
+    } else {
+      this.cache.set(cacheKey, {
+        access_token: '',
+        expires_at: 0,
+        refreshPromise,
+      });
+    }
+
+    try {
+      const token = await refreshPromise;
+      return token;
+    } finally {
+      // Clear the in-flight promise regardless of outcome
+      const entry = this.cache.get(cacheKey);
+      if (entry) {
+        entry.refreshPromise = undefined;
+      }
+    }
+  }
+
+  private async fetchToken(
+    tokenUrl: string,
+    clientId: string,
+    clientSecret: string,
+    scopes?: string[]
+  ): Promise<string> {
+    logger.verbose(`[oauth2] Fetching token from ${tokenUrl}`);
+
+    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+
+    const bodyParams = new URLSearchParams({ grant_type: 'client_credentials' });
+    if (scopes?.length) {
+      bodyParams.set('scope', scopes.join(' '));
+    }
+
+    const response = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${credentials}`,
+      },
+      body: bodyParams.toString(),
+    });
+
+    if (!response.ok) {
+      let errorDetail = '';
+      try {
+        errorDetail = await response.text();
+      } catch {}
+      throw new Error(
+        `OAuth2 token request failed: HTTP ${response.status} ${response.statusText}${errorDetail ? ` - ${errorDetail.substring(0, 200)}` : ''}`
+      );
+    }
+
+    const data = (await response.json()) as {
+      access_token: string;
+      expires_in?: number;
+      token_type?: string;
+    };
+
+    if (!data.access_token) {
+      throw new Error('OAuth2 token response missing access_token');
+    }
+
+    // Default to 1 hour if expires_in not provided
+    const expiresIn = data.expires_in ?? 3600;
+    const expiresAt = Date.now() + expiresIn * 1000;
+
+    const cacheKey = `${tokenUrl}|${clientId}`;
+    this.cache.set(cacheKey, {
+      access_token: data.access_token,
+      expires_at: expiresAt,
+    });
+
+    logger.verbose(`[oauth2] Token acquired, expires in ${expiresIn}s`);
+    return data.access_token;
+  }
+
+  /** Clear all cached tokens (for testing or credential rotation) */
+  clear(): void {
+    this.cache.clear();
+  }
+}

--- a/tests/unit/providers/http-client-provider.test.ts
+++ b/tests/unit/providers/http-client-provider.test.ts
@@ -4,6 +4,7 @@ import { ReviewSummary } from '../../../src/reviewer';
 // eslint-disable-next-line no-restricted-imports -- needed for type in test mock
 import { Liquid } from 'liquidjs';
 import { EnvironmentResolver } from '../../../src/utils/env-resolver';
+import { OAuth2TokenCache } from '../../../src/utils/oauth2-token-cache';
 
 // Mock fetch globally
 const mockFetch = jest.fn();
@@ -399,6 +400,210 @@ describe('HttpClientProvider', () => {
           }),
         })
       );
+    });
+  });
+
+  describe('base_url + path support', () => {
+    it('should build URL from base_url and path', async () => {
+      const config = {
+        type: 'http_client' as const,
+        base_url: 'https://cloud.mongodb.com/api/atlas/v2',
+        path: '/groups',
+        headers: { Accept: 'application/json' },
+      };
+
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: { get: jest.fn().mockReturnValue('application/json') },
+        json: jest.fn().mockResolvedValue({ results: [] }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await provider.execute(mockPRInfo, config, new Map());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://cloud.mongodb.com/api/atlas/v2/groups',
+        expect.any(Object)
+      );
+    });
+
+    it('should substitute path params', async () => {
+      const config = {
+        type: 'http_client' as const,
+        base_url: 'https://cloud.mongodb.com/api/atlas/v2',
+        path: '/groups/{groupId}/clusters/{clusterName}',
+        params: { groupId: 'abc123', clusterName: 'my-cluster' },
+        headers: {},
+      };
+
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: { get: jest.fn().mockReturnValue('application/json') },
+        json: jest.fn().mockResolvedValue({ name: 'my-cluster' }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await provider.execute(mockPRInfo, config, new Map());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://cloud.mongodb.com/api/atlas/v2/groups/abc123/clusters/my-cluster',
+        expect.any(Object)
+      );
+    });
+
+    it('should append query parameters', async () => {
+      const config = {
+        type: 'http_client' as const,
+        base_url: 'https://api.example.com/v2',
+        path: '/items',
+        query: { status: 'OPEN', limit: '10' },
+        headers: {},
+      };
+
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: { get: jest.fn().mockReturnValue('application/json') },
+        json: jest.fn().mockResolvedValue({ results: [] }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await provider.execute(mockPRInfo, config, new Map());
+
+      const calledUrl = mockFetch.mock.calls[0][0];
+      expect(calledUrl).toContain('https://api.example.com/v2/items?');
+      expect(calledUrl).toContain('status=OPEN');
+      expect(calledUrl).toContain('limit=10');
+    });
+
+    it('should handle trailing/leading slashes correctly', async () => {
+      const config = {
+        type: 'http_client' as const,
+        base_url: 'https://api.example.com/v2/',
+        path: '/items/',
+        headers: {},
+      };
+
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: { get: jest.fn().mockReturnValue('application/json') },
+        json: jest.fn().mockResolvedValue({}),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await provider.execute(mockPRInfo, config, new Map());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.example.com/v2/items/',
+        expect.any(Object)
+      );
+    });
+
+    it('should validate config with base_url instead of url', async () => {
+      const config = {
+        type: 'http_client' as const,
+        base_url: 'https://api.example.com/v2',
+      };
+
+      const isValid = await provider.validateConfig(config);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe('OAuth2 auth support', () => {
+    beforeEach(() => {
+      OAuth2TokenCache.resetInstance();
+    });
+
+    it('should inject Bearer token from OAuth2 auth config', async () => {
+      // Mock the OAuth2 token fetch
+      const tokenFetchResponse = {
+        ok: true,
+        json: async () => ({ access_token: 'oauth-token-xyz', expires_in: 3600 }),
+      };
+
+      const apiResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: { get: jest.fn().mockReturnValue('application/json') },
+        json: jest.fn().mockResolvedValue({ clusters: [] }),
+      };
+
+      // First call = OAuth token, second = API call
+      mockFetch.mockResolvedValueOnce(tokenFetchResponse).mockResolvedValueOnce(apiResponse);
+
+      const config = {
+        type: 'http_client' as const,
+        url: 'https://cloud.mongodb.com/api/atlas/v2/groups',
+        headers: { Accept: 'application/vnd.atlas.2025-03-12+json' },
+        auth: {
+          type: 'oauth2_client_credentials' as const,
+          token_url: 'https://cloud.mongodb.com/api/oauth/token',
+          client_id: 'my-client-id',
+          client_secret: 'my-client-secret',
+        },
+      };
+
+      await provider.execute(mockPRInfo, config, new Map());
+
+      // Verify token was fetched
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      // Verify the API call includes the Bearer token
+      const apiCallHeaders = mockFetch.mock.calls[1][1].headers;
+      expect(apiCallHeaders['Authorization']).toBe('Bearer oauth-token-xyz');
+      expect(apiCallHeaders['Accept']).toBe('application/vnd.atlas.2025-03-12+json');
+    });
+
+    it('should work with base_url + path + auth combined', async () => {
+      const tokenFetchResponse = {
+        ok: true,
+        json: async () => ({ access_token: 'combined-token', expires_in: 3600 }),
+      };
+
+      const apiResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: { get: jest.fn().mockReturnValue('application/json') },
+        json: jest.fn().mockResolvedValue({ name: 'my-cluster' }),
+      };
+
+      mockFetch.mockResolvedValueOnce(tokenFetchResponse).mockResolvedValueOnce(apiResponse);
+
+      const config = {
+        type: 'http_client' as const,
+        base_url: 'https://cloud.mongodb.com/api/atlas/v2',
+        path: '/groups/{groupId}/clusters',
+        params: { groupId: 'proj-123' },
+        query: { itemsPerPage: '5' },
+        headers: { Accept: 'application/vnd.atlas.2025-03-12+json' },
+        auth: {
+          type: 'oauth2_client_credentials' as const,
+          token_url: 'https://cloud.mongodb.com/api/oauth/token',
+          client_id: 'cid',
+          client_secret: 'csecret',
+        },
+      };
+
+      const result = await provider.execute(mockPRInfo, config, new Map());
+
+      expect(result.issues).toHaveLength(0);
+      // Verify URL was built correctly
+      const calledUrl = mockFetch.mock.calls[1][0];
+      expect(calledUrl).toBe(
+        'https://cloud.mongodb.com/api/atlas/v2/groups/proj-123/clusters?itemsPerPage=5'
+      );
+      // Verify auth header
+      expect(mockFetch.mock.calls[1][1].headers['Authorization']).toBe('Bearer combined-token');
     });
   });
 });

--- a/tests/unit/utils/oauth2-token-cache.test.ts
+++ b/tests/unit/utils/oauth2-token-cache.test.ts
@@ -1,0 +1,270 @@
+import {
+  OAuth2TokenCache,
+  OAuth2ClientCredentialsConfig,
+} from '../../../src/utils/oauth2-token-cache';
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Mock logger
+jest.mock('../../../src/logger', () => ({
+  logger: {
+    verbose: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+// Mock env-resolver
+jest.mock('../../../src/utils/env-resolver', () => ({
+  EnvironmentResolver: {
+    resolveValue: jest.fn((v: string) => v),
+  },
+}));
+
+describe('OAuth2TokenCache', () => {
+  const config: OAuth2ClientCredentialsConfig = {
+    type: 'oauth2_client_credentials',
+    token_url: 'https://cloud.mongodb.com/api/oauth/token',
+    client_id: 'test-client-id',
+    client_secret: 'test-client-secret',
+    token_ttl_buffer: 300,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    OAuth2TokenCache.resetInstance();
+  });
+
+  it('fetches a new token on first call', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'new-token-123',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      }),
+    });
+
+    const cache = OAuth2TokenCache.getInstance();
+    const token = await cache.getToken(config);
+
+    expect(token).toBe('new-token-123');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Verify the fetch call
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://cloud.mongodb.com/api/oauth/token');
+    expect(options.method).toBe('POST');
+    expect(options.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+    expect(options.headers['Authorization']).toMatch(/^Basic /);
+    expect(options.body).toBe('grant_type=client_credentials');
+  });
+
+  it('returns cached token on subsequent calls', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'cached-token',
+        expires_in: 3600,
+      }),
+    });
+
+    const cache = OAuth2TokenCache.getInstance();
+    const token1 = await cache.getToken(config);
+    const token2 = await cache.getToken(config);
+
+    expect(token1).toBe('cached-token');
+    expect(token2).toBe('cached-token');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes token when expired', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'old-token',
+          expires_in: 1, // expires in 1 second
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-token',
+          expires_in: 3600,
+        }),
+      });
+
+    const cache = OAuth2TokenCache.getInstance();
+
+    // Use a config with 0 buffer so the token expires after 1s
+    const shortConfig = { ...config, token_ttl_buffer: 0 };
+    await cache.getToken(shortConfig);
+
+    // Wait for token to expire
+    await new Promise(resolve => setTimeout(resolve, 1100));
+
+    const token = await cache.getToken(shortConfig);
+    expect(token).toBe('new-token');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes token when within buffer period', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'expiring-token',
+          expires_in: 200, // 200 seconds — within 300s buffer
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'fresh-token',
+          expires_in: 3600,
+        }),
+      });
+
+    const cache = OAuth2TokenCache.getInstance();
+    await cache.getToken(config);
+
+    // Second call should refresh because 200s < 300s buffer
+    const token = await cache.getToken(config);
+    expect(token).toBe('fresh-token');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates concurrent token fetches', async () => {
+    let resolveToken: (v: unknown) => void;
+    const tokenPromise = new Promise(resolve => {
+      resolveToken = resolve;
+    });
+
+    mockFetch.mockImplementationOnce(async () => {
+      await tokenPromise;
+      return {
+        ok: true,
+        json: async () => ({
+          access_token: 'shared-token',
+          expires_in: 3600,
+        }),
+      };
+    });
+
+    const cache = OAuth2TokenCache.getInstance();
+    const promise1 = cache.getToken(config);
+    const promise2 = cache.getToken(config);
+
+    // Release the fetch
+    resolveToken!(undefined);
+
+    const [token1, token2] = await Promise.all([promise1, promise2]);
+    expect(token1).toBe('shared-token');
+    expect(token2).toBe('shared-token');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on HTTP error', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: async () => 'Invalid credentials',
+    });
+
+    const cache = OAuth2TokenCache.getInstance();
+    await expect(cache.getToken(config)).rejects.toThrow('OAuth2 token request failed: HTTP 401');
+  });
+
+  it('throws on missing access_token', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    const cache = OAuth2TokenCache.getInstance();
+    await expect(cache.getToken(config)).rejects.toThrow('missing access_token');
+  });
+
+  it('sends scopes when configured', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'scoped-token',
+        expires_in: 3600,
+      }),
+    });
+
+    const cache = OAuth2TokenCache.getInstance();
+    await cache.getToken({ ...config, scopes: ['read', 'write'] });
+
+    const body = mockFetch.mock.calls[0][1].body;
+    expect(body).toContain('scope=read+write');
+  });
+
+  it('uses base64-encoded client_id:client_secret', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'token',
+        expires_in: 3600,
+      }),
+    });
+
+    const cache = OAuth2TokenCache.getInstance();
+    await cache.getToken(config);
+
+    const expectedBasic = Buffer.from('test-client-id:test-client-secret').toString('base64');
+    const authHeader = mockFetch.mock.calls[0][1].headers['Authorization'];
+    expect(authHeader).toBe(`Basic ${expectedBasic}`);
+  });
+
+  it('clear() removes all cached tokens', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: 'token',
+        expires_in: 3600,
+      }),
+    });
+
+    const cache = OAuth2TokenCache.getInstance();
+    await cache.getToken(config);
+    cache.clear();
+
+    // Should fetch again after clear
+    await cache.getToken(config);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('supports multiple providers with different cache keys', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'token-a', expires_in: 3600 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'token-b', expires_in: 3600 }),
+      });
+
+    const configB = {
+      ...config,
+      token_url: 'https://other-provider.com/oauth/token',
+      client_id: 'other-client',
+    };
+
+    const cache = OAuth2TokenCache.getInstance();
+    const tokenA = await cache.getToken(config);
+    const tokenB = await cache.getToken(configB);
+
+    expect(tokenA).toBe('token-a');
+    expect(tokenB).toBe('token-b');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds first-class OAuth2 `client_credentials` authentication to the `http_client` provider, eliminating the need for bash+curl workarounds when integrating with OAuth2-protected APIs (e.g. MongoDB Atlas)
- Adds `base_url` + `path` + `params` + `query` support for building URLs from parts with `{placeholder}` substitution — enables structured API tool definitions
- Token cache is singleton, keyed by `token_url + client_id`, with near-expiry refresh (5 min buffer), concurrent request deduplication, and TTL read from OAuth response

### New config options on `http_client`

```yaml
auth:
  type: oauth2_client_credentials
  token_url: "https://cloud.mongodb.com/api/oauth/token"
  client_id: "${MONGO_ATLAS_CLIENT_ID}"
  client_secret: "${MONGO_ATLAS_CLIENT_SECRET}"
  scopes: ["read"]                    # optional
  token_ttl_buffer: 300               # optional, seconds before expiry to refresh

base_url: "https://cloud.mongodb.com/api/atlas/v2"
path: "/groups/{groupId}/clusters"
params: { groupId: "abc123" }
query: { itemsPerPage: "10" }
```

## Test plan

- [x] 11 new tests for `OAuth2TokenCache` (token fetch, caching, expiry, buffer refresh, concurrent dedup, errors, scopes, multi-provider)
- [x] 7 new tests for `HttpClientProvider` (base_url+path building, param substitution, query params, slash handling, validation, OAuth2 injection, combined flow)
- [x] All 19 existing `http-client-provider` tests still pass
- [x] All 117 pre-commit YAML tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)