### PR TITLE
fix: deduplicate workspace projects by repository to prevent -2 suffixes

### DIFF
--- a/src/utils/workspace-manager.ts
+++ b/src/utils/workspace-manager.ts
@@ -261,6 +261,20 @@ export class WorkspaceManager {
       }
     }
 
+    // Scan existing entries in the workspace directory to populate usedNames.
+    // This handles reused workspaces (e.g. Slack threads) where a previous run
+    // left symlinks on disk but the in-memory state was cleared by cleanup().
+    try {
+      const entries = await fsp.readdir(this.workspacePath, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.name !== mainProjectName) {
+          this.usedNames.add(entry.name);
+        }
+      }
+    } catch {
+      // Best-effort — workspace just created, nothing to scan
+    }
+
     // Register cleanup handlers
     this.registerCleanupHandlers();
 
@@ -280,7 +294,7 @@ export class WorkspaceManager {
 
   /**
    * Add a project to the workspace (creates symlink to worktree)
-   * If the same repository + worktreePath combination already exists, returns the existing path.
+   * If the same repository already exists, updates the symlink to the new worktree path.
    */
   async addProject(
     repository: string,
@@ -291,14 +305,27 @@ export class WorkspaceManager {
       throw new Error('Workspace not initialized. Call initialize() first.');
     }
 
-    // Check if this exact project (same repo + worktree path) is already added
-    // This prevents duplicate checkouts when tyk-code-talk is called multiple times
+    // Check if this repository is already added (dedup by repository, not worktree path).
+    // Worktree paths change across sessions (session-scoped hashing) and across
+    // nested workflow invocations (each gets a fresh sessionId), but the workspace
+    // symlink should always point to the latest worktree for a given repo.
     for (const [existingName, existingProject] of this.projects.entries()) {
-      if (
-        existingProject.repository === repository &&
-        existingProject.worktreePath === worktreePath
-      ) {
-        logger.debug(`Reusing existing project: ${existingName} (${repository})`);
+      if (existingProject.repository === repository) {
+        if (existingProject.worktreePath !== worktreePath) {
+          // Worktree path changed (new session/invocation) — update symlink
+          logger.debug(
+            `Updating project symlink: ${existingName} (${repository}) -> ${worktreePath}`
+          );
+          await fsp.rm(existingProject.path, { recursive: true, force: true });
+          try {
+            await fsp.symlink(worktreePath, existingProject.path);
+          } catch (error) {
+            throw new Error(`Failed to update symlink for project ${existingName}: ${error}`);
+          }
+          existingProject.worktreePath = worktreePath;
+        } else {
+          logger.debug(`Reusing existing project: ${existingName} (${repository})`);
+        }
         return existingProject.path;
       }
     }

--- a/tests/unit/workspace-manager.test.ts
+++ b/tests/unit/workspace-manager.test.ts
@@ -203,7 +203,7 @@ describe('WorkspaceManager', () => {
       fs.rmSync(worktreePath, { recursive: true, force: true });
     });
 
-    it('handles duplicate project names', async () => {
+    it('handles duplicate project names from different repositories', async () => {
       const { commandExecutor } = require('../../src/utils/command-executor');
       commandExecutor.execute.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
 
@@ -231,6 +231,76 @@ describe('WorkspaceManager', () => {
       fs.rmSync(testOriginalPath, { recursive: true, force: true });
       fs.rmSync(worktreePath1, { recursive: true, force: true });
       fs.rmSync(worktreePath2, { recursive: true, force: true });
+    });
+
+    it('deduplicates by repository when worktree path changes (same session)', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+      commandExecutor.execute.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
+
+      if (!fs.existsSync(testOriginalPath)) {
+        fs.mkdirSync(testOriginalPath, { recursive: true });
+      }
+
+      const worktreePath1 = '/tmp/test-worktree-session-a';
+      const worktreePath2 = '/tmp/test-worktree-session-b';
+      fs.mkdirSync(worktreePath1, { recursive: true });
+      fs.mkdirSync(worktreePath2, { recursive: true });
+
+      const manager = WorkspaceManager.getInstance(testSessionId, testOriginalPath, {
+        basePath: testBasePath,
+      });
+
+      await manager.initialize();
+
+      // First call: adds project
+      const result1 = await manager.addProject('TykTechnologies/tyk', worktreePath1);
+      expect(result1).toContain('tyk');
+
+      // Second call: same repo, different worktree path (e.g., nested workflow with fresh session)
+      const result2 = await manager.addProject('TykTechnologies/tyk', worktreePath2);
+
+      // Should return same workspace path (no -2 suffix)
+      expect(result2).toBe(result1);
+
+      // Should have only 1 project, not 2
+      expect(manager.listProjects().length).toBe(1);
+
+      // Symlink should now point to the new worktree path
+      const symlinkTarget = fs.readlinkSync(result2);
+      expect(symlinkTarget).toBe(worktreePath2);
+
+      // Cleanup
+      fs.rmSync(testOriginalPath, { recursive: true, force: true });
+      fs.rmSync(worktreePath1, { recursive: true, force: true });
+      fs.rmSync(worktreePath2, { recursive: true, force: true });
+    });
+
+    it('deduplicates by repository and returns existing path when worktree is same', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+      commandExecutor.execute.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
+
+      if (!fs.existsSync(testOriginalPath)) {
+        fs.mkdirSync(testOriginalPath, { recursive: true });
+      }
+
+      const worktreePath = '/tmp/test-worktree-same';
+      fs.mkdirSync(worktreePath, { recursive: true });
+
+      const manager = WorkspaceManager.getInstance(testSessionId, testOriginalPath, {
+        basePath: testBasePath,
+      });
+
+      await manager.initialize();
+
+      const result1 = await manager.addProject('TykTechnologies/tyk', worktreePath);
+      const result2 = await manager.addProject('TykTechnologies/tyk', worktreePath);
+
+      expect(result2).toBe(result1);
+      expect(manager.listProjects().length).toBe(1);
+
+      // Cleanup
+      fs.rmSync(testOriginalPath, { recursive: true, force: true });
+      fs.rmSync(worktreePath, { recursive: true, force: true });
     });
   });
 


### PR DESCRIPTION
## Summary
- Workspace `addProject` now deduplicates by **repository** alone, not by repository + worktree path
- When the same repo is re-added with a different worktree path (e.g., from a nested workflow re-invocation via `goto`), the existing symlink is updated instead of creating a duplicate entry (`tyk-2`, etc.)
- During `initialize()`, existing entries in the workspace directory are now scanned to populate `usedNames`, preventing name collisions with on-disk symlinks from prior runs whose in-memory state was cleared by `cleanup(cleanupOnExit=false)`

## Root cause
Commit 58f96bf introduced session-scoped worktree isolation, which includes the `sessionId` in worktree path hashing. Nested workflows (via `workflow-check-provider.ts`) generate a fresh `sessionId` each time they're invoked. When a `goto` loop re-triggers the same workflow, checkout steps create worktrees with different paths. The old `addProject` dedup checked both `repository` and `worktreePath`, so it treated the re-invocation as a new project and appended a `-2` suffix.

## Test plan
- [x] Added test: "deduplicates by repository when worktree path changes"
- [x] Added test: "deduplicates by repository and returns existing path when worktree is same"
- [x] All 117 existing tests pass (unit + YAML integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)