### PR TITLE
fix: extract telegram_conversation into eventContext alongside slack_conversation

### DIFF
--- a/src/providers/ai-check-provider.ts
+++ b/src/providers/ai-check-provider.ts
@@ -80,7 +80,9 @@ export class AICheckProvider extends CheckProvider {
       const first = Array.from(map.values())[0] as any;
       if (!first || typeof first !== 'object') return {};
       const ev = first.event;
-      const conv = first.slack_conversation;
+      const slackConv = first.slack_conversation;
+      const telegramConv = first.telegram_conversation;
+      const conv = slackConv || telegramConv;
       if (!ev && !conv) return {};
       // Attach conversation to prInfo so downstream helpers (XML context) can use it
       if (conv && prInfo) {
@@ -90,7 +92,11 @@ export class AICheckProvider extends CheckProvider {
           // best-effort only
         }
       }
-      return { slack: { event: ev, conversation: conv } };
+      // Build transport-specific context
+      const transportCtx = slackConv
+        ? { slack: { event: ev, conversation: slackConv } }
+        : { telegram: { event: ev, conversation: telegramConv } };
+      return { ...transportCtx, conversation: conv };
     } catch {
       return {};
     }

--- a/src/state-machine/states/level-dispatch.ts
+++ b/src/state-machine/states/level-dispatch.ts
@@ -817,7 +817,7 @@ async function executeCheckWithForEachItems(
         }
       } catch {}
 
-      // Extract Slack conversation from webhookContext (for Slack socket mode)
+      // Extract conversation from webhookContext (for Slack/Telegram socket mode)
       // The socket-runner stores conversation data in webhookData under the endpoint key
       try {
         const webhookCtx = (context.executionContext as any)?.webhookContext;
@@ -828,27 +828,29 @@ async function executeCheckWithForEachItems(
           );
         }
         if (webhookData && webhookData.size > 0) {
-          // Find the payload with slack_conversation
+          // Find the payload with slack_conversation or telegram_conversation
           for (const payload of webhookData.values()) {
             const slackConv = (payload as any)?.slack_conversation;
-            if (slackConv) {
-              // Build slack context with event and conversation
+            const telegramConv = (payload as any)?.telegram_conversation;
+            const conv = slackConv || telegramConv;
+            if (conv) {
               const event = (payload as any)?.event;
-              const messageCount = Array.isArray(slackConv?.messages)
-                ? slackConv.messages.length
+              const messageCount = Array.isArray(conv?.messages)
+                ? conv.messages.length
                 : 0;
               if (context.debug) {
                 logger.info(
-                  `[LevelDispatch] Slack conversation extracted: ${messageCount} messages`
+                  `[LevelDispatch] Conversation extracted (${conv?.transport || 'unknown'}): ${messageCount} messages`
                 );
               }
+              // Build transport-specific context
+              const transportCtx = slackConv
+                ? { slack: { event: event || {}, conversation: slackConv } }
+                : { telegram: { event: event || {}, conversation: telegramConv }, webhook: payload };
               (providerConfig as any).eventContext = {
                 ...(providerConfig as any).eventContext,
-                slack: {
-                  event: event || {},
-                  conversation: slackConv,
-                },
-                conversation: slackConv, // Also expose at top level for convenience
+                ...transportCtx,
+                conversation: conv, // Expose at top level for all transports
               };
               break;
             }
@@ -857,7 +859,7 @@ async function executeCheckWithForEachItems(
       } catch {}
 
       // Fallback: expose conversation from executionContext (for CLI --message)
-      // Only if no Slack conversation was set above
+      // Only if no conversation was set above
       try {
         if (
           !(providerConfig as any).eventContext?.conversation &&
@@ -2266,7 +2268,7 @@ async function executeSingleCheck(
       }
     } catch {}
 
-    // Extract Slack conversation from webhookContext (for Slack socket mode)
+    // Extract conversation from webhookContext (for Slack/Telegram socket mode)
     // The socket-runner stores conversation data in webhookData under the endpoint key
     try {
       const webhookCtx = (context.executionContext as any)?.webhookContext;
@@ -2277,23 +2279,25 @@ async function executeSingleCheck(
         );
       }
       if (webhookData && webhookData.size > 0) {
-        // Find the payload with slack_conversation
+        // Find the payload with slack_conversation or telegram_conversation
         for (const payload of webhookData.values()) {
           const slackConv = (payload as any)?.slack_conversation;
-          if (slackConv) {
-            // Build slack context with event and conversation
+          const telegramConv = (payload as any)?.telegram_conversation;
+          const conv = slackConv || telegramConv;
+          if (conv) {
             const event = (payload as any)?.event;
-            const messageCount = Array.isArray(slackConv?.messages) ? slackConv.messages.length : 0;
+            const messageCount = Array.isArray(conv?.messages) ? conv.messages.length : 0;
             if (context.debug) {
-              logger.info(`[LevelDispatch] Slack conversation extracted: ${messageCount} messages`);
+              logger.info(`[LevelDispatch] Conversation extracted (${conv?.transport || 'unknown'}): ${messageCount} messages`);
             }
+            // Build transport-specific context
+            const transportCtx = slackConv
+              ? { slack: { event: event || {}, conversation: slackConv } }
+              : { telegram: { event: event || {}, conversation: telegramConv }, webhook: payload };
             (providerConfig as any).eventContext = {
               ...(providerConfig as any).eventContext,
-              slack: {
-                event: event || {},
-                conversation: slackConv,
-              },
-              conversation: slackConv, // Also expose at top level for convenience
+              ...transportCtx,
+              conversation: conv, // Expose at top level for all transports
             };
             break;
           }
@@ -2302,7 +2306,7 @@ async function executeSingleCheck(
     } catch {}
 
     // Fallback: expose conversation from executionContext (for CLI --message)
-    // Only if no Slack conversation was set above
+    // Only if no conversation was set above
     try {
       if (
         !(providerConfig as any).eventContext?.conversation &&


### PR DESCRIPTION
## Summary

Fixes #506

The engine's conversation context extraction in `level-dispatch.ts` and `ai-check-provider.ts` only checked for `slack_conversation` in webhook payloads. When a Telegram bot trigger fires, the webhook payload contains `telegram_conversation` instead, but this was never extracted — causing the AI provider to receive no conversation context for Telegram-originated checks.

### Changes

- **`src/state-machine/states/level-dispatch.ts`** — In both `executeCheckWithForEachItems` and `executeSingleCheck`, the extraction loop now checks for `telegram_conversation` alongside `slack_conversation`. When found, it builds a transport-specific context (`telegram: { event, conversation }`) mirroring the existing `slack` structure, and always sets a top-level `conversation` field regardless of transport.
- **`src/providers/ai-check-provider.ts`** — `extractSlackContext` now also extracts `telegram_conversation`, returning the appropriate transport-specific key and a top-level `conversation` for downstream consumers.
- Debug log messages updated from "Slack conversation extracted" to a transport-generic format.

### Backward compatibility

- Slack payloads continue to produce the same `{ slack: { event, conversation } }` structure as before.
- The top-level `conversation` field (already present for Slack) is now consistently set for both transports.

## Test plan

- [ ] Verify existing Slack conversation context extraction still works (slack_conversation payload produces `eventContext.slack`)
- [ ] Verify Telegram conversation context extraction works (telegram_conversation payload produces `eventContext.telegram` and `eventContext.conversation`)
- [ ] Verify fallback to CLI `--message` conversation still works when neither transport is present