### PR TITLE
fix: build conversation context for root message triggers

### DIFF
--- a/src/slack/socket-runner.ts
+++ b/src/slack/socket-runner.ts
@@ -904,11 +904,12 @@ export class SlackSocketRunner {
         return;
       }
 
-      // Build conversation context (for thread replies, fetch full thread)
+      // Build conversation context
       let conversationContext: any = undefined;
       try {
         const isThreadReply = !!threadTs && threadTs !== ts;
         if (isThreadReply) {
+          // Thread reply: fetch full thread history
           const adapter = this.getSlackAdapter();
           if (adapter && channel && threadTs) {
             const cleanedText = String(ev.text || '')
@@ -929,6 +930,23 @@ export class SlackSocketRunner {
         );
       }
 
+      // For root messages without thread context, build a minimal conversation
+      // so that {{ conversation.current.text }} works in templates
+      if (!conversationContext) {
+        const cleanedText = String(ev.text || '')
+          .replace(/<@[A-Z0-9]+>/g, '')
+          .trim();
+        conversationContext = {
+          current: {
+            user,
+            text: cleanedText || String(ev.text || ''),
+            timestamp: Date.now(),
+            files: Array.isArray(ev.files) ? ev.files : undefined,
+          },
+          messages: [],
+        };
+      }
+
       // Build synthetic webhook payload
       const triggerPayload = {
         ...payload,
@@ -937,7 +955,7 @@ export class SlackSocketRunner {
           type: 'on_message',
           workflow: trigger.workflow,
         },
-        ...(conversationContext ? { slack_conversation: conversationContext } : {}),
+        slack_conversation: conversationContext,
       };
 
       const webhookData = new Map<string, unknown>();


### PR DESCRIPTION
## Summary
- Message triggers on root (non-thread) messages crashed with `Cannot get property current of null` because `conversation.current.text` was evaluated but `conversation` was null
- Root cause: `dispatchMessageTrigger` only built conversation context for thread replies, leaving it `undefined` for root messages
- Fix: always build a minimal conversation object with `current.text` from the incoming message, matching what the scheduler already does for scheduled events

## Test plan
- [x] `npm run build` passes
- [x] All 122 YAML tests pass
- [ ] Manual test: configure a message trigger on a channel, send a root message → should process without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)