### PR TITLE
fix: stop appending echoed schema to AI response text

### DIFF
--- a/src/ai-review-service.ts
+++ b/src/ai-review-service.ts
@@ -2556,21 +2556,15 @@ ${'='.repeat(60)}
             const pos = parseInt(trailingMatch[1], 10);
             try {
               reviewData = JSON.parse(sanitizedResponse.substring(0, pos));
-              // Preserve trailing content (e.g., DSL output buffer from ProbeAgent)
-              // by appending it to the text field if present
+              // Discard trailing content — legitimate ProbeAgent output is
+              // already extracted via <<<RAW_OUTPUT>>> blocks above (line ~2489).
+              // Trailing content here is typically an AI echo of the schema
+              // definition, which should not be appended to the response text.
               const trailing = sanitizedResponse.substring(pos).trim();
-              if (
-                trailing &&
-                reviewData &&
-                typeof reviewData === 'object' &&
-                typeof (reviewData as any).text === 'string'
-              ) {
-                (reviewData as any).text = (reviewData as any).text + '\n\n' + trailing;
+              if (trailing) {
                 log(
-                  `✅ Recovered JSON and appended ${trailing.length} chars of trailing content to text field`
+                  `✅ Recovered JSON by trimming ${trailing.length} chars of trailing content at position ${pos}`
                 );
-              } else {
-                log(`✅ Recovered JSON by trimming trailing content at position ${pos}`);
               }
               if (debugInfo) debugInfo.jsonParseSuccess = true;
               recovered = true;

--- a/tests/unit/raw-output-extraction.test.ts
+++ b/tests/unit/raw-output-extraction.test.ts
@@ -130,4 +130,44 @@ describe('parseAIResponse RAW_OUTPUT extraction', () => {
     // The text should NOT contain the RAW_OUTPUT delimiters
     expect(result.output.text).not.toContain('<<<RAW_OUTPUT>>>');
   });
+
+  it('should discard echoed JSON schema from trailing content', () => {
+    // Simulates AI echoing the schema definition after its JSON response
+    const json = JSON.stringify({
+      text: 'This ensures the links resolve correctly to the specific API documentation pages.',
+    });
+    const echoedSchema = `\njson\n${JSON.stringify(
+      {
+        type: 'object',
+        properties: { text: { type: 'string', description: 'The response to the user' } },
+        required: ['text'],
+      },
+      null,
+      2
+    )}`;
+    // Concatenate so JSON.parse sees valid JSON followed by trailing schema
+    const response = json + echoedSchema;
+
+    const result = (service as any).parseAIResponse(response, undefined, 'custom');
+
+    // The text field should NOT contain the echoed schema
+    expect(result.output.text).toBe(
+      'This ensures the links resolve correctly to the specific API documentation pages.'
+    );
+    expect(result.output.text).not.toContain('"type": "object"');
+    expect(result.output.text).not.toContain('"properties"');
+  });
+
+  it('should discard all trailing content (not just schemas)', () => {
+    // Trailing content is always discarded — legitimate output goes through
+    // <<<RAW_OUTPUT>>> blocks instead
+    const json = JSON.stringify({ text: 'Main answer here.' });
+    const trailing = '\nSome trailing junk from the model.';
+    const response = json + trailing;
+
+    const result = (service as any).parseAIResponse(response, undefined, 'custom');
+
+    expect(result.output.text).toBe('Main answer here.');
+    expect(result.output.text).not.toContain('trailing junk');
+  });
 });


### PR DESCRIPTION
## Summary
- Fix AI responses sometimes showing the JSON schema definition appended to the message text in Slack
- Root cause: when `JSON.parse()` found valid JSON followed by trailing content, recovery code appended that trailing content to the `text` field
- This was a legacy workaround from before `<<<RAW_OUTPUT>>>` blocks existed for ProbeAgent output buffers
- Now that `RAW_OUTPUT` properly handles legitimate trailing data, the append is unnecessary and was leaking echoed schema definitions into user-visible responses

## Test plan
- [x] Existing `raw-output-extraction.test.ts` tests pass (9/9)
- [x] New test: echoed JSON schema in trailing content is discarded
- [x] New test: all trailing content is discarded (not just schemas)
- [x] `<<<RAW_OUTPUT>>>` extraction still works correctly
- [ ] Manual: verify Slack responses no longer show JSON schema definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)