### PR TITLE
feat: add transform_js support for http_client tools

### DIFF
--- a/docs/custom-tools.md
+++ b/docs/custom-tools.md
@@ -196,12 +196,19 @@ Tools have access to a rich template context through Liquid templates:
 - `{{ outputs }}` - Outputs from previous checks
 - `{{ env }}` - Environment variables
 
-### In `transform` and `transform_js`:
+### In `transform` and `transform_js` (command tools):
 - All of the above, plus:
 - `{{ output }}` - The raw command output (or parsed JSON if `parseJson: true`)
 - `{{ stdout }}` - Standard output (raw string)
 - `{{ stderr }}` - Standard error (raw string)
 - `{{ exitCode }}` - Command exit code (number)
+
+### In `transform_js` (http_client tools):
+- `output` - Parsed response body (JSON object or string)
+- `path` - API path called (e.g. `/jobs/ABC/candidates`)
+- `method` - HTTP method (`GET`, `POST`, etc.)
+- `query` - Query parameters object
+- `args` - Full tool arguments as passed by the AI
 
 ## Examples
 
@@ -365,6 +372,69 @@ Runnable examples in this repo:
 - `examples/api-tools-mcp-example.yaml` (includes embedded tests)
 - `examples/api-tools-ai-example.yaml` (includes embedded tests)
 - `examples/api-tools-inline-overlay-example.yaml` (includes embedded tests)
+
+### 6. HTTP Client Tool (`type: http_client`)
+
+Expose a REST API as a single MCP tool that the AI can call with arbitrary paths, methods, and parameters:
+
+```yaml
+tools:
+  my-api:
+    type: http_client
+    name: my-api
+    description: Call the Example API
+    base_url: "https://api.example.com/v1"
+    auth:
+      type: bearer
+      token: "${API_TOKEN}"
+    headers:
+      Content-Type: "application/json"
+```
+
+The AI receives a tool with `path`, `method`, `query`, and `body` parameters and can call any endpoint under `base_url`.
+
+**HTTP Client Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `base_url` | Base URL for all API calls | Required |
+| `auth` | Authentication config (`type: bearer`, `token`) | - |
+| `headers` | Default headers (supports `${ENV_VAR}` substitution) | {} |
+| `timeout` | Request timeout in milliseconds | 30000 |
+| `transform_js` | JavaScript to transform every response | - |
+
+**Response Transform with `transform_js`:**
+
+The `transform_js` runs after every API response and receives request context for conditional logic:
+
+```yaml
+tools:
+  my-api:
+    type: http_client
+    base_url: "https://api.example.com/v1"
+    auth:
+      type: bearer
+      token: "${API_TOKEN}"
+    transform_js: |
+      // Available variables:
+      //   output  - parsed response body (JSON object or string)
+      //   path    - API path called (e.g. "/candidates")
+      //   method  - HTTP method (e.g. "GET")
+      //   query   - query parameters object
+      //   args    - full tool arguments
+
+      // Example: filter results conditionally based on endpoint
+      if (path.includes('/candidates') && output.candidates) {
+        output.candidates = output.candidates.filter(c => !c.disqualified);
+      }
+      return output;
+```
+
+This is useful for:
+- **Filtering broken API responses** (e.g. when query params are ignored by the API)
+- **Normalizing data** across endpoints
+- **Stripping sensitive fields** before they reach the AI
+- **Reducing token usage** by removing unnecessary data
 
 ## Tool Libraries and Extends
 

--- a/src/providers/mcp-custom-sse-server.ts
+++ b/src/providers/mcp-custom-sse-server.ts
@@ -22,6 +22,7 @@ import {
 // Legacy Slack-specific imports for backwards compatibility
 import { extractSlackContext } from '../slack/schedule-tool-handler';
 import { EnvironmentResolver } from '../utils/env-resolver';
+import { createSecureSandbox, compileAndRun } from '../utils/sandbox';
 
 /**
  * Check if a tool definition is an http_client tool
@@ -1104,24 +1105,70 @@ export class CustomToolsSSEServer implements CustomMCPServer {
 
       // Parse response
       const contentType = response.headers.get('content-type');
+      let result: unknown;
       if (contentType && contentType.includes('application/json')) {
-        return await response.json();
-      }
-
-      const text = await response.text();
-      if (text.trim().startsWith('{') || text.trim().startsWith('[')) {
-        try {
-          return JSON.parse(text);
-        } catch {
-          return text;
+        result = await response.json();
+      } else {
+        const text = await response.text();
+        if (text.trim().startsWith('{') || text.trim().startsWith('[')) {
+          try {
+            result = JSON.parse(text);
+          } catch {
+            result = text;
+          }
+        } else {
+          result = text;
         }
       }
-      return text;
+
+      // Apply transform_js if specified
+      if (tool.transform_js) {
+        result = await this.applyHttpClientTransform(tool.transform_js, result, {
+          path: apiPath,
+          method,
+          query: queryParams,
+          url,
+          args,
+        });
+      }
+
+      return result;
     } catch (error: unknown) {
       clearTimeout(timeoutId);
       if (error instanceof Error && error.name === 'AbortError') {
         throw new Error(`HTTP client request timed out after ${timeout}ms`);
       }
+      throw error;
+    }
+  }
+
+  /**
+   * Apply a JavaScript transform to an http_client tool response.
+   * The transform receives `output` (parsed response) and `context` with request details
+   * (path, method, query, url, args) for conditional logic per endpoint.
+   */
+  private async applyHttpClientTransform(
+    transformJs: string,
+    output: unknown,
+    context: Record<string, unknown>
+  ): Promise<unknown> {
+    const sandbox = createSecureSandbox();
+
+    const code = `
+      const output = ${JSON.stringify(output)};
+      const context = ${JSON.stringify(context)};
+      const path = context.path || '';
+      const method = context.method || 'GET';
+      const query = context.query || {};
+      const args = context.args || {};
+
+      ${transformJs}
+    `;
+
+    try {
+      return await compileAndRun(sandbox, code, { timeout: 5000 });
+    } catch (error) {
+      logger.error(`[CustomToolsSSEServer] HTTP client transform_js error: ${error}`);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

- Implements `transform_js` for `http_client` tool type in `mcp-custom-sse-server.ts`, matching existing support for command tools
- The transform runs in a secure sandbox after every API response and receives request context (`path`, `method`, `query`, `args`) for conditional per-endpoint logic
- Documents the feature in `docs/custom-tools.md` with a new HTTP Client Tool section, options table, usage examples, and updated transform context reference

**Use case:** Post-process API responses — e.g. filter out disqualified candidates from Workable API (whose `disqualified` query param is broken and ignored server-side).

```yaml
tools:
  my-api:
    type: http_client
    base_url: "https://api.example.com/v1"
    transform_js: |
      if (path.includes('/candidates') && output.candidates) {
        output.candidates = output.candidates.filter(c => !c.disqualified);
      }
      return output;
```

## Test plan

- [ ] Verify build passes with `npm run build`
- [ ] Test with a real `http_client` tool with `transform_js` filtering responses
- [ ] Confirm transform receives correct `path`, `method`, `query` context
- [ ] Verify transform errors are caught and logged properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)