### PR TITLE
fix: respect step-level timeout and post errors to Slack on AI timeout

### DIFF
--- a/src/frontends/slack-frontend.ts
+++ b/src/frontends/slack-frontend.ts
@@ -534,6 +534,26 @@ export class SlackFrontend implements Frontend {
         text = (text || '') + '\n\n' + out._rawOutput.trim();
       }
 
+      // Fallback: if no text was extracted, check for error issues (e.g. timeout)
+      // and post an error message so the user isn't left with silence.
+      if (!text) {
+        const issues: any[] = (result as any)?.issues || [];
+        const errorIssues = issues.filter(
+          (i: any) =>
+            i.severity === 'error' &&
+            (i.ruleId?.startsWith('system/') || i.ruleId?.endsWith('/error'))
+        );
+        if (errorIssues.length > 0) {
+          const errorMessages = errorIssues.map((i: any) => i.message).join('\n');
+          text = `:warning: Something went wrong while processing your request:\n${errorMessages}`;
+          // Prevent maybePostExecutionFailure from double-posting the same error
+          this.errorNotified = true;
+          ctx.logger.warn(
+            `[slack-frontend] posting error fallback for ${checkId}: ${errorIssues.length} system error(s)`
+          );
+        }
+      }
+
       if (!text) {
         ctx.logger.info(
           `[slack-frontend] skip posting AI reply for ${checkId}: no renderable text in check output`

--- a/src/state-machine/dispatch/execution-invoker.ts
+++ b/src/state-machine/dispatch/execution-invoker.ts
@@ -638,7 +638,7 @@ export async function executeSingleCheck(
       workflowInputs,
       ai: {
         ...(checkConfig.ai || {}),
-        timeout: checkConfig.ai?.timeout || 1800000,
+        timeout: checkConfig.timeout || checkConfig.ai?.timeout || 1800000,
         debug: !!context.debug,
       },
     };
@@ -759,7 +759,7 @@ export async function executeSingleCheck(
           context,
           prInfo,
           dependencyResults,
-          checkConfig.ai?.timeout || 1800000,
+          checkConfig.timeout || checkConfig.ai?.timeout || 1800000,
           () => provider.execute(prInfo, providerConfig, dependencyResults, executionContext)
         );
         // Capture output in span for trace visualization

--- a/src/state-machine/dispatch/foreach-processor.ts
+++ b/src/state-machine/dispatch/foreach-processor.ts
@@ -191,7 +191,7 @@ export async function executeCheckWithForEachItems(
         workflowInputs,
         ai: {
           ...(checkConfig.ai || {}),
-          timeout: checkConfig.ai?.timeout || 1800000,
+          timeout: checkConfig.timeout || checkConfig.ai?.timeout || 1800000,
           debug: !!context.debug,
         },
       };
@@ -289,7 +289,7 @@ export async function executeCheckWithForEachItems(
             context,
             prInfo,
             dependencyResults,
-            checkConfig.ai?.timeout || 1800000,
+            checkConfig.timeout || checkConfig.ai?.timeout || 1800000,
             () => provider.execute(prInfo, providerConfig, dependencyResults, executionContext)
           );
           try {

--- a/src/state-machine/dispatch/on-init-handlers.ts
+++ b/src/state-machine/dispatch/on-init-handlers.ts
@@ -179,7 +179,7 @@ async function executeInvocation(
       __outputHistory: outputHistory,
       ai: {
         ...(stepConfig.ai || {}),
-        timeout: stepConfig.ai?.timeout || 1800000,
+        timeout: stepConfig.timeout || stepConfig.ai?.timeout || 1800000,
         debug: !!context.debug,
       },
     };

--- a/src/state-machine/states/level-dispatch.ts
+++ b/src/state-machine/states/level-dispatch.ts
@@ -801,7 +801,7 @@ async function executeCheckWithForEachItems(
         workflowInputs,
         ai: {
           ...(checkConfig.ai || {}),
-          timeout: checkConfig.ai?.timeout || 1800000,
+          timeout: checkConfig.timeout || checkConfig.ai?.timeout || 1800000,
           debug: !!context.debug,
         },
       };
@@ -835,9 +835,7 @@ async function executeCheckWithForEachItems(
             const conv = slackConv || telegramConv;
             if (conv) {
               const event = (payload as any)?.event;
-              const messageCount = Array.isArray(conv?.messages)
-                ? conv.messages.length
-                : 0;
+              const messageCount = Array.isArray(conv?.messages) ? conv.messages.length : 0;
               if (context.debug) {
                 logger.info(
                   `[LevelDispatch] Conversation extracted (${conv?.transport || 'unknown'}): ${messageCount} messages`
@@ -846,7 +844,10 @@ async function executeCheckWithForEachItems(
               // Build transport-specific context
               const transportCtx = slackConv
                 ? { slack: { event: event || {}, conversation: slackConv } }
-                : { telegram: { event: event || {}, conversation: telegramConv }, webhook: payload };
+                : {
+                    telegram: { event: event || {}, conversation: telegramConv },
+                    webhook: payload,
+                  };
               (providerConfig as any).eventContext = {
                 ...(providerConfig as any).eventContext,
                 ...transportCtx,
@@ -1045,7 +1046,7 @@ async function executeCheckWithForEachItems(
             context,
             prInfo,
             dependencyResults,
-            checkConfig.ai?.timeout || 1800000,
+            checkConfig.timeout || checkConfig.ai?.timeout || 1800000,
             () => provider.execute(prInfo, providerConfig, dependencyResults, executionContext)
           );
           try {
@@ -2252,7 +2253,7 @@ async function executeSingleCheck(
       workflowInputs,
       ai: {
         ...(checkConfig.ai || {}),
-        timeout: checkConfig.ai?.timeout || 1800000,
+        timeout: checkConfig.timeout || checkConfig.ai?.timeout || 1800000,
         debug: !!context.debug,
       },
     };
@@ -2288,7 +2289,9 @@ async function executeSingleCheck(
             const event = (payload as any)?.event;
             const messageCount = Array.isArray(conv?.messages) ? conv.messages.length : 0;
             if (context.debug) {
-              logger.info(`[LevelDispatch] Conversation extracted (${conv?.transport || 'unknown'}): ${messageCount} messages`);
+              logger.info(
+                `[LevelDispatch] Conversation extracted (${conv?.transport || 'unknown'}): ${messageCount} messages`
+              );
             }
             // Build transport-specific context
             const transportCtx = slackConv
@@ -2452,7 +2455,7 @@ async function executeSingleCheck(
           context,
           prInfo,
           dependencyResults,
-          checkConfig.ai?.timeout || 1800000,
+          checkConfig.timeout || checkConfig.ai?.timeout || 1800000,
           () => provider.execute(prInfo, providerConfig, dependencyResults, executionContext)
         );
         try {

--- a/tests/frontends/slack-frontend.test.ts
+++ b/tests/frontends/slack-frontend.test.ts
@@ -130,6 +130,54 @@ describe('SlackFrontend (event-bus)', () => {
     expect(req.text).toBe('AI response here');
   });
 
+  test('posts error fallback when workflow output.text is null but has system error issues', async () => {
+    const bus = new EventBus();
+    const slack = makeFakeSlack();
+    const fe = new SlackFrontend({ defaultChannel: 'C1', debounceMs: 0 });
+    const map = new Map<string, unknown>();
+    map.set('/bots/slack/support', {
+      event: { type: 'app_mention', channel: 'C1', ts: '888.1', text: 'do something' },
+    });
+    fe.start({
+      eventBus: bus,
+      logger: console as any,
+      config: {
+        slack: { endpoint: '/bots/slack/support' },
+        checks: {
+          chat: { type: 'workflow', workflow: 'assistant' },
+        },
+      },
+      run: { runId: 'r5' },
+      webhookContext: { webhookData: map },
+    } as any);
+    (fe as any).getSlack = () => slack;
+
+    // Simulate: generate-response timed out, workflow output.text is null,
+    // but error issues propagated up from the inner check
+    await bus.emit({
+      type: 'CheckCompleted',
+      checkId: 'chat',
+      scope: [],
+      result: {
+        issues: [
+          {
+            file: 'system',
+            line: 0,
+            ruleId: 'system/ai-execution-error',
+            message: 'AI review timed out after 1800000ms',
+            severity: 'error',
+            category: 'logic',
+          },
+        ],
+        output: { text: null, intent: 'chat' },
+      },
+    });
+
+    expect(slack.chat.postMessage).toHaveBeenCalledTimes(1);
+    const [req] = slack.chat.postMessage.mock.calls[0];
+    expect(req.text).toContain('timed out');
+  });
+
   test('posts error notice for execution failures on completed checks', async () => {
     const bus = new EventBus();
     const slack = makeFakeSlack();


### PR DESCRIPTION
## Summary
- **Timeout fix**: All 9 locations in the state machine that set AI check timeout now read `checkConfig.timeout || checkConfig.ai?.timeout || 1800000` instead of only `checkConfig.ai?.timeout || 1800000`. This means step-level `timeout: 3000000` (50 min) in workflow YAML is now respected, instead of always falling back to the 30-min default.
- **Slack silence fix**: When an AI check times out, its output becomes `undefined` and the workflow output.text becomes `null`. The Slack frontend silently skipped posting. Added error-issue fallback in `maybePostDirectReply`: when no text is extractable but the result contains system error issues (`system/*` or `*/error` ruleIds), post the error message to Slack so users aren't left with silence.

## Context
Found in trace `6233b4af4d46409e8059df5e05b57991`:
- `engineer-task` timed out at exactly 1800s (30 min) despite `timeout: 3000000` (50 min) in engineer.yaml
- User received no Slack response — complete silence after 36 minutes of processing

## Test plan
- [x] All 5 slack-frontend tests pass (including new timeout error fallback test)
- [x] All 97 frontend tests pass
- [x] All 8 engine tests pass
- [ ] Deploy and verify with a long-running engineer task that step-level timeout is respected
- [ ] Verify that when a check times out, user sees error message in Slack thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)