### PR TITLE
fix: numeric comparison operators & mock exhaustion loop termination

### DIFF
--- a/src/providers/check-provider.interface.ts
+++ b/src/providers/check-provider.interface.ts
@@ -65,6 +65,8 @@ export interface ExecutionContext {
     onHumanInput?: (request: HumanInputRequest) => Promise<string>;
     onPromptCaptured?: (info: { step: string; provider: string; prompt: string }) => void;
     mockForStep?: (step: string) => unknown | undefined;
+    /** Returns true if the mock for a step has been consumed (for loop termination) */
+    isMockExhausted?: (step: string) => boolean;
     /** Called when a check completes - useful for streaming TUI updates */
     onCheckComplete?: (info: {
       checkId: string;

--- a/src/providers/human-input-check-provider.ts
+++ b/src/providers/human-input-check-provider.ts
@@ -349,6 +349,18 @@ export class HumanInputCheckProvider extends CheckProvider {
         return s;
       }
     } catch {}
+
+    // If the test runner signals that the mock for this step is exhausted
+    // (goto loop re-entered a human-input step after consuming its mock),
+    // throw an awaiting error to cleanly terminate the pipeline loop.
+    try {
+      if (context?.hooks?.isMockExhausted?.(checkName)) {
+        throw this.buildAwaitingError(checkName, 'Mock exhausted — loop terminated');
+      }
+    } catch (e) {
+      if (e && (e as any).issues) throw e;
+    }
+
     const prompt = (config.prompt as string) || 'Please provide input:';
     const placeholder = (config.placeholder as string | undefined) || 'Enter your response...';
     const allowEmpty = (config.allow_empty as boolean | undefined) ?? false;

--- a/src/test-runner/assertions.ts
+++ b/src/test-runner/assertions.ts
@@ -31,6 +31,10 @@ export interface OutputsExpectation {
   equals?: unknown;
   equalsDeep?: unknown;
   matches?: string; // regex
+  gt?: number; // greater than
+  gte?: number; // greater than or equal
+  lt?: number; // less than
+  lte?: number; // less than or equal
   where?: {
     path: string;
     equals?: unknown;

--- a/src/test-runner/core/flow-stage.ts
+++ b/src/test-runner/core/flow-stage.ts
@@ -115,6 +115,7 @@ export class FlowStage {
           }
           return raw;
         },
+        isMockExhausted: (step: string) => mockMgr.has(step) && mockMgr.isExhausted(step),
       },
     } as any);
 

--- a/src/test-runner/core/mocks.ts
+++ b/src/test-runner/core/mocks.ts
@@ -1,6 +1,7 @@
 export class MockManager {
   private mocks: Record<string, unknown> = {};
   private cursors: Record<string, number> = {};
+  private consumed: Set<string> = new Set();
 
   constructor(mocks?: Record<string, unknown>) {
     if (mocks && typeof mocks === 'object') this.mocks = { ...mocks };
@@ -8,6 +9,7 @@ export class MockManager {
 
   reset(overrides?: Record<string, unknown>): void {
     this.cursors = {};
+    this.consumed = new Set();
     this.mocks = { ...this.mocks, ...(overrides || {}) };
   }
 
@@ -20,6 +22,26 @@ export class MockManager {
       this.cursors[listKey] = i + 1;
       return list[idx];
     }
-    return (this.mocks as any)[step];
+    const val = (this.mocks as any)[step];
+    if (val !== undefined) this.consumed.add(step);
+    return val;
+  }
+
+  /** Returns true if the mock for this step was already consumed (scalar) or has no more items (array). */
+  isExhausted(step: string): boolean {
+    const listKey = `${step}[]`;
+    const list = (this.mocks as any)[listKey];
+    if (Array.isArray(list)) {
+      const i = this.cursors[listKey] || 0;
+      return i >= list.length;
+    }
+    return this.consumed.has(step);
+  }
+
+  /** Returns true if a mock exists for this step (scalar or array). */
+  has(step: string): boolean {
+    return (
+      (this.mocks as any)[step] !== undefined || Array.isArray((this.mocks as any)[`${step}[]`])
+    );
   }
 }

--- a/src/test-runner/evaluators.ts
+++ b/src/test-runner/evaluators.ts
@@ -312,6 +312,29 @@ export function evaluateWorkflowOutputs(
         errors.push(`Workflow output ${path} missing elements (unordered)`);
       }
     }
+    // Numeric comparison operators
+    if (o.gt !== undefined) {
+      if (typeof v !== 'number')
+        errors.push(`Workflow output ${path} expected number for gt but got ${typeof v}`);
+      else if (!(v > o.gt)) errors.push(`Workflow output ${path} expected > ${o.gt} but got ${v}`);
+    }
+    if (o.gte !== undefined) {
+      if (typeof v !== 'number')
+        errors.push(`Workflow output ${path} expected number for gte but got ${typeof v}`);
+      else if (!(v >= o.gte))
+        errors.push(`Workflow output ${path} expected >= ${o.gte} but got ${v}`);
+    }
+    if (o.lt !== undefined) {
+      if (typeof v !== 'number')
+        errors.push(`Workflow output ${path} expected number for lt but got ${typeof v}`);
+      else if (!(v < o.lt)) errors.push(`Workflow output ${path} expected < ${o.lt} but got ${v}`);
+    }
+    if (o.lte !== undefined) {
+      if (typeof v !== 'number')
+        errors.push(`Workflow output ${path} expected number for lte but got ${typeof v}`);
+      else if (!(v <= o.lte))
+        errors.push(`Workflow output ${path} expected <= ${o.lte} but got ${v}`);
+    }
   }
 }
 
@@ -382,6 +405,31 @@ export function evaluateOutputs(
         errors.push(`Output ${o.step}.${o.path} not an array for contains_unordered`);
       else if (!containsUnordered(v as unknown[], o.contains_unordered))
         errors.push(`Output ${o.step}.${o.path} missing elements (unordered)`);
+    }
+    // Numeric comparison operators
+    if (o.gt !== undefined) {
+      if (typeof v !== 'number')
+        errors.push(`Output ${o.step}.${o.path} expected number for gt but got ${typeof v}`);
+      else if (!(v > o.gt))
+        errors.push(`Output ${o.step}.${o.path} expected > ${o.gt} but got ${v}`);
+    }
+    if (o.gte !== undefined) {
+      if (typeof v !== 'number')
+        errors.push(`Output ${o.step}.${o.path} expected number for gte but got ${typeof v}`);
+      else if (!(v >= o.gte))
+        errors.push(`Output ${o.step}.${o.path} expected >= ${o.gte} but got ${v}`);
+    }
+    if (o.lt !== undefined) {
+      if (typeof v !== 'number')
+        errors.push(`Output ${o.step}.${o.path} expected number for lt but got ${typeof v}`);
+      else if (!(v < o.lt))
+        errors.push(`Output ${o.step}.${o.path} expected < ${o.lt} but got ${v}`);
+    }
+    if (o.lte !== undefined) {
+      if (typeof v !== 'number')
+        errors.push(`Output ${o.step}.${o.path} expected number for lte but got ${typeof v}`);
+      else if (!(v <= o.lte))
+        errors.push(`Output ${o.step}.${o.path} expected <= ${o.lte} but got ${v}`);
     }
   }
 }

--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -474,6 +474,8 @@ export class VisorTestRunner {
           if (noMockSteps.size > 0 && noMockSteps.has(step)) return undefined;
           return mockMgr.get(step);
         },
+        // Signal to human-input provider that a mock is exhausted (goto loop re-entry)
+        isMockExhausted: (step: string) => mockMgr.has(step) && mockMgr.isExhausted(step),
         // Ensure human-input never blocks tests: prefer case mock, then default value
         onHumanInput: async (req: { checkId: string; default?: string }) => {
           if (noMocks) return (req.default ?? '').toString();

--- a/src/test-runner/validator.ts
+++ b/src/test-runner/validator.ts
@@ -327,6 +327,10 @@ const schema: any = {
         equals: {},
         equalsDeep: {},
         matches: { type: 'string' },
+        gt: { type: 'number' },
+        gte: { type: 'number' },
+        lt: { type: 'number' },
+        lte: { type: 'number' },
         where: {
           type: 'object',
           additionalProperties: false,
@@ -350,6 +354,10 @@ const schema: any = {
         equals: {},
         equalsDeep: {},
         matches: { type: 'string' },
+        gt: { type: 'number' },
+        gte: { type: 'number' },
+        lt: { type: 'number' },
+        lte: { type: 'number' },
         contains: {
           oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
         },
@@ -498,6 +506,11 @@ const knownKeys = new Set([
   'equalsDeep',
   'where',
   'contains_unordered',
+  // numeric comparisons
+  'gt',
+  'gte',
+  'lt',
+  'lte',
   // routing
   'max_loops',
 ]);

--- a/tests/unit/numeric-assertions.test.ts
+++ b/tests/unit/numeric-assertions.test.ts
@@ -1,0 +1,96 @@
+import { evaluateOutputs, evaluateWorkflowOutputs } from '../../src/test-runner/evaluators';
+import type { ExpectBlock } from '../../src/test-runner/assertions';
+
+describe('Numeric comparison operators in output assertions', () => {
+  const outputHistory: Record<string, unknown[]> = {
+    calc: [{ settlement: { deductions: 5, barCutAmount: 0, total: -1 }, count: 3 }],
+  };
+
+  it('gt passes when value is greater', () => {
+    const errors: string[] = [];
+    const exp: ExpectBlock = {
+      outputs: [{ step: 'calc', path: 'settlement.deductions', gt: 0 }],
+    };
+    evaluateOutputs(errors, exp, outputHistory);
+    expect(errors).toEqual([]);
+  });
+
+  it('gt fails when value is equal', () => {
+    const errors: string[] = [];
+    const exp: ExpectBlock = {
+      outputs: [{ step: 'calc', path: 'count', gt: 3 }],
+    };
+    evaluateOutputs(errors, exp, outputHistory);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('expected > 3 but got 3');
+  });
+
+  it('gte passes when value is equal', () => {
+    const errors: string[] = [];
+    const exp: ExpectBlock = {
+      outputs: [{ step: 'calc', path: 'count', gte: 3 }],
+    };
+    evaluateOutputs(errors, exp, outputHistory);
+    expect(errors).toEqual([]);
+  });
+
+  it('gte fails when value is less', () => {
+    const errors: string[] = [];
+    const exp: ExpectBlock = {
+      outputs: [{ step: 'calc', path: 'count', gte: 4 }],
+    };
+    evaluateOutputs(errors, exp, outputHistory);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('expected >= 4 but got 3');
+  });
+
+  it('lt passes when value is less', () => {
+    const errors: string[] = [];
+    const exp: ExpectBlock = {
+      outputs: [{ step: 'calc', path: 'settlement.total', lt: 0 }],
+    };
+    evaluateOutputs(errors, exp, outputHistory);
+    expect(errors).toEqual([]);
+  });
+
+  it('lte passes when value is equal', () => {
+    const errors: string[] = [];
+    const exp: ExpectBlock = {
+      outputs: [{ step: 'calc', path: 'settlement.barCutAmount', lte: 0 }],
+    };
+    evaluateOutputs(errors, exp, outputHistory);
+    expect(errors).toEqual([]);
+  });
+
+  it('reports type error for non-numeric value', () => {
+    const history: Record<string, unknown[]> = {
+      step1: [{ val: 'hello' }],
+    };
+    const errors: string[] = [];
+    const exp: ExpectBlock = {
+      outputs: [{ step: 'step1', path: 'val', gt: 0 }],
+    };
+    evaluateOutputs(errors, exp, history);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('expected number for gt but got string');
+  });
+
+  it('works with workflow_output assertions', () => {
+    const errors: string[] = [];
+    const exp: ExpectBlock = {
+      workflow_output: [{ path: 'total', gte: 1 }],
+    } as any;
+    evaluateWorkflowOutputs(errors, exp, { total: 5 });
+    expect(errors).toEqual([]);
+  });
+
+  it('workflow_output gt fails correctly', () => {
+    const errors: string[] = [];
+    const exp: ExpectBlock = {
+      workflow_output: [{ path: 'total', gt: 10 }],
+    } as any;
+    evaluateWorkflowOutputs(errors, exp, { total: 5 });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('expected > 10 but got 5');
+  });
+});


### PR DESCRIPTION
## Summary
- **#486**: Add `gt`, `gte`, `lt`, `lte` numeric comparison operators to test framework output assertions (both `outputs` and `workflow_output`)
- **#487**: Auto-terminate goto loops when human-input mocks are exhausted, preventing tests from wasting time looping with empty/default input

## Changes
- `assertions.ts` — Added numeric comparison fields to `OutputsExpectation` interface
- `validator.ts` — Added schema validation and typo suggestion support for new operators
- `evaluators.ts` — Added evaluation logic for numeric comparisons with type checking
- `mocks.ts` — Added `isExhausted()` and `has()` methods to `MockManager`
- `check-provider.interface.ts` — Added `isMockExhausted` hook to `ExecutionContext`
- `human-input-check-provider.ts` — Check mock exhaustion before test-mode fallback
- `index.ts`, `flow-stage.ts` — Wire up `isMockExhausted` hook in both test runners

## Key design decision
The mock exhaustion check only applies to `human-input` provider steps. Regular steps retain the existing last-element-repeat behavior for array mocks, which is needed for goto loops that intentionally re-run steps with the same mock value.

## Test plan
- [x] New unit tests for all numeric operators (gt, gte, lt, lte) including edge cases and type errors
- [x] All 303 Jest test suites pass (3185 tests)
- [x] All 122 YAML integration tests pass (20 suites)

Closes #486, closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)