### PR TITLE
fix: remove bash code-exploration commands from explore-code and add worktree ops

### DIFF
--- a/defaults/code-talk.yaml
+++ b/defaults/code-talk.yaml
@@ -491,14 +491,13 @@ steps:
           - "git:rev-parse:*"
           - "git:ls-files:*"
           - "git:ls-tree:*"
-          # File operations
+          - "git:worktree:list:*"
+          - "git:worktree:remove:*"
+          # File operations — ONLY ls and wc allowed
+          # Do NOT use cat/grep/find/head/tail for code exploration —
+          # use search() and extract() tools instead, they are faster and more accurate
           - "ls:*"
-          - "find:*"
-          - "cat:*"
-          - "head:*"
-          - "tail:*"
           - "wc:*"
-          - "grep:*"
           # GitHub CLI read-only operations
           - "gh:run:*"
           - "gh:run:list:*"


### PR DESCRIPTION
## Summary

Root cause analysis of trace `00b606ac` showed that the `explore-code` step in the `code-talk` workflow wastes iterations using bash commands (`cat`, `grep`, `find`) instead of Probe's native `search`/`extract` tools. Additionally, stale worktrees from previous sessions block branch checkout, and `git worktree remove` was denied by the bash permission policy.

**Changes:**
- Remove `cat`, `grep`, `find`, `head`, `tail` from explore-code's bash allow list — forces the model to use Probe's `search()`/`extract()` tools which are faster and more accurate
- Add `git:worktree:list` and `git:worktree:remove` to allow cleanup of stale worktrees

**Before:** explore-code burned 44 iterations on bash (`cat -n file | grep "pattern"`, `grep -i "group" file1 file2 file3`, etc.)
**After:** those commands are denied, forcing the model to use `search("group")` and `extract("file.mdx")` instead

## Test plan

- [ ] Run code-explorer against a multi-repo question and verify it uses search/extract instead of bash
- [ ] Verify stale worktree cleanup works with `git worktree remove`
- [ ] Verify `ls` and `wc` still work (kept in allow list)
- [ ] Verify git read-only commands still work (`git diff`, `git log`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)