### PR TITLE
fix: missing event triggers and test runner config path resolution

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,10 @@ export const VALID_EVENT_TRIGGERS: readonly EventTrigger[] = [
   'schedule',
   'webhook_received',
   'slack_message',
+  'telegram_message',
+  'email_message',
+  'whatsapp_message',
+  'teams_message',
 ] as const;
 
 /**

--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -761,6 +761,28 @@ export class VisorTestRunner {
       } catch {
         throw new Error(`Explicit tests file not accessible: ${resolved}`);
       }
+      // If the explicit path is a config file (not a .tests.yaml), look for
+      // tests files relative to the config file's directory (#503).
+      if (!/\.tests\.ya?ml$/i.test(resolved)) {
+        const configDir = path.dirname(resolved);
+        const testsCandidates = [
+          path.resolve(configDir, 'defaults/visor.tests.yaml'),
+          path.resolve(configDir, 'defaults/visor.tests.yml'),
+          path.resolve(configDir, '.visor.tests.yaml'),
+          path.resolve(configDir, '.visor.tests.yml'),
+        ];
+        for (const p of testsCandidates) {
+          const np = path.normalize(p);
+          if (!np.startsWith(normalizedCwd)) continue;
+          try {
+            if (fs.statSync(p).isFile()) return p;
+          } catch {
+            continue;
+          }
+        }
+        // Fall through to return the explicit path as-is (loadSuite will
+        // report a clear error if it's not a valid tests file).
+      }
       return resolved;
     }
     const candidates = [


### PR DESCRIPTION
## Summary

- Add `telegram_message`, `email_message`, `whatsapp_message`, `teams_message` to `VALID_EVENT_TRIGGERS` in `config.ts` — the `EventTrigger` type and SDK already had them but the CLI validator array was stale (fixes #502)
- When `visor test --config agent/assistant.yaml` is run from the project root, look for `.visor.tests.yaml` relative to the config file's directory (`agent/`), not just `process.cwd()` (fixes #503)

## Test plan

- [x] `npm run build` succeeds
- [x] All config tests pass (144 tests)
- [x] Pre-commit hooks pass (lint, format, full test suite)
- [ ] Verify `visor validate --config` accepts `telegram_message` in `on:` triggers
- [ ] Verify `visor test --config agent/assistant.yaml` discovers `agent/.visor.tests.yaml`

Closes #502, Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)