### PR TITLE
fix: protect worktree-checked-out branches from deletion

### DIFF
--- a/src/utils/workspace-manager.ts
+++ b/src/utils/workspace-manager.ts
@@ -643,10 +643,31 @@ export class WorkspaceManager {
   }
 
   /**
-   * Delete all local branches in a worktree.
+   * Delete local branches in a worktree that are safe to remove.
+   * IMPORTANT: Git worktrees share the branch namespace with the main repo
+   * and all other worktrees. We must NOT delete branches that are checked out
+   * in the main working tree or any other worktree — doing so would destroy
+   * the user's work.
    */
   private async deleteLocalBranches(worktreePath: string): Promise<void> {
     const escapedPath = shellEscape(worktreePath);
+
+    // First, discover which branches are checked out in ANY worktree (including main).
+    // `git worktree list --porcelain` output contains "branch refs/heads/<name>" lines.
+    const worktreeListResult = await commandExecutor.execute(
+      `git -C ${escapedPath} worktree list --porcelain`,
+      { timeout: 10000 }
+    );
+    const protectedBranches = new Set<string>();
+    if (worktreeListResult.exitCode === 0) {
+      for (const line of worktreeListResult.stdout.split('\n')) {
+        const match = line.match(/^branch refs\/heads\/(.+)$/);
+        if (match) {
+          protectedBranches.add(match[1]);
+        }
+      }
+    }
+
     const listResult = await commandExecutor.execute(
       `git -C ${escapedPath} branch --list --format='%(refname:short)'`,
       { timeout: 10000 }
@@ -662,6 +683,10 @@ export class WorkspaceManager {
       .filter(b => b.length > 0);
 
     for (const branch of branches) {
+      if (protectedBranches.has(branch)) {
+        logger.debug(`[Workspace] Skipping branch '${branch}' — checked out in another worktree`);
+        continue;
+      }
       const deleteResult = await commandExecutor.execute(
         `git -C ${escapedPath} branch -D ${shellEscape(branch)}`,
         { timeout: 10000 }

--- a/src/utils/worktree-manager.ts
+++ b/src/utils/worktree-manager.ts
@@ -648,11 +648,29 @@ export class WorktreeManager {
   }
 
   /**
-   * Delete all local branches in a worktree.
+   * Delete local branches in a worktree that are safe to remove.
    * Worktrees are always used in detached HEAD state, so any local branches
    * were unintentionally created and should be cleaned up.
+   * IMPORTANT: Git worktrees share the branch namespace with the main repo
+   * and all other worktrees. We must NOT delete branches that are checked out
+   * in the main working tree or any other worktree — doing so would destroy
+   * the user's work.
    */
   private async deleteLocalBranches(worktreePath: string): Promise<void> {
+    // First, discover which branches are checked out in ANY worktree (including main).
+    // `git worktree list --porcelain` output contains "branch refs/heads/<name>" lines.
+    const worktreeListCmd = `git -C ${this.escapeShellArg(worktreePath)} worktree list --porcelain`;
+    const worktreeListResult = await this.executeGitCommand(worktreeListCmd, { timeout: 10000 });
+    const protectedBranches = new Set<string>();
+    if (worktreeListResult.exitCode === 0) {
+      for (const line of worktreeListResult.stdout.split('\n')) {
+        const match = line.match(/^branch refs\/heads\/(.+)$/);
+        if (match) {
+          protectedBranches.add(match[1]);
+        }
+      }
+    }
+
     const listCmd = `git -C ${this.escapeShellArg(worktreePath)} branch --list --format='%(refname:short)'`;
     const listResult = await this.executeGitCommand(listCmd, { timeout: 10000 });
     if (listResult.exitCode !== 0 || !listResult.stdout.trim()) {
@@ -666,6 +684,10 @@ export class WorktreeManager {
       .filter(b => b.length > 0);
 
     for (const branch of branches) {
+      if (protectedBranches.has(branch)) {
+        logger.debug(`Skipping branch '${branch}' — checked out in another worktree`);
+        continue;
+      }
       const deleteCmd = `git -C ${this.escapeShellArg(worktreePath)} branch -D ${this.escapeShellArg(branch)}`;
       const deleteResult = await this.executeGitCommand(deleteCmd, { timeout: 10000 });
       if (deleteResult.exitCode === 0) {

--- a/tests/unit/workspace-manager.test.ts
+++ b/tests/unit/workspace-manager.test.ts
@@ -487,8 +487,8 @@ describe('WorkspaceManager', () => {
         fs.mkdirSync(testOriginalPath, { recursive: true });
       }
 
-      // First init: createMainProjectWorktree (fetch, resolve, sha, worktree add, reset, clean, branch --list)
-      // Second init: refreshWorktreeToUpstream (fetch, resolve, sha, checkout, reset, clean, branch --list)
+      // First init: createMainProjectWorktree (fetch, resolve, sha, worktree add, reset, clean, worktree list, branch --list)
+      // Second init: refreshWorktreeToUpstream (fetch, resolve, sha, checkout, reset, clean, worktree list, branch --list)
       commandExecutor.execute
         // --- First init: createMainProjectWorktree ---
         .mockResolvedValueOnce({ exitCode: 0, stdout: '.git', stderr: '' }) // isGitRepository(original)
@@ -499,6 +499,7 @@ describe('WorkspaceManager', () => {
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // reset --hard
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // clean -fdx
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree list --porcelain (protected branches)
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch --list (no local branches)
         // --- Second init: reuse path → refreshWorktreeToUpstream ---
         .mockResolvedValueOnce({ exitCode: 0, stdout: '.git', stderr: '' }) // isGitRepository(original) on 2nd init
@@ -510,6 +511,7 @@ describe('WorkspaceManager', () => {
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // checkout --detach
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // reset --hard
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // clean -fdx
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree list --porcelain (protected branches)
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // branch --list (no local branches)
 
       const manager1 = WorkspaceManager.getInstance('reuse-git-1', testOriginalPath, {
@@ -556,7 +558,7 @@ describe('WorkspaceManager', () => {
         fs.mkdirSync(testOriginalPath, { recursive: true });
       }
 
-      // First init: createMainProjectWorktree (fetch, resolve, sha, worktree add, reset, clean, branch --list)
+      // First init: createMainProjectWorktree (fetch, resolve, sha, worktree add, reset, clean, worktree list, branch --list)
       // Second init: invalid path → prune → createMainProjectWorktree again
       commandExecutor.execute
         // --- First init: createMainProjectWorktree ---
@@ -568,6 +570,7 @@ describe('WorkspaceManager', () => {
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // reset --hard
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // clean -fdx
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree list --porcelain (protected branches)
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch --list (no local branches)
         // --- Second init: invalid worktree → recreate ---
         .mockResolvedValueOnce({ exitCode: 0, stdout: '.git', stderr: '' }) // isGitRepository(original) 2nd
@@ -580,6 +583,7 @@ describe('WorkspaceManager', () => {
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add (recreate)
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // reset --hard
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // clean -fdx
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree list --porcelain (protected branches)
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // branch --list (no local branches)
 
       const manager1 = WorkspaceManager.getInstance('invalid-wt-1', testOriginalPath, {
@@ -971,6 +975,7 @@ describe('WorkspaceManager', () => {
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // reset --hard
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // clean -fdx
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree list --porcelain (protected branches)
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch --list (no local branches)
         // --- Second init: refreshWorktreeToUpstream with checkout failure ---
         .mockResolvedValueOnce({ exitCode: 0, stdout: '.git', stderr: '' }) // isGitRepository(original)
@@ -982,6 +987,7 @@ describe('WorkspaceManager', () => {
         .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'checkout failed' }) // checkout --detach FAILS
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // reset --hard HEAD (cleanup fallback)
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // clean -fdx
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree list --porcelain (protected branches)
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // branch --list (no local branches)
 
       const manager1 = WorkspaceManager.getInstance('checkout-fail-1', testOriginalPath, {
@@ -1030,6 +1036,7 @@ describe('WorkspaceManager', () => {
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
         .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'reset failed' }) // reset --hard FAILS
         .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'clean failed' }) // clean -fdx FAILS
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree list --porcelain (protected branches)
         .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }); // branch --list (no local branches)
 
       const manager = WorkspaceManager.getInstance('reset-fail-1', testOriginalPath, {


### PR DESCRIPTION
## Summary
- `deleteLocalBranches()` in both `workspace-manager.ts` and `worktree-manager.ts` now queries `git worktree list --porcelain` before deleting branches
- Branches currently checked out in any worktree are skipped during cleanup, preventing destruction of in-progress work in other worktrees
- Updated workspace-manager tests to include the new worktree list command in mock sequences

## Context
Found during trace analysis of `00b606ac4424ecfd4358ee0f704216ee` — git worktrees share branch namespaces with the main repo, so `git branch -D` in one workspace can destroy branches actively used by another workspace.

## Test plan
- [ ] Existing workspace-manager tests pass (updated mocks)
- [ ] Manual: create two worktrees with different branches, run cleanup on one — verify the other's branch is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)