### PR TITLE
docs: add A2A (Agent-to-Agent) protocol documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@
   [![Node](https://img.shields.io/badge/Node.js-18%2B-green)](https://nodejs.org/)
   [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
-  Orchestrate checks, MCP tools, and AI providers with YAML-driven pipelines.
-  Runs as GitHub Action, CLI, Slack bot, or HTTP API.
+  Orchestrate checks, MCP tools, AI providers, and A2A agents with YAML-driven pipelines.
+  Runs as GitHub Action, CLI, Slack bot, HTTP API, or A2A agent server.
 </div>
 
 ---
 
-Visor is an open-source workflow engine that lets you define multi-step AI pipelines in YAML. Wire up shell commands, AI providers, MCP tools, HTTP calls, and custom scripts into dependency-aware DAGs — then run them from your terminal, CI, Slack, or an HTTP endpoint.
+Visor is an open-source workflow engine that lets you define multi-step AI pipelines in YAML. Wire up shell commands, AI providers, MCP tools, A2A agents, HTTP calls, and custom scripts into dependency-aware DAGs — then run them from your terminal, CI, Slack, an HTTP endpoint, or as a standards-compliant A2A agent server.
 
 **What you get out of the box:**
 
 - **YAML-driven pipelines** — define checks, transforms, routing, and AI prompts in a single config file.
-- **4 runtime modes** — CLI, GitHub Action, Slack bot, HTTP server — same config, any surface.
-- **12+ provider types** — `ai`, `command`, `script`, `mcp`, `http`, `claude-code`, `github`, `memory`, `workflow`, and more.
+- **5 runtime modes** — CLI, GitHub Action, Slack bot, HTTP server, A2A agent server — same config, any surface.
+- **15+ provider types** — `ai`, `a2a`, `command`, `script`, `mcp`, `http`, `claude-code`, `github`, `memory`, `workflow`, and more.
+- **Agent interoperability** — A2A protocol support: expose workflows as discoverable agents, or call external A2A agents from your pipelines.
 - **AI orchestration** — multi-provider (Gemini, Claude, OpenAI, Bedrock), session reuse, MCP tool calling, retry & fallback.
 - **Execution engine** — dependency DAGs, parallel waves, forEach fan-out, conditional routing, failure auto-remediation.
 - **Built-in testing** — YAML-native integration tests with fixtures, mocks, and assertions.
@@ -34,6 +35,7 @@ Visor is an open-source workflow engine that lets you define multi-step AI pipel
 - [Provider Types](#-provider-types)
 - [Orchestration](#-orchestration)
 - [AI & MCP](#-ai--mcp)
+- [Agent Protocol (A2A)](#-agent-protocol-a2a)
 - [GitHub Provider](#-github-provider)
 - [Templating & Transforms](#-templating--transforms)
 - [Suppressing Warnings](#-suppressing-warnings)
@@ -163,7 +165,7 @@ Learn more: [docs/assistant-workflows.md](docs/assistant-workflows.md) | Example
 
 ## 🖥️ Runtime Modes
 
-Visor runs the same YAML config across four surfaces:
+Visor runs the same YAML config across five surfaces:
 
 | Mode | How to run | Best for |
 |------|-----------|----------|
@@ -171,6 +173,7 @@ Visor runs the same YAML config across four surfaces:
 | **GitHub Action** | `uses: probelabs/visor@v1` | PR reviews, issue triage, annotations |
 | **Slack bot** | `visor --slack --config .visor.yaml` | Team assistants, ChatOps |
 | **HTTP server** | `http_server: { enabled: true, port: 8080 }` | Webhooks, API integrations |
+| **A2A agent** | `visor --a2a --config .visor.yaml` | Agent interoperability, multi-agent systems |
 
 Additional modes:
 - **TUI** — interactive chat-style terminal UI: `visor --tui`
@@ -185,6 +188,8 @@ visor --analyze-branch-diff                   # PR-style diff analysis
 visor --event pr_updated                      # Simulate GitHub events
 visor --tui --config ./workflow.yaml          # Interactive TUI
 visor --debug-server --debug-port 3456        # Live web debugger
+visor --a2a --config workflow.yaml            # A2A agent server
+visor tasks list --watch                      # Monitor A2A task queue
 visor config snapshots                        # Config version history
 visor validate                                # Validate config
 visor test --progress compact                 # Run integration tests
@@ -227,6 +232,7 @@ Learn more: [docs/commands.md](docs/commands.md)
 | Provider | Description | Example use |
 |----------|------------|------------|
 | `ai` | Multi-provider AI (Gemini, Claude, OpenAI, Bedrock) | Code review, analysis, generation |
+| `a2a` | Call external A2A agents | Agent delegation, multi-agent workflows |
 | `command` | Shell commands with Liquid templating | Run tests, build, lint |
 | `script` | JavaScript in a secure sandbox | Transform data, custom logic |
 | `mcp` | MCP tool execution (stdio/SSE/HTTP) | External tool integration |
@@ -433,6 +439,57 @@ steps:
 ```
 
 Learn more: [docs/claude-code.md](docs/claude-code.md) · [docs/mcp-provider.md](docs/mcp-provider.md) · [docs/advanced-ai.md](docs/advanced-ai.md)
+
+## 🤝 Agent Protocol (A2A)
+
+Visor implements the [A2A (Agent-to-Agent) protocol](https://github.com/google/A2A) for agent interoperability. Every Visor workflow can become a discoverable, standards-compliant agent — and every A2A agent in the ecosystem becomes a callable step in your workflows.
+
+### Server: Expose Workflows as an A2A Agent
+
+```yaml
+agent_protocol:
+  enabled: true
+  protocol: a2a
+  port: 9000
+  agent_card_inline:
+    name: "Code Review Agent"
+    description: "AI-powered code review"
+    skills:
+      - id: security
+        name: Security Review
+        description: Analyze code for vulnerabilities
+  skill_routing:
+    security: security-review
+  default_workflow: general-review
+  auth:
+    type: bearer
+    token_env: AGENT_AUTH_TOKEN
+```
+
+```bash
+visor --a2a --config .visor.yaml    # Start A2A server on port 9000
+visor tasks list --watch            # Monitor task queue
+```
+
+### Client: Call External A2A Agents
+
+```yaml
+steps:
+  compliance-scan:
+    type: a2a
+    agent_url: "http://compliance-agent:9000"
+    message: |
+      Review PR #{{ pr.number }}: {{ pr.title }}
+    blocking: true
+    timeout: 60000
+
+  summarize:
+    type: ai
+    depends_on: [compliance-scan]
+    prompt: "Summarize: {{ outputs['compliance-scan'] | json }}"
+```
+
+Learn more: [docs/a2a-provider.md](docs/a2a-provider.md) · [RFC: A2A Protocol Support](rfc/001-a2a-protocol-support.md) · [Example config](examples/a2a-agent-example.yaml)
 
 ## 🧰 GitHub Provider
 
@@ -709,7 +766,7 @@ Learn more: [docs/enterprise-policy.md](docs/enterprise-policy.md)
 [Assistant workflows](docs/assistant-workflows.md) · [CLI commands](docs/commands.md) · [Configuration](docs/configuration.md) · [AI config](docs/ai-configuration.md) · [Dependencies](docs/dependencies.md) · [forEach propagation](docs/foreach-dependency-propagation.md) · [Failure routing](docs/failure-routing.md) · [Liquid templates](docs/liquid-templates.md) · [Schema-template system](docs/schema-templates.md) · [Fail conditions](docs/fail-if.md) · [Timeouts](docs/timeouts.md) · [Execution limits](docs/limits.md) · [Output formats](docs/output-formats.md) · [Output formatting](docs/output-formatting.md) · [HTTP integration](docs/http.md) · [Scheduler](docs/scheduler.md)
 
 **Providers:**
-[Command](docs/command-provider.md) · [Script](docs/script.md) · [MCP](docs/mcp-provider.md) · [MCP tools for AI](docs/mcp.md) · [Claude Code](docs/claude-code.md) · [GitHub ops](docs/github-ops.md) · [Custom providers](docs/pluggable.md)
+[A2A](docs/a2a-provider.md) · [Command](docs/command-provider.md) · [Script](docs/script.md) · [MCP](docs/mcp-provider.md) · [MCP tools for AI](docs/mcp.md) · [Claude Code](docs/claude-code.md) · [GitHub ops](docs/github-ops.md) · [Custom providers](docs/pluggable.md)
 
 **Operations:**
 [GitHub Action reference](docs/action-reference.md) · [Security](docs/security.md) · [Performance](docs/performance.md) · [Observability](docs/observability.md) · [Debugging](docs/debugging.md) · [Debug visualizer](docs/debug-visualizer.md) · [Troubleshooting](docs/troubleshooting.md) · [Suppressions](docs/suppressions.md) · [GitHub checks](docs/GITHUB_CHECKS.md)

--- a/docs/a2a-provider.md
+++ b/docs/a2a-provider.md
@@ -1,0 +1,672 @@
+# A2A Provider (Agent-to-Agent Protocol)
+
+Visor implements the [A2A (Agent-to-Agent) protocol](https://github.com/google/A2A) for agent interoperability. This enables two modes of operation:
+
+- **Server mode** — Visor exposes workflows as a discoverable A2A agent that external systems can call
+- **Client mode** — Visor calls external A2A agents as workflow steps using `type: a2a`
+
+### A2A vs MCP
+
+| | A2A | MCP |
+|---|---|---|
+| **Pattern** | Agent-to-Agent task delegation | Agent-to-Tool function calls |
+| **Communication** | Stateful tasks with lifecycle | Stateless function invocation |
+| **Input** | Natural language + structured data | Typed JSON Schema parameters |
+| **Discovery** | Agent Card at `/.well-known/agent-card.json` | Tool listing via `tools/list` |
+| **Multi-turn** | Built-in (input_required state) | Not applicable |
+
+Use MCP when you need deterministic tool calls with typed schemas. Use A2A when you need to delegate complex tasks to another agent that may require multiple turns or long-running execution.
+
+---
+
+## Quick Start
+
+### Server: Expose a Workflow as an A2A Agent
+
+```yaml
+# .visor.yaml
+version: "1.0"
+
+agent_protocol:
+  enabled: true
+  protocol: a2a
+  port: 9000
+  agent_card_inline:
+    name: "Review Agent"
+    description: "AI code review"
+    skills:
+      - id: review
+        name: Code Review
+        description: Review code for issues
+  default_workflow: review
+
+steps:
+  review:
+    type: ai
+    prompt: "Review the submitted code for issues"
+    on: [manual]
+```
+
+```bash
+# Start the A2A server
+visor --a2a --config .visor.yaml
+
+# Test with curl
+curl http://localhost:9000/.well-known/agent-card.json
+curl -X POST http://localhost:9000/message:send \
+  -H "Content-Type: application/json" \
+  -d '{"message": {"message_id": "1", "role": "user", "parts": [{"text": "Review my code"}]}}'
+```
+
+### Client: Call an External A2A Agent
+
+```yaml
+steps:
+  scan:
+    type: a2a
+    agent_url: "http://compliance-agent:9000"
+    message: "Review PR #{{ pr.number }}: {{ pr.title }}"
+    blocking: true
+```
+
+---
+
+## Server Mode: Visor as an A2A Agent
+
+### Enabling the Server
+
+Start with the `--a2a` CLI flag:
+
+```bash
+visor --a2a --config .visor.yaml
+```
+
+Or enable in configuration:
+
+```yaml
+agent_protocol:
+  enabled: true
+  protocol: a2a
+  port: 9000          # default: 9000
+  host: "0.0.0.0"     # default: 0.0.0.0
+```
+
+A2A can run alongside other modes:
+
+```bash
+visor --a2a --slack --config .visor.yaml    # A2A + Slack simultaneously
+```
+
+### Agent Card
+
+The Agent Card describes your agent to external clients. Define it inline or load from a file:
+
+```yaml
+# Inline
+agent_protocol:
+  agent_card_inline:
+    name: "Code Review Agent"
+    description: "AI-powered code review"
+    version: "1.0.0"
+    provider:
+      organization: "My Org"
+      url: "https://myorg.com"
+    skills:
+      - id: security
+        name: Security Review
+        description: OWASP Top 10 analysis
+        tags: [security, owasp]
+      - id: performance
+        name: Performance Review
+        description: Performance bottleneck detection
+        tags: [performance]
+    supported_interfaces:
+      - url: "http://localhost:9000"
+        protocol_binding: "a2a/v1"
+    capabilities:
+      streaming: false
+      push_notifications: false
+
+# Or load from file
+agent_protocol:
+  agent_card: "./agent-card.json"
+```
+
+The Agent Card is served publicly at `GET /.well-known/agent-card.json` (no authentication required).
+
+### Skill Routing
+
+Map incoming A2A skill IDs to internal Visor workflows:
+
+```yaml
+agent_protocol:
+  skill_routing:
+    security: security-review       # A2A skill "security" → workflow "security-review"
+    performance: performance-review
+  default_workflow: general-review   # Fallback when skill not matched
+```
+
+When a client sends a message with `metadata.skill_id: "security"`, Visor routes it to the `security-review` workflow. Unmatched skills use `default_workflow`.
+
+### Authentication
+
+Configure authentication for inbound requests:
+
+```yaml
+agent_protocol:
+  auth:
+    type: bearer                    # bearer | api_key | none
+    token_env: AGENT_AUTH_TOKEN     # Environment variable containing the token
+```
+
+**Bearer token:**
+```yaml
+auth:
+  type: bearer
+  token_env: AGENT_AUTH_TOKEN       # Checked via Authorization: Bearer <token>
+```
+
+**API key:**
+```yaml
+auth:
+  type: api_key
+  key_env: AGENT_API_KEY
+  header_name: X-API-Key            # default: x-api-key
+  param_name: api_key               # also checked as query parameter
+```
+
+> The Agent Card endpoint (`/.well-known/agent-card.json`) is always public regardless of auth configuration.
+
+### HTTP Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/.well-known/agent-card.json` | No | Agent Card for discovery |
+| `POST` | `/message:send` | Yes | Submit a task / send a message |
+| `GET` | `/tasks/{id}` | Yes | Get task by ID |
+| `GET` | `/tasks` | Yes | List all tasks |
+| `POST` | `/tasks/{id}:cancel` | Yes | Cancel a running task |
+
+### Task Lifecycle
+
+Tasks follow a state machine with these transitions:
+
+```
+                            ┌─────────────┐
+                            │  submitted  │
+                            └──────┬──────┘
+                      ┌────────────┼────────────┐
+                      v            v            v
+                ┌──────────┐ ┌──────────┐ ┌──────────┐
+                │ working  │ │ canceled │ │ rejected │
+                └────┬─────┘ └──────────┘ └──────────┘
+           ┌─────┬───┼───┬─────────┐
+           v     v   v   v         v
+     ┌─────────┐ │ ┌───┐ │  ┌────────────────┐
+     │completed│ │ │   │ │  │input_required  │──→ working (resumed)
+     └─────────┘ │ │   │ │  └────────────────┘
+           ┌─────┘ │   │ └──────────┐
+           v       v   v            v
+     ┌──────────┐  ┌──────────┐  ┌────────────────┐
+     │  failed  │  │ canceled │  │ auth_required  │──→ working (resumed)
+     └──────────┘  └──────────┘  └────────────────┘
+```
+
+**Terminal states:** `completed`, `failed`, `canceled`, `rejected`
+
+| State | Description |
+|-------|-------------|
+| `submitted` | Task created, waiting to be picked up |
+| `working` | Workflow engine is processing the task |
+| `input_required` | Agent needs additional input from the client |
+| `auth_required` | Agent needs authentication credentials |
+| `completed` | Task finished successfully |
+| `failed` | Task execution encountered an error |
+| `canceled` | Task was canceled by the client |
+| `rejected` | Task was rejected at submission |
+
+### Task Queue
+
+For async execution, configure the task queue:
+
+```yaml
+agent_protocol:
+  queue:
+    poll_interval: 1000        # Poll database every N ms (default: 1000)
+    max_concurrent: 5          # Max concurrent tasks (default: 5)
+    stale_claim_timeout: 300000  # Worker timeout in ms (default: 300000)
+  task_ttl: "7d"               # Task retention period (default: 7d)
+```
+
+**Blocking vs async:**
+- **Blocking** (default): The `POST /message:send` request waits for the workflow to complete and returns the full task with artifacts.
+- **Async**: Set `configuration.blocking: false` in the request. Returns the task ID immediately; the client polls `GET /tasks/{id}` for status updates.
+
+### TLS
+
+For production deployments:
+
+```yaml
+agent_protocol:
+  tls:
+    cert: "/path/to/cert.pem"
+    key: "/path/to/key.pem"
+```
+
+---
+
+## Client Mode: Calling External A2A Agents
+
+Use `type: a2a` to call external A2A-compatible agents from your workflow.
+
+### Basic Usage
+
+```yaml
+steps:
+  compliance-scan:
+    type: a2a
+    agent_url: "http://compliance-agent:9000"
+    message: |
+      Review PR #{{ pr.number }}: {{ pr.title }}
+      Files changed: {{ files | size }}
+    blocking: true
+    timeout: 60000
+```
+
+### Agent Discovery
+
+Specify the agent endpoint in one of two ways (mutually exclusive):
+
+```yaml
+# Option 1: Direct URL to the agent
+agent_url: "http://agent.example.com:9000"
+
+# Option 2: URL to the Agent Card (endpoint resolved from card)
+agent_card: "https://agent.example.com/.well-known/agent-card.json"
+```
+
+When using `agent_card`, Visor fetches the card, caches it for 5 minutes, and resolves the endpoint from `supported_interfaces`.
+
+### Authentication
+
+```yaml
+steps:
+  scan:
+    type: a2a
+    agent_url: "http://agent:9000"
+    message: "Review this code"
+    auth:
+      scheme: bearer              # bearer | api_key
+      token_env: AGENT_TOKEN      # Environment variable with the token
+      # header_name: X-API-Key    # For api_key scheme (default: x-api-key)
+```
+
+### Message Construction
+
+**Text message** (Liquid template):
+```yaml
+message: |
+  Review PR #{{ pr.number }}: {{ pr.title }}
+  Author: {{ pr.author }}
+```
+
+**Structured data** (Liquid-templated key-value pairs sent as data parts):
+```yaml
+data:
+  repo_context: '{{ pr.repo | json }}'
+  file_list: '{{ files | json }}'
+```
+
+**File attachments:**
+```yaml
+files:
+  - url: "https://example.com/requirements.txt"
+    media_type: "text/plain"
+    filename: "requirements.txt"
+```
+
+### Polling and Multi-Turn
+
+```yaml
+steps:
+  interactive-agent:
+    type: a2a
+    agent_url: "http://agent:9000"
+    message: "Analyze {{ pr.title }}"
+
+    blocking: true          # Wait for completion (default: true)
+    timeout: 300000         # Max wait in ms (default: 300000)
+    poll_interval: 2000     # Poll frequency in ms (default: 2000)
+
+    # Multi-turn conversation
+    max_turns: 3            # Max conversation turns (default: 1)
+    on_input_required: |    # Auto-reply when agent asks for more info
+      Here is additional context:
+      {{ pr.body }}
+```
+
+When the agent enters `input_required` state, Visor automatically sends the `on_input_required` template as a follow-up message. This continues up to `max_turns`.
+
+### Output Transformation
+
+Transform agent responses into structured issues with JavaScript:
+
+```yaml
+steps:
+  scan:
+    type: a2a
+    agent_url: "http://agent:9000"
+    message: "Security scan"
+    transform_js: |
+      return {
+        issues: (output.issues || []).map(function(i) {
+          return {
+            file: i.file,
+            line: i.line || 0,
+            ruleId: 'a2a/' + (i.ruleId || 'issue'),
+            message: i.message,
+            severity: i.severity || 'warning'
+          };
+        })
+      };
+```
+
+### Error Handling
+
+A2A errors are surfaced as issues with `ruleId: a2a/error`:
+
+| Error | When |
+|-------|------|
+| `A2ATimeoutError` | Task didn't complete within `timeout` |
+| `A2AMaxTurnsExceededError` | Conversation exceeded `max_turns` |
+| `A2AInputRequiredError` | Agent needs input but `max_turns` exhausted |
+| `A2AAuthRequiredError` | Agent requires authentication credentials |
+| `A2ATaskFailedError` | Task execution failed on the remote agent |
+| `A2ATaskRejectedError` | Task was rejected or canceled |
+| `A2ARequestError` | HTTP request to the agent failed |
+| `AgentCardFetchError` | Failed to fetch Agent Card |
+| `InvalidAgentCardError` | Agent Card is malformed |
+
+---
+
+## Task Management CLI
+
+Monitor and manage A2A tasks with `visor tasks`:
+
+```bash
+visor tasks                                    # List all tasks (alias for list)
+visor tasks list                               # List tasks
+visor tasks list --state working               # Filter by state
+visor tasks list --agent security-review       # Filter by workflow
+visor tasks list --limit 50                    # Show more results
+visor tasks list --output json                 # JSON output
+visor tasks list --watch                       # Live refresh every 2s
+visor tasks stats                              # Queue summary statistics
+visor tasks stats --output json                # Stats as JSON
+visor tasks cancel <task-id>                   # Cancel a running task
+visor tasks help                               # Show usage
+```
+
+**Flags:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--state <state>` | Filter by task state | all |
+| `--agent <workflow-id>` | Filter by workflow | all |
+| `--limit <n>` | Number of tasks to show | 20 |
+| `--output <format>` | Output format: `table`, `json`, `markdown` | table |
+| `--watch` | Refresh every 2 seconds | off |
+
+---
+
+## Configuration Reference
+
+### Server-Side: `agent_protocol`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable the A2A server |
+| `protocol` | string | `"a2a"` | Protocol binding |
+| `port` | number | `9000` | HTTP listen port |
+| `host` | string | `"0.0.0.0"` | HTTP bind address |
+| `public_url` | string | auto | Public URL for Agent Card |
+| `agent_card_inline` | object | - | Inline Agent Card definition |
+| `agent_card` | string | - | Path to Agent Card JSON file |
+| `auth` | object | - | Authentication config |
+| `auth.type` | string | - | `bearer`, `api_key`, or `none` |
+| `auth.token_env` | string | - | Env var for bearer token |
+| `auth.key_env` | string | - | Env var for API key |
+| `auth.header_name` | string | `"x-api-key"` | Custom header for API key |
+| `auth.param_name` | string | `"api_key"` | Query parameter for API key |
+| `skill_routing` | object | - | Map of skill_id to workflow name |
+| `default_workflow` | string | - | Fallback workflow for unmatched skills |
+| `task_ttl` | string | `"7d"` | Task retention period |
+| `queue.poll_interval` | number | `1000` | Queue poll interval in ms |
+| `queue.max_concurrent` | number | `5` | Max concurrent task executions |
+| `queue.stale_claim_timeout` | number | `300000` | Worker stale claim timeout in ms |
+| `tls.cert` | string | - | Path to TLS certificate |
+| `tls.key` | string | - | Path to TLS private key |
+
+### Client-Side: `type: a2a` Check Provider
+
+| Key | Type | Default | Required | Description |
+|-----|------|---------|----------|-------------|
+| `agent_url` | string | - | one of | Direct agent endpoint URL |
+| `agent_card` | string | - | one of | URL to Agent Card |
+| `message` | string | - | yes | Liquid template for the message text |
+| `data` | object | - | no | Liquid-templated structured data parts |
+| `files` | array | - | no | File attachments (`url`, `media_type`, `filename`) |
+| `auth.scheme` | string | - | no | `bearer` or `api_key` |
+| `auth.token_env` | string | - | no | Env var containing auth token |
+| `auth.header_name` | string | `"x-api-key"` | no | Custom header for API key |
+| `blocking` | boolean | `true` | no | Wait for task completion |
+| `timeout` | number | `300000` | no | Max wait time in ms |
+| `poll_interval` | number | `2000` | no | Poll interval in ms |
+| `max_turns` | number | `1` | no | Max conversation turns |
+| `on_input_required` | string | - | no | Liquid template for auto-reply |
+| `transform_js` | string | - | no | JavaScript output transformation |
+| `accepted_output_modes` | string[] | `["text/plain", "application/json"]` | no | Accepted MIME types |
+
+---
+
+## Examples
+
+### Server: Code Review Agent
+
+Full example from [examples/a2a-agent-example.yaml](../examples/a2a-agent-example.yaml):
+
+```yaml
+version: "1.0"
+
+agent_protocol:
+  enabled: true
+  protocol: a2a
+  port: 9000
+  host: "0.0.0.0"
+
+  agent_card_inline:
+    name: "Code Review Agent"
+    description: "AI-powered code review agent built with Visor"
+    version: "1.0.0"
+    provider:
+      organization: "Visor"
+    skills:
+      - id: security
+        name: Security Review
+        description: Analyze code for security vulnerabilities (OWASP Top 10)
+        tags: [security, owasp]
+      - id: performance
+        name: Performance Review
+        description: Analyze code for performance issues and bottlenecks
+        tags: [performance]
+    supported_interfaces:
+      - url: "http://localhost:9000"
+        protocol_binding: "a2a/v1"
+    capabilities:
+      streaming: false
+      push_notifications: false
+
+  auth:
+    type: bearer
+    token_env: AGENT_AUTH_TOKEN
+
+  skill_routing:
+    security: security-review
+    performance: performance-review
+  default_workflow: general-review
+
+  task_ttl: "7d"
+  queue:
+    max_concurrent: 5
+
+steps:
+  security-review:
+    type: ai
+    prompt: |
+      Perform a security review focusing on OWASP Top 10 vulnerabilities.
+      Check for SQL injection, XSS, CSRF, and authentication issues.
+    on: [manual]
+
+  performance-review:
+    type: ai
+    prompt: |
+      Review for performance issues: N+1 queries, memory leaks,
+      unnecessary allocations, and algorithmic complexity.
+    on: [manual]
+
+  general-review:
+    type: ai
+    prompt: |
+      General code quality review: naming, structure, error handling,
+      and adherence to project conventions.
+    on: [manual]
+```
+
+```bash
+# Start
+visor --a2a --config examples/a2a-agent-example.yaml
+
+# Discover
+curl http://localhost:9000/.well-known/agent-card.json | jq .
+
+# Send a task targeting the security skill
+curl -X POST http://localhost:9000/message:send \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AGENT_AUTH_TOKEN" \
+  -d '{
+    "message": {
+      "message_id": "msg-1",
+      "role": "user",
+      "parts": [{"text": "Review auth.py for security issues"}],
+      "metadata": {"skill_id": "security"}
+    }
+  }'
+
+# Monitor tasks
+visor tasks list --watch
+```
+
+### Client: Multi-Agent Composition
+
+Chain multiple A2A agents and aggregate results:
+
+```yaml
+steps:
+  compliance-scan:
+    type: a2a
+    agent_url: "http://compliance-agent:9000"
+    message: "Check compliance for PR #{{ pr.number }}"
+    blocking: true
+
+  security-scan:
+    type: a2a
+    agent_url: "http://security-agent:9000"
+    message: "Security review for PR #{{ pr.number }}"
+    blocking: true
+
+  summarize:
+    type: ai
+    depends_on: [compliance-scan, security-scan]
+    prompt: |
+      Summarize findings from two agents:
+      Compliance: {{ outputs["compliance-scan"] | json }}
+      Security: {{ outputs["security-scan"] | json }}
+```
+
+### Multi-Turn Conversation
+
+Handle agents that ask follow-up questions:
+
+```yaml
+steps:
+  interactive-review:
+    type: a2a
+    agent_card: "https://agent.example.com/.well-known/agent-card.json"
+    message: "Analyze {{ pr.title }} for best practices"
+    max_turns: 3
+    on_input_required: |
+      Here is additional context:
+      {{ pr.body }}
+    transform_js: |
+      return {
+        issues: (output.issues || []).map(function(i) {
+          return {
+            file: i.file,
+            line: i.line || 0,
+            ruleId: 'a2a/' + (i.ruleId || 'issue'),
+            message: i.message,
+            severity: i.severity || 'warning'
+          };
+        })
+      };
+```
+
+---
+
+## Security Considerations
+
+- **Always configure auth for production** — without it, anyone can submit tasks to your agent
+- **Use `token_env` / `key_env`** — never hardcode tokens in config files
+- **Enable TLS** for public-facing servers
+- **Agent Card is public** — it's served without auth, so don't include sensitive information
+- **Task TTL** — set appropriate retention to limit stored data (`task_ttl: "7d"`)
+- **Token comparison** uses timing-safe comparison to prevent timing attacks
+
+---
+
+## Debugging
+
+```bash
+# Start with debug logging
+visor --a2a --debug --config .visor.yaml
+
+# Verify Agent Card is served correctly
+curl http://localhost:9000/.well-known/agent-card.json | jq .
+
+# Monitor live task queue
+visor tasks list --watch
+
+# Check queue statistics
+visor tasks stats
+
+# View specific task
+visor tasks list --state failed    # Find failed tasks
+```
+
+With OpenTelemetry enabled, A2A tasks emit spans with:
+- `agent.task.id` — Task ID
+- `agent.task.state` — Current state
+- `agent.task.workflow_id` — Target workflow
+
+---
+
+## Related Documentation
+
+- [MCP Provider](./mcp-provider.md) — MCP tool integration (complementary to A2A)
+- [HTTP Integration](./http.md) — HTTP server and webhooks
+- [Workflows](./workflows.md) — Reusable workflow definitions
+- [Configuration](./configuration.md) — Configuration reference
+- [Architecture](./architecture.md) — System architecture overview
+- [Security](./security.md) — Security best practices
+- [Debugging](./debugging.md) — Debugging techniques
+- [RFC: A2A Protocol Support](../rfc/001-a2a-protocol-support.md) — Design document

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@ This document provides a comprehensive overview of Visor's internal architecture
 
 ## System Overview
 
-Visor is an AI-powered workflow orchestration tool that can run as a GitHub Action, CLI tool, or Slack bot. The system uses a state machine-based execution engine to orchestrate checks (steps) with sophisticated dependency resolution, routing, and error handling.
+Visor is an AI-powered workflow orchestration tool that can run as a GitHub Action, CLI tool, Slack bot, or A2A agent server. The system uses a state machine-based execution engine to orchestrate checks (steps) with sophisticated dependency resolution, routing, and error handling.
 
 ### High-Level Architecture Diagram
 
@@ -36,16 +36,16 @@ Visor is an AI-powered workflow orchestration tool that can run as a GitHub Acti
                                     |   Entry Points   |
                                     +------------------+
                                     |                  |
-                      +-------------+---+----------+---+-------------+
-                      |                 |              |             |
-                      v                 v              v             v
-               +------+------+   +------+------+  +---+---+   +-----+-----+
-               | GitHub      |   |    CLI      |  | Slack |   | HTTP      |
-               | Action      |   | (cli-main)  |  | Socket|   | Webhook   |
-               | (index.ts)  |   |             |  | Mode  |   | Server    |
-               +------+------+   +------+------+  +---+---+   +-----+-----+
-                      |                 |              |             |
-                      +--------+--------+--------------+-------------+
+                +------+------+-----+----+--------+---+----------+
+                |             |          |        |              |
+                v             v          v        v              v
+         +------+------+ +---+----+ +---+---+ +--+-------+ +----+------+
+         | GitHub      | |  CLI   | | Slack | | HTTP     | | A2A       |
+         | Action      | |        | | Socket| | Webhook  | | Agent     |
+         | (index.ts)  | |        | | Mode  | | Server   | | Server    |
+         +------+------+ +---+----+ +---+---+ +--+-------+ +----+------+
+                |             |          |        |              |
+                +------+------+----------+--------+--------------+
                                |
                                v
                     +----------+-----------+
@@ -82,7 +82,7 @@ Visor is an AI-powered workflow orchestration tool that can run as a GitHub Acti
 
 | Component | Description |
 |-----------|-------------|
-| **Entry Points** | GitHub Action, CLI, Slack Socket Mode, HTTP webhooks |
+| **Entry Points** | GitHub Action, CLI, Slack Socket Mode, HTTP webhooks, A2A Agent Protocol |
 | **Configuration Manager** | Loads and validates YAML configuration |
 | **State Machine Engine** | Orchestrates check execution with wave-based scheduling |
 | **Provider Registry** | Registry of pluggable check providers |
@@ -163,6 +163,33 @@ http_server:
     - path: /webhook
       transform: "{{ request.body | json }}"
 ```
+
+### A2A Agent Server (`src/agent-protocol/a2a-frontend.ts`)
+
+The A2A (Agent-to-Agent) entry point exposes Visor workflows as standards-compliant A2A agents:
+
+```bash
+visor --a2a --config .visor.yaml
+```
+
+**Responsibilities:**
+- Serve Agent Card at `/.well-known/agent-card.json` for discovery
+- Accept tasks via `POST /message:send`
+- Route incoming A2A skills to internal workflows via `skill_routing`
+- Manage task lifecycle (submitted → working → completed/failed)
+- Persist tasks in SQLite via `TaskStore`
+- Execute workflows through the state machine engine
+
+**Supported A2A Endpoints:**
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/.well-known/agent-card.json` | No | Agent Card for discovery |
+| `POST` | `/message:send` | Yes | Submit a task |
+| `GET` | `/tasks/{id}` | Yes | Get task status |
+| `GET` | `/tasks` | Yes | List tasks |
+| `POST` | `/tasks/{id}:cancel` | Yes | Cancel a task |
+
+See [A2A Provider](./a2a-provider.md) for complete documentation.
 
 ---
 
@@ -264,6 +291,104 @@ checks:
       run: [aggregation-step]
 ```
 
+### Agent Protocol Layer
+
+The A2A feature introduces a task-based execution layer that sits between external clients and the workflow engine. This is architecturally separate from the step-level state machine — it governs the lifecycle of inbound agent tasks.
+
+```
+External A2A Client
+      │
+      ▼
+┌─────────────────────┐
+│  A2A Frontend       │  HTTP server, auth, Agent Card
+│  (a2a-frontend.ts)  │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐     ┌─────────────────────┐
+│  Task Store         │◄───►│  Task Queue          │
+│  (SQLite)           │     │  (async execution)   │
+└──────────┬──────────┘     └──────────┬──────────┘
+           │                           │
+           ▼                           ▼
+┌──────────────────────────────────────────────────┐
+│  State Machine Execution Engine                  │
+│  (same engine used by CLI, GitHub Action, etc.)  │
+└──────────────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────┐
+│  Provider Registry → [ai, a2a, command, ...]     │
+└──────────────────────────────────────────────────┘
+```
+
+#### Task Store (`src/agent-protocol/task-store.ts`)
+
+SQLite-backed persistence for A2A tasks:
+
+```sql
+CREATE TABLE agent_tasks (
+  id TEXT PRIMARY KEY,           -- UUID
+  context_id TEXT NOT NULL,      -- Session grouping
+  state TEXT NOT NULL,           -- Task state
+  created_at TEXT NOT NULL,      -- ISO 8601
+  updated_at TEXT NOT NULL,
+  request_message TEXT NOT NULL, -- JSON: original message
+  artifacts TEXT DEFAULT '[]',   -- JSON: AgentArtifact[]
+  history TEXT DEFAULT '[]',     -- JSON: AgentMessage[]
+  workflow_id TEXT,              -- Target workflow
+  run_id TEXT,                   -- Engine run correlation
+  claimed_by TEXT,               -- Worker ID (queue)
+  claimed_at TEXT,               -- Claim timestamp
+  ttl TEXT                       -- Expiration
+);
+```
+
+The store provides CRUD operations with state transition enforcement — invalid transitions (e.g., `completed` → `working`) throw `InvalidStateTransitionError`.
+
+#### Task Queue (`src/agent-protocol/task-queue.ts`)
+
+Manages async task execution with configurable concurrency:
+
+- Polls the database at `poll_interval` for unclaimed `submitted` tasks
+- Claims tasks using a worker ID with `stale_claim_timeout` to recover from crashed workers
+- Feeds tasks to the state machine engine, limited by `max_concurrent`
+- Updates task state and artifacts on completion
+
+#### Task State Machine (`src/agent-protocol/state-transitions.ts`)
+
+Separate from the workflow engine state machine — this governs task lifecycle:
+
+```
+submitted ──→ working ──→ completed (terminal)
+    │            ├──→ failed (terminal)
+    │            ├──→ canceled (terminal)
+    │            ├──→ input_required ──→ working (resumed)
+    │            └──→ auth_required ──→ working (resumed)
+    ├──→ canceled (terminal)
+    └──→ rejected (terminal)
+```
+
+Terminal states: `completed`, `failed`, `canceled`, `rejected`.
+
+#### Agent Card & Discovery
+
+The Agent Card is a JSON document describing the agent's capabilities:
+
+```typescript
+interface AgentCard {
+  name: string;
+  description?: string;
+  version?: string;
+  provider?: { organization: string; url?: string };
+  skills?: AgentSkill[];        // Advertised capabilities
+  supported_interfaces?: Array<{ url: string; protocol_binding?: string }>;
+  capabilities?: { streaming?: boolean; push_notifications?: boolean };
+}
+```
+
+Skills are mapped to internal workflows via `skill_routing` configuration. When a client sends a message with `metadata.skill_id`, the frontend resolves the target workflow and dispatches execution.
+
 ---
 
 ## Provider Architecture
@@ -311,6 +436,7 @@ class CheckProviderRegistry {
 
 | Provider | Type | Description |
 |----------|------|-------------|
+| `a2a` | A2A Agent | Calls external A2A-compatible agents |
 | `ai` | AI-powered | Uses Gemini, Claude, OpenAI, or Bedrock for analysis |
 | `command` | Command | Executes shell commands |
 | `script` | Script | Executes JavaScript in a sandbox |
@@ -507,6 +633,19 @@ checks:
       {% assign data = request.body | json %}
       {{ data.message }}
 ```
+
+### A2A Protocol
+
+External agents and orchestrators send tasks via the A2A protocol:
+
+1. Client fetches Agent Card from `GET /.well-known/agent-card.json`
+2. Client sends `POST /message:send` with `skill_id` in metadata
+3. A2A Frontend authenticates the request (bearer/api_key)
+4. Task created in TaskStore (state: `submitted`)
+5. Skill routing maps `skill_id` → internal workflow name
+6. Engine executes the workflow (same engine as CLI/GitHub Action)
+7. Task updated with artifacts (state: `completed`)
+8. Client receives response (blocking) or polls `GET /tasks/{id}` (async)
 
 ---
 
@@ -1063,6 +1202,7 @@ Currently, Visor does not cache AI responses between runs. For expensive operati
 - [Security](./security.md) - Security overview and best practices
 - [Providers](./providers/) - Provider-specific documentation
 - [Custom Tools](./custom-tools.md) - Creating custom tools
+- [A2A Provider](./a2a-provider.md) - Agent-to-Agent protocol integration
 - [MCP Provider](./mcp-provider.md) - MCP integration details
 - [Command Provider](./command-provider.md) - Shell command execution
 - [HTTP Integration](./http.md) - HTTP server and client features
@@ -1100,6 +1240,7 @@ src/
   providers/
     check-provider.interface.ts  # Provider base class
     check-provider-registry.ts   # Provider registry
+    a2a-check-provider.ts        # A2A agent client provider
     ai-check-provider.ts         # AI provider (Gemini, Claude, OpenAI)
     claude-code-check-provider.ts # Claude Code SDK provider
     command-check-provider.ts    # Shell command provider
@@ -1121,6 +1262,17 @@ src/
   event-bus/
     event-bus.ts              # Event bus for frontends
     types.ts                  # Event envelope types
+
+  agent-protocol/
+    a2a-frontend.ts             # A2A HTTP server and endpoints
+    types.ts                    # Protocol-agnostic types and error classes
+    state-transitions.ts        # Task state machine validation
+    task-store.ts               # SQLite-backed task persistence
+    task-queue.ts               # Async task execution queue
+    task-stream-manager.ts      # SSE streaming support
+    push-notification-manager.ts # Push notification delivery
+    tasks-cli-handler.ts        # CLI: visor tasks
+    index.ts                    # Re-exports
 
   frontends/
     host.ts                   # Frontend manager
@@ -1182,6 +1334,9 @@ interface VisorConfig {
 
   // HTTP server
   http_server?: HttpServerConfig;
+
+  // Agent Protocol (A2A)
+  agent_protocol?: AgentProtocolConfig;
 
   // Workflow imports
   imports?: string[];
@@ -1257,4 +1412,11 @@ Events that flow through the state machine:
 | **Scope** | Hierarchical path for nested workflow execution |
 | **Frontend** | Integration point (GitHub, Slack) |
 | **Routing** | Control flow based on check results |
+| **A2A** | Agent-to-Agent protocol — Google's open standard for agent interoperability |
+| **Agent Card** | JSON metadata describing an agent's capabilities, skills, and endpoints |
+| **Task** | A unit of work in the A2A protocol with lifecycle state (submitted → working → completed) |
+| **Skill** | A named capability advertised in an Agent Card, mapped to a Visor workflow |
+| **Skill Routing** | Configuration mapping A2A skill IDs to internal workflow names |
+| **Task Store** | SQLite-backed persistence layer for A2A tasks |
+| **Task Queue** | Async execution queue for processing A2A tasks with concurrency control |
 | **MCP** | Model Context Protocol - standard for AI tool integration |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -113,6 +113,39 @@ visor mcp-server [options]
 - `--mcp-tool-name <name>` - Custom tool name for the MCP server
 - `--mcp-tool-description <desc>` - Custom tool description
 
+#### `visor tasks`
+
+Monitor and manage A2A agent tasks.
+
+```bash
+visor tasks [command] [options]
+```
+
+**Subcommands:**
+- `list` (default) — List tasks with optional filters
+- `stats` — Queue summary statistics
+- `cancel <task-id>` — Cancel a running task
+- `help` — Show usage
+
+**Options:**
+- `--state <state>` — Filter by state: `submitted`, `working`, `completed`, `failed`, `canceled`
+- `--agent <workflow-id>` — Filter by workflow
+- `--limit <n>` — Number of tasks to show (default: 20)
+- `--output <format>` — Output format: `table` (default), `json`, `markdown`
+- `--watch` — Live refresh every 2 seconds
+
+**Examples:**
+```bash
+visor tasks                                  # List all tasks
+visor tasks list --state working             # Show only working tasks
+visor tasks list --agent security-review     # Tasks for a specific workflow
+visor tasks list --output json               # JSON output
+visor tasks list --watch                     # Live monitoring
+visor tasks stats                            # Queue summary
+visor tasks stats --output json              # Stats as JSON
+visor tasks cancel abc123                    # Cancel a task
+```
+
 ### Common CLI Options
 
 #### Check Selection
@@ -174,6 +207,9 @@ See [Tag Filtering](tag-filtering.md) for detailed tag filtering documentation.
 - `--github-installation-id <id>` - GitHub App installation ID, auto-detected if omitted
 
 See [GitHub Authentication](github-auth.md) for setup guide and details.
+
+#### Agent Protocol
+- `--a2a` - Enable A2A Agent Protocol server mode (see [A2A Provider](a2a-provider.md))
 
 #### Other Options
 - `--slack` - Enable Slack Socket Mode runner

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,7 @@ Visor supports the following check types:
 
 | Type | Description | Documentation |
 |------|-------------|---------------|
+| `a2a` | Call external A2A agents | [A2A Provider](./a2a-provider.md) |
 | `ai` | AI-powered analysis using LLMs | [AI Configuration](./ai-configuration.md) |
 | `claude-code` | Claude Code SDK integration | [Claude Code](./claude-code.md) |
 | `command` | Execute shell commands | [Command Provider](./command-provider.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Visor Documentation
 
-Visor is an AI-powered workflow orchestration tool for code review, automation, and CI/CD pipelines. It supports multiple AI providers, pluggable check providers, and integrates with GitHub Actions and Slack.
+Visor is an AI-powered workflow orchestration tool for code review, automation, and CI/CD pipelines. It supports multiple AI providers, pluggable check providers, A2A agent interoperability, and integrates with GitHub Actions and Slack.
 
 ---
 
@@ -35,7 +35,7 @@ Visor is an AI-powered workflow orchestration tool for code review, automation, 
 
 ## Providers
 
-Visor supports 15 provider types for different check and workflow operations.
+Visor supports 16 provider types for different check and workflow operations.
 
 ### AI Providers
 
@@ -66,6 +66,12 @@ Visor supports 15 provider types for different check and workflow operations.
 | [Git Checkout](./providers/git-checkout.md) | Checkout code from repositories using git worktrees |
 | [Memory Provider](./memory.md) | Persistent key-value storage for stateful workflows |
 | [Human Input](./human-input-provider.md) | Pause workflows to collect user input via CLI, stdin, or SDK |
+
+### Agent Protocol
+
+| Document | Description |
+|----------|-------------|
+| [A2A Provider](./a2a-provider.md) | Agent-to-Agent protocol: server mode, client provider, task management, and multi-agent composition |
 
 ### Utility Providers
 
@@ -187,6 +193,7 @@ Internal design documents, proposals, and implementation tracking.
 | [on_init Hook](./rfc/on_init-hook.md) | Lifecycle hook for context preprocessing |
 | [Telemetry Tracing](./telemetry-tracing-rfc.md) | OpenTelemetry tracing architecture |
 | [Test Framework](./test-framework-rfc.md) | In-YAML integration test framework design |
+| [A2A Protocol Support](../rfc/001-a2a-protocol-support.md) | Agent-to-Agent protocol for agent interoperability ([docs](./a2a-provider.md)) |
 
 ### Design Documents
 

--- a/docs/pluggable.md
+++ b/docs/pluggable.md
@@ -2,7 +2,7 @@
 
 Visor supports multiple provider types. You can also add custom providers.
 
-**Built-in Providers:** ai, mcp, command, script, http, http_input, http_client, log, memory, noop, github, human-input, workflow, git-checkout, claude-code
+**Built-in Providers:** a2a, ai, mcp, command, script, http, http_input, http_client, log, memory, noop, github, human-input, workflow, git-checkout, claude-code
 
 ### Custom Provider Skeleton (TypeScript)
 
@@ -17,6 +17,21 @@ class CustomCheckProvider {
 ```
 
 ### Built-in Providers
+
+#### A2A Provider (`type: a2a`)
+Call external A2A-compatible agents and collect their responses. Supports agent card discovery, multi-turn conversations, and JavaScript output transforms.
+
+```yaml
+steps:
+  compliance-check:
+    type: a2a
+    agent_url: "http://compliance-agent:9000"
+    message: "Review PR #{{ pr.number }}: {{ pr.title }}"
+    blocking: true
+    timeout: 60000
+```
+
+[Learn more](./a2a-provider.md)
 
 #### AI Provider (`type: ai`)
 Execute AI-powered analysis using Google Gemini, Anthropic Claude, OpenAI, or AWS Bedrock.


### PR DESCRIPTION
## Summary

- Created `docs/a2a-provider.md` (672 lines) — canonical A2A documentation covering server mode, client provider, task management CLI, configuration reference, and examples
- Updated `README.md` with A2A positioning: 5 runtime modes, 15+ providers, new Agent Protocol section
- Updated `docs/architecture.md` with A2A architectural layer: Task Store, Task Queue, state machine, Agent Card discovery, integration diagrams, glossary entries
- Updated `docs/commands.md` with `visor tasks` subcommand and `--a2a` flag
- Updated `docs/configuration.md`, `docs/index.md`, `docs/pluggable.md` with A2A provider references

PR #467 merged full A2A support (server mode, client provider, 170+ tests) but no user-facing documentation was updated. This PR fills that gap.

## Test plan
- [ ] Verify all internal links resolve (`docs/a2a-provider.md` exists)
- [ ] Verify provider counts are consistent across README (15+), index.md (16), pluggable.md
- [ ] Verify no broken markdown (heading levels, table alignment, code fences)
- [ ] Grep for `a2a` across docs/ and README.md to confirm coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)