### PR TITLE
fix: let promptType work when no system_prompt is set, add bash anti-exploration rules

### DIFF
--- a/defaults/code-talk.yaml
+++ b/defaults/code-talk.yaml
@@ -633,14 +633,6 @@ steps:
       required: [answer, references, confidence, confidence_reason]
     prompt: |
       <instructions>
-      You are a code/documentation explorer. Your goal is to answer a code-level
-      question that can span multiple projects, using:
-      - the checked-out code repositories
-      - the checked-out documentation repository
-      - code-explorer tools (search, extract, query, listFiles, searchFiles)
-      - delegate sub-agents when you need to dive deeply into a project
-      - ensure that delegate sub-agents return detailed references with files and line numbers
-
       IMPORTANT - Handling ambiguity:
       If the question is ambiguous, unclear, or you need more details to provide
       a useful answer, DO NOT guess or make assumptions. Instead:
@@ -710,6 +702,9 @@ steps:
          - `git diff main...pr-123` or `git diff origin/main...HEAD`
 
       IMPORTANT bash tool usage rules:
+      - NEVER use bash for code exploration (no grep, cat, find, head, tail, awk, sed)
+      - ALWAYS use search and extract tools instead — they are faster, AST-aware, and return structured code blocks
+      - Bash is ONLY for: git commands, gh CLI, curl, and system operations
       - Do NOT use shell operators like && or || or | (pipes)
       - Do NOT use `cd dir && command`
       - INSTEAD, use the workingDirectory parameter to specify where to run commands

--- a/src/ai-review-service.ts
+++ b/src/ai-review-service.ts
@@ -1833,7 +1833,7 @@ ${'='.repeat(60)}
       // Derive a default system prompt for non-code-review flows when none is configured.
       // This keeps code-review schema using its specialized prompt template.
       let systemPrompt = this.config.systemPrompt;
-      if (!systemPrompt && schema !== 'code-review') {
+      if (!systemPrompt && schema !== 'code-review' && !this.config.promptType) {
         systemPrompt = 'You are general assistant, follow user instructions.';
       }
 


### PR DESCRIPTION
## Summary
- Fix bug where generic fallback system prompt (`"You are general assistant..."`) was injected when no `ai.system_prompt` is set, which overrode `prompt_type: code-explorer` in ProbeAgent
- Add explicit anti-bash-for-code-exploration rules to code-talk.yaml explore-code prompt
- Remove redundant role/tool listing from explore-code prompt (now handled by ProbeAgent's predefined code-explorer prompt)

## Context
Jaeger traces showed AI models making 67+ bash calls (grep, cat, find) for code exploration instead of using search/extract tools. Root cause: the generic fallback became `customPrompt` in ProbeAgent, which has higher priority than `promptType`, so the code-explorer predefined prompt with proper tool guidance was never used.

## Test plan
- [x] All 117 visor tests pass
- [ ] Verify with `prompt_type: code-explorer` config that the predefined prompt is now used
- [ ] Verify bash usage drops significantly in Jaeger traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)