### PR TITLE
fix: preserve sandboxes when converting standalone workflow files to config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -557,6 +557,12 @@ export class ConfigManager {
     if (workflowData.on) {
       (visorConfig as any).on = workflowData.on;
     }
+    if (workflowData.sandboxes) {
+      visorConfig.sandboxes = workflowData.sandboxes;
+    }
+    if (workflowData.sandbox) {
+      visorConfig.sandbox = workflowData.sandbox;
+    }
 
     logger.debug(
       `Standalone workflow config has ${Object.keys(workflowSteps).length} workflow steps as checks`

--- a/tests/unit/sandbox-config-validation.test.ts
+++ b/tests/unit/sandbox-config-validation.test.ts
@@ -376,4 +376,32 @@ describe('Sandbox Config Validation', () => {
     expect(result.sandboxes).toBeUndefined();
     expect(result.sandbox).toBeUndefined();
   });
+
+  it('should accept sandboxes defined in standalone workflow files', async () => {
+    // Standalone workflow files have `id` and `steps` instead of `checks`
+    const workflowData = {
+      id: 'test-workflow',
+      name: 'Test Workflow',
+      version: '1.0',
+      sandboxes: {
+        'bwrap-env': {
+          engine: 'bubblewrap',
+          network: true,
+        },
+      },
+      steps: {
+        'my-task': {
+          type: 'command',
+          exec: 'echo hello',
+          sandbox: 'bwrap-env',
+        },
+      },
+    };
+
+    // loadConfigFromObject detects `id` and calls convertWorkflowToConfig
+    const result = await configManager.loadConfigFromObject(workflowData as any);
+    expect(result.sandboxes).toBeDefined();
+    expect(result.sandboxes!['bwrap-env']).toBeDefined();
+    expect(result.checks['my-task'].sandbox).toBe('bwrap-env');
+  });
 });


### PR DESCRIPTION
## Summary
- Fixed `convertWorkflowToConfig()` in `src/config.ts` to propagate `sandboxes` and `sandbox` fields when converting standalone workflow files to VisorConfig
- Root cause: the method copies workflow fields into VisorConfig shape but was missing these two fields, causing the validator to reject workflows that define/reference sandboxes
- Added test case in `sandbox-config-validation.test.ts` to verify sandboxes work in standalone workflow files

Fixes #459

## Test plan
- [x] Added unit test: "should accept sandboxes defined in standalone workflow files"
- [x] All 117 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)