### PR TITLE
feat: add fair round-robin AI concurrency limiter

### DIFF
--- a/src/frontends/github-frontend.ts
+++ b/src/frontends/github-frontend.ts
@@ -303,8 +303,18 @@ ${end}`);
     this.updateLocks.set(group, ourLock);
 
     try {
-      // Wait for the previous lock to complete (if any)
+      // Wait for the previous update to complete (if any)
       if (existingLock) {
+        logger.info(
+          `[github-frontend] Comment update for group "${group}" queued, waiting for previous update to finish...`
+        );
+        const queuedAt = Date.now();
+        const reminder = setInterval(() => {
+          const waited = Math.round((Date.now() - queuedAt) / 1000);
+          logger.info(
+            `[github-frontend] Comment update for group "${group}" still queued (${waited}s).`
+          );
+        }, 10000);
         try {
           await existingLock;
         } catch (error) {
@@ -312,6 +322,14 @@ ${end}`);
             `[github-frontend] Previous update for group ${group} failed: ${error instanceof Error ? error.message : error}`
           );
           // Continue with current update despite previous failure
+        } finally {
+          clearInterval(reminder);
+          const waitedMs = Date.now() - queuedAt;
+          if (waitedMs > 100) {
+            logger.info(
+              `[github-frontend] Comment update for group "${group}" dequeued after ${Math.round(waitedMs / 1000)}s.`
+            );
+          }
         }
       }
 

--- a/src/state-machine/context/build-engine-context.ts
+++ b/src/state-machine/context/build-engine-context.ts
@@ -7,20 +7,7 @@ import { generateHumanId } from '../../utils/human-id';
 import { logger } from '../../logger';
 import type { VisorConfig as VCfg, CheckConfig as CfgCheck } from '../../types/config';
 import { WorkspaceManager } from '../../utils/workspace-manager';
-
-// Lazy-resolve DelegationManager from @probelabs/probe.
-// The class may not be exported in older published versions, so we
-// fall back gracefully to avoid breaking the build.
-let _DelegationManager: (new (opts?: any) => any) | null = null;
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const probe = require('@probelabs/probe');
-  if (probe && typeof probe.DelegationManager === 'function') {
-    _DelegationManager = probe.DelegationManager;
-  }
-} catch {
-  // Not available — max_ai_concurrency will be silently ignored
-}
+import { FairConcurrencyLimiter } from '../../utils/fair-concurrency-limiter';
 
 /**
  * Apply minimal criticality defaults in-place.
@@ -113,16 +100,40 @@ export function buildEngineContextForRun(
   const journal = new ExecutionJournal();
   const memory = MemoryStore.getInstance(clonedConfig.memory);
 
-  // Create shared AI concurrency limiter if configured
+  // Create shared AI concurrency limiter if configured.
+  // Uses a global singleton fair limiter: round-robin across sessions so
+  // no single user/task can starve others.
   let sharedConcurrencyLimiter: any = undefined;
-  if (clonedConfig.max_ai_concurrency && _DelegationManager) {
-    sharedConcurrencyLimiter = new _DelegationManager({
-      maxConcurrent: clonedConfig.max_ai_concurrency,
-      maxPerSession: 999, // No per-session limit needed for global AI gating
-    });
-    logger.debug(
-      `[EngineContext] Created shared AI concurrency limiter (max: ${clonedConfig.max_ai_concurrency})`
-    );
+  const sessionId = generateHumanId();
+  if (clonedConfig.max_ai_concurrency) {
+    const fairLimiter = FairConcurrencyLimiter.getInstance(clonedConfig.max_ai_concurrency);
+    // Bind this engine run's session ID into acquire/release so the fair limiter
+    // knows which user/task each call belongs to. Probe calls acquire(null) —
+    // we intercept and inject our session ID.
+    sharedConcurrencyLimiter = {
+      async acquire(parentSessionId: any, _dbg?: boolean, queueTimeout?: number | null) {
+        // Use visor session ID if probe didn't provide one
+        const sid = parentSessionId || sessionId;
+        return fairLimiter.acquire(sid, _dbg, queueTimeout);
+      },
+      release(parentSessionId: any, _dbg?: boolean) {
+        const sid = parentSessionId || sessionId;
+        return fairLimiter.release(sid, _dbg);
+      },
+      tryAcquire(parentSessionId: any) {
+        const sid = parentSessionId || sessionId;
+        return fairLimiter.tryAcquire(sid);
+      },
+      getStats() {
+        return fairLimiter.getStats();
+      },
+      shutdown() {
+        // Don't destroy the singleton — other sessions may still use it
+      },
+      cleanup() {
+        // Don't destroy the singleton — other sessions may still use it
+      },
+    };
   }
 
   return {
@@ -133,7 +144,7 @@ export function buildEngineContextForRun(
     memory,
     workingDirectory,
     originalWorkingDirectory: workingDirectory,
-    sessionId: generateHumanId(),
+    sessionId,
     event: prInfo.eventType,
     debug,
     maxParallelism,

--- a/src/state-machine/states/level-dispatch.ts
+++ b/src/state-machine/states/level-dispatch.ts
@@ -481,7 +481,32 @@ async function executeCheckGroup(
 
     // Wait if pool is full
     if (pool.length >= maxParallelism) {
-      await Promise.race(pool);
+      const activeCount = pool.filter(p => !(p as any)._settled).length;
+      logger.info(
+        `[LevelDispatch] Check pool full (${activeCount}/${maxParallelism} active). ` +
+          `Check "${checkId}" queued, waiting for a slot...`
+      );
+      const queuedAt = Date.now();
+      // Periodic reminder while waiting
+      const reminder = setInterval(() => {
+        const waited = Math.round((Date.now() - queuedAt) / 1000);
+        const stillActive = pool.filter(p => !(p as any)._settled).length;
+        logger.info(
+          `[LevelDispatch] Check "${checkId}" still queued (${waited}s). ` +
+            `${stillActive}/${maxParallelism} slots busy.`
+        );
+      }, 15000);
+      try {
+        await Promise.race(pool);
+      } finally {
+        clearInterval(reminder);
+      }
+      const waitedMs = Date.now() - queuedAt;
+      if (waitedMs > 100) {
+        logger.info(
+          `[LevelDispatch] Check "${checkId}" dequeued after ${Math.round(waitedMs / 1000)}s wait.`
+        );
+      }
       // Remove completed promises
       pool.splice(
         0,

--- a/src/utils/fair-concurrency-limiter.ts
+++ b/src/utils/fair-concurrency-limiter.ts
@@ -1,0 +1,292 @@
+/**
+ * Fair round-robin concurrency limiter.
+ *
+ * Single global limiter for all AI/delegation calls in the process.
+ * Instead of FIFO (which lets one session hog all slots), this grants
+ * slots in round-robin order across sessions so every user gets fair access.
+ *
+ * Usage:
+ *   const limiter = FairConcurrencyLimiter.getInstance(maxConcurrent);
+ *   await limiter.acquire(sessionId);  // blocks until slot available
+ *   try { ... } finally { limiter.release(sessionId); }
+ */
+
+import { logger } from '../logger';
+
+interface WaitEntry {
+  resolve: (value: boolean) => void;
+  reject: (error: Error) => void;
+  queuedAt: number;
+  reminder?: ReturnType<typeof setInterval>;
+}
+
+export class FairConcurrencyLimiter {
+  private maxConcurrent: number;
+  private globalActive = 0;
+
+  // Per-session FIFO queues
+  private sessionQueues = new Map<string, WaitEntry[]>();
+  // Round-robin order of sessions with waiting entries
+  private roundRobinSessions: string[] = [];
+  private roundRobinIndex = 0;
+
+  // Per-session active count (for stats)
+  private sessionActive = new Map<string, number>();
+
+  constructor(maxConcurrent: number) {
+    this.maxConcurrent = maxConcurrent;
+  }
+
+  static getInstance(maxConcurrent: number): FairConcurrencyLimiter {
+    const key = Symbol.for('visor.fairConcurrencyLimiter');
+    let instance = (globalThis as any)[key] as FairConcurrencyLimiter | undefined;
+    if (!instance) {
+      instance = new FairConcurrencyLimiter(maxConcurrent);
+      (globalThis as any)[key] = instance;
+      logger.info(`[FairLimiter] Created global fair concurrency limiter (max: ${maxConcurrent})`);
+    } else if (instance.maxConcurrent !== maxConcurrent) {
+      // Config changed — update max (live resize)
+      const old = instance.maxConcurrent;
+      instance.maxConcurrent = maxConcurrent;
+      logger.info(`[FairLimiter] Updated max concurrency: ${old} -> ${maxConcurrent}`);
+      // Process queue in case new slots opened up
+      instance._processQueue();
+    }
+    return instance;
+  }
+
+  /**
+   * Try to acquire a slot immediately (non-blocking).
+   */
+  tryAcquire(sessionId?: string | null): boolean {
+    if (this.globalActive >= this.maxConcurrent) {
+      return false;
+    }
+    this.globalActive++;
+    const sid = sessionId || '__anonymous__';
+    this.sessionActive.set(sid, (this.sessionActive.get(sid) || 0) + 1);
+    return true;
+  }
+
+  /**
+   * Acquire a slot, waiting in a fair queue if necessary.
+   * Sessions are served round-robin so no single session can starve others.
+   */
+  async acquire(
+    sessionId?: string | null,
+    _debug?: boolean,
+    queueTimeout?: number | null
+  ): Promise<boolean> {
+    const sid = sessionId || '__anonymous__';
+
+    // Fast path — slot available
+    if (this.tryAcquire(sid)) {
+      return true;
+    }
+
+    // Compute queue stats for logging
+    const totalQueued = this._totalQueued();
+    const sessionsWaiting = this.sessionQueues.size;
+    const sessionQueueLen = this.sessionQueues.get(sid)?.length || 0;
+    logger.info(
+      `[FairLimiter] Slot unavailable (${this.globalActive}/${this.maxConcurrent} active). ` +
+        `Session "${sid}" queued (${sessionQueueLen} own + ${totalQueued} total across ${sessionsWaiting} sessions). Waiting...`
+    );
+
+    const queuedAt = Date.now();
+    const effectiveTimeout = queueTimeout ?? 120000; // default 2 min
+
+    return new Promise<boolean>((resolve, reject) => {
+      const entry: WaitEntry = { resolve, reject, queuedAt };
+
+      // Periodic reminder every 15s
+      entry.reminder = setInterval(() => {
+        const waited = Math.round((Date.now() - queuedAt) / 1000);
+        const curQueued = this._totalQueued();
+        const curSessions = this._waitingSessions();
+        logger.info(
+          `[FairLimiter] Session "${sid}" still waiting (${waited}s). ` +
+            `${this.globalActive}/${this.maxConcurrent} active, ` +
+            `${curQueued} queued across ${curSessions} sessions.`
+        );
+      }, 15000);
+
+      // Add to this session's queue
+      let queue = this.sessionQueues.get(sid);
+      if (!queue) {
+        queue = [];
+        this.sessionQueues.set(sid, queue);
+        // Add to round-robin rotation
+        this.roundRobinSessions.push(sid);
+      }
+      queue.push(entry);
+
+      // Timeout
+      if (effectiveTimeout > 0) {
+        setTimeout(() => {
+          // Remove from queue if still there
+          const q = this.sessionQueues.get(sid);
+          if (q) {
+            const idx = q.indexOf(entry);
+            if (idx !== -1) {
+              q.splice(idx, 1);
+              if (q.length === 0) {
+                this.sessionQueues.delete(sid);
+                this._removeFromRoundRobin(sid);
+              }
+              this._clearReminder(entry);
+              reject(
+                new Error(
+                  `[FairLimiter] Queue timeout: session "${sid}" waited ${effectiveTimeout}ms for a slot`
+                )
+              );
+            }
+          }
+        }, effectiveTimeout);
+      }
+    });
+  }
+
+  /**
+   * Release a slot and grant the next one fairly (round-robin across sessions).
+   */
+  release(sessionId?: string | null, _debug?: boolean): void {
+    const sid = sessionId || '__anonymous__';
+    this.globalActive = Math.max(0, this.globalActive - 1);
+
+    const active = this.sessionActive.get(sid);
+    if (active !== undefined) {
+      if (active <= 1) {
+        this.sessionActive.delete(sid);
+      } else {
+        this.sessionActive.set(sid, active - 1);
+      }
+    }
+
+    this._processQueue();
+  }
+
+  /**
+   * Round-robin queue processing: cycle through sessions and grant one slot per session per round.
+   */
+  private _processQueue(): void {
+    const toGrant: Array<{ entry: WaitEntry; sid: string }> = [];
+
+    while (this.globalActive < this.maxConcurrent && this.roundRobinSessions.length > 0) {
+      // Wrap index
+      if (this.roundRobinIndex >= this.roundRobinSessions.length) {
+        this.roundRobinIndex = 0;
+      }
+
+      const sid = this.roundRobinSessions[this.roundRobinIndex];
+      const queue = this.sessionQueues.get(sid);
+
+      if (!queue || queue.length === 0) {
+        // Session has no more waiters — remove from rotation
+        this.sessionQueues.delete(sid);
+        this.roundRobinSessions.splice(this.roundRobinIndex, 1);
+        // Don't increment index — next session slides into this position
+        continue;
+      }
+
+      // Grant the oldest entry from this session
+      const entry = queue.shift()!;
+      if (queue.length === 0) {
+        this.sessionQueues.delete(sid);
+        this.roundRobinSessions.splice(this.roundRobinIndex, 1);
+        // Don't increment — next session slides in
+      } else {
+        this.roundRobinIndex++;
+      }
+
+      this.globalActive++;
+      this.sessionActive.set(sid, (this.sessionActive.get(sid) || 0) + 1);
+      toGrant.push({ entry, sid });
+    }
+
+    // Resolve outside the loop to avoid reentrancy issues
+    for (const { entry, sid } of toGrant) {
+      this._clearReminder(entry);
+      const waitedMs = Date.now() - entry.queuedAt;
+      if (waitedMs > 100) {
+        logger.info(
+          `[FairLimiter] Session "${sid}" acquired slot after ${Math.round(waitedMs / 1000)}s wait.`
+        );
+      }
+      // Defer to next tick to avoid blocking event loop
+      setImmediate(() => entry.resolve(true));
+    }
+  }
+
+  getStats(): {
+    globalActive: number;
+    maxConcurrent: number;
+    queueSize: number;
+    waitingSessions: number;
+    perSession: Record<string, { active: number; queued: number }>;
+  } {
+    const perSession: Record<string, { active: number; queued: number }> = {};
+    const allSessions = new Set([...this.sessionActive.keys(), ...this.sessionQueues.keys()]);
+    for (const sid of allSessions) {
+      perSession[sid] = {
+        active: this.sessionActive.get(sid) || 0,
+        queued: this.sessionQueues.get(sid)?.length || 0,
+      };
+    }
+    return {
+      globalActive: this.globalActive,
+      maxConcurrent: this.maxConcurrent,
+      queueSize: this._totalQueued(),
+      waitingSessions: this._waitingSessions(),
+      perSession,
+    };
+  }
+
+  cleanup(): void {
+    // Clear all reminders
+    for (const queue of this.sessionQueues.values()) {
+      for (const entry of queue) {
+        this._clearReminder(entry);
+      }
+    }
+    this.sessionQueues.clear();
+    this.roundRobinSessions = [];
+    this.roundRobinIndex = 0;
+    // Remove singleton
+    const key = Symbol.for('visor.fairConcurrencyLimiter');
+    delete (globalThis as any)[key];
+  }
+
+  shutdown(): void {
+    this.cleanup();
+  }
+
+  // -- helpers --
+
+  private _totalQueued(): number {
+    let n = 0;
+    for (const q of this.sessionQueues.values()) n += q.length;
+    return n;
+  }
+
+  private _waitingSessions(): number {
+    return this.roundRobinSessions.length;
+  }
+
+  private _removeFromRoundRobin(sid: string): void {
+    const idx = this.roundRobinSessions.indexOf(sid);
+    if (idx !== -1) {
+      this.roundRobinSessions.splice(idx, 1);
+      if (this.roundRobinIndex > idx) {
+        this.roundRobinIndex--;
+      }
+    }
+  }
+
+  private _clearReminder(entry: WaitEntry): void {
+    if (entry.reminder) {
+      clearInterval(entry.reminder);
+      entry.reminder = undefined;
+    }
+  }
+}

--- a/src/utils/interactive-prompt.ts
+++ b/src/utils/interactive-prompt.ts
@@ -17,7 +17,27 @@ async function acquirePromptLock(): Promise<void> {
     activePrompt = true;
     return;
   }
-  await new Promise<void>(resolve => waiters.push(resolve));
+  console.error(
+    `[human-input] Prompt queued, waiting for active prompt to finish (${waiters.length} already waiting).`
+  );
+  const queuedAt = Date.now();
+  const reminder = setInterval(() => {
+    const waited = Math.round((Date.now() - queuedAt) / 1000);
+    console.error(
+      `[human-input] Still waiting for prompt lock (${waited}s, ${waiters.length} in queue).`
+    );
+  }, 10000);
+  try {
+    await new Promise<void>(resolve => waiters.push(resolve));
+  } finally {
+    clearInterval(reminder);
+    const waitedMs = Date.now() - queuedAt;
+    if (waitedMs > 100) {
+      console.error(
+        `[human-input] Prompt lock acquired after ${Math.round(waitedMs / 1000)}s wait.`
+      );
+    }
+  }
   activePrompt = true;
 }
 

--- a/tests/unit/fair-concurrency-limiter.test.ts
+++ b/tests/unit/fair-concurrency-limiter.test.ts
@@ -1,0 +1,140 @@
+import { FairConcurrencyLimiter } from '../../src/utils/fair-concurrency-limiter';
+
+jest.mock('../../src/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('FairConcurrencyLimiter', () => {
+  let limiter: FairConcurrencyLimiter;
+
+  beforeEach(() => {
+    limiter = new FairConcurrencyLimiter(3);
+  });
+
+  afterEach(() => {
+    limiter.cleanup();
+  });
+
+  it('allows immediate acquisition when slots available', async () => {
+    expect(await limiter.acquire('session-a')).toBe(true);
+    expect(limiter.getStats().globalActive).toBe(1);
+  });
+
+  it('blocks when all slots are full', async () => {
+    await limiter.acquire('a');
+    await limiter.acquire('a');
+    await limiter.acquire('a');
+    expect(limiter.getStats().globalActive).toBe(3);
+
+    let resolved = false;
+    const p = limiter.acquire('b', false, 5000).then(() => {
+      resolved = true;
+    });
+
+    // Give it a tick — should NOT resolve
+    await new Promise(r => setTimeout(r, 50));
+    expect(resolved).toBe(false);
+    expect(limiter.getStats().queueSize).toBe(1);
+
+    // Release one — should resolve
+    limiter.release('a');
+    await p;
+    expect(resolved).toBe(true);
+  });
+
+  it('round-robins across sessions fairly', async () => {
+    // Fill all 3 slots with session A
+    await limiter.acquire('a');
+    await limiter.acquire('a');
+    await limiter.acquire('a');
+
+    // Queue: 2 from A, 2 from B — interleaved
+    const order: string[] = [];
+    const pA1 = limiter.acquire('a', false, 5000).then(() => order.push('a'));
+    const pB1 = limiter.acquire('b', false, 5000).then(() => order.push('b'));
+    const pA2 = limiter.acquire('a', false, 5000).then(() => order.push('a'));
+    const pB2 = limiter.acquire('b', false, 5000).then(() => order.push('b'));
+
+    await new Promise(r => setTimeout(r, 50));
+    expect(limiter.getStats().queueSize).toBe(4);
+
+    // Release all 3 slots — should grant round-robin: a, b, a (3 slots)
+    limiter.release('a');
+    limiter.release('a');
+    limiter.release('a');
+
+    // Wait for all grants to settle
+    await Promise.all(
+      [pA1, pB1, pA2, pB2].map(p => Promise.race([p, new Promise(r => setTimeout(r, 200))]))
+    );
+
+    // First 3 granted should alternate: a, b, a (round-robin)
+    // The 4th (b) waits since all 3 slots are re-filled
+    expect(order.length).toBeGreaterThanOrEqual(3);
+    // Check fairness: both sessions should get at least 1 slot in the first 3 grants
+    const aCount = order.slice(0, 3).filter(s => s === 'a').length;
+    const bCount = order.slice(0, 3).filter(s => s === 'b').length;
+    expect(aCount).toBeGreaterThanOrEqual(1);
+    expect(bCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('tryAcquire returns false when full', () => {
+    expect(limiter.tryAcquire('a')).toBe(true);
+    expect(limiter.tryAcquire('a')).toBe(true);
+    expect(limiter.tryAcquire('a')).toBe(true);
+    expect(limiter.tryAcquire('b')).toBe(false);
+  });
+
+  it('release decrements counters', async () => {
+    await limiter.acquire('a');
+    await limiter.acquire('b');
+    expect(limiter.getStats().globalActive).toBe(2);
+
+    limiter.release('a');
+    expect(limiter.getStats().globalActive).toBe(1);
+
+    limiter.release('b');
+    expect(limiter.getStats().globalActive).toBe(0);
+  });
+
+  it('getStats shows per-session breakdown', async () => {
+    await limiter.acquire('user-1');
+    await limiter.acquire('user-1');
+    await limiter.acquire('user-2');
+
+    const stats = limiter.getStats();
+    expect(stats.globalActive).toBe(3);
+    expect(stats.perSession['user-1'].active).toBe(2);
+    expect(stats.perSession['user-2'].active).toBe(1);
+  });
+
+  it('queue timeout rejects', async () => {
+    await limiter.acquire('a');
+    await limiter.acquire('a');
+    await limiter.acquire('a');
+
+    await expect(limiter.acquire('b', false, 100)).rejects.toThrow(/Queue timeout/);
+  });
+
+  it('singleton via getInstance', () => {
+    const a = FairConcurrencyLimiter.getInstance(5);
+    const b = FairConcurrencyLimiter.getInstance(5);
+    expect(a).toBe(b);
+    a.cleanup(); // remove singleton
+  });
+
+  it('getInstance updates maxConcurrent on change', () => {
+    const a = FairConcurrencyLimiter.getInstance(5);
+    expect(a.getStats().maxConcurrent).toBe(5);
+
+    const b = FairConcurrencyLimiter.getInstance(10);
+    expect(b).toBe(a);
+    expect(b.getStats().maxConcurrent).toBe(10);
+    a.cleanup();
+  });
+});


### PR DESCRIPTION
## Summary

- New `FairConcurrencyLimiter` — global singleton that replaces probe's FIFO `DelegationManager` for AI call gating
- **Round-robin across sessions** so no single user can starve others
- **Always-on queue logging** for all concurrency mechanisms (no more silent blocking)

## Problem

When multiple users are active in Slack mode, probe's `DelegationManager` uses a global FIFO queue. One user's burst of `search.delegate` calls can consume all slots, pushing other users to the back of the queue with zero log output.

Observed in production: `[DelegationManager] Slot unavailable (10/10), queuing... (queue size: 15)` — one session hogging all slots while others silently wait.

## Solution

### Fair concurrency limiter (`src/utils/fair-concurrency-limiter.ts`)

- **Global singleton** via `globalThis` — shared across all engine runs in the process
- **Round-robin queue**: when slots free up, cycles through sessions (`A→B→A→B`) instead of FIFO (`A→A→A→B`)
- **Always-on logging**: logs on queue entry, every 15s while waiting, on acquisition
- **Per-session stats**: `getStats()` shows active/queued breakdown per session
- Activated via `max_ai_concurrency` config option

### Queue logging for all blocking mechanisms

Every place visor blocks now logs clearly:

| Mechanism | File | What's logged |
|-----------|------|---------------|
| Check execution pool | `level-dispatch.ts` | `Check "X" queued, waiting for a slot...` + 15s reminders |
| GitHub comment mutex | `github-frontend.ts` | `Comment update for group "X" queued...` + 10s reminders |
| Interactive prompt lock | `interactive-prompt.ts` | `Prompt queued, waiting...` + 10s reminders |
| AI concurrency | `fair-concurrency-limiter.ts` | `Session "X" queued (N own + M total)...` + 15s reminders |

### Session ID injection

`build-engine-context.ts` binds visor's session ID into the limiter wrapper. When probe calls `acquire(null)`, the wrapper injects the correct session, enabling fair scheduling.

## Usage

```yaml
# visor config
max_ai_concurrency: 10
```

```bash
# .env — disable probe's redundant per-agent FIFO limiter
MAX_CONCURRENT_DELEGATIONS=999
MAX_DELEGATIONS_PER_SESSION=999
```

## Test plan

- [x] `npm run build` passes
- [x] All 291 test suites pass (2920 tests)
- [x] New `tests/unit/fair-concurrency-limiter.test.ts` — 9 tests covering:
  - Immediate acquisition, blocking when full, round-robin fairness
  - tryAcquire, release, per-session stats, queue timeout
  - Singleton behavior, live max concurrency resize

## Related

- probelabs/probe#487 — Silent blocking in probe's concurrency mechanisms
- probelabs/probe#486 — search.delegate performance issues
- TykTechnologies/REFINE#98 — Oel config: `max_ai_concurrency: 10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)