### PR TITLE
fix: worktree-safe branch checkout in code-explorer prompt

### DIFF
--- a/defaults/code-talk.yaml
+++ b/defaults/code-talk.yaml
@@ -613,10 +613,15 @@ steps:
       - Use the workingDirectory parameter instead of `cd`; no pipes or chained commands
       - Always use relative paths (e.g., "gateway/mw_jwt.go"), never absolute /tmp/ paths
 
-      Shallow clone awareness:
-      - Repos use fetch_depth: 1. Fetch before checkout: `git fetch origin <branch>`
-      - For PRs: `git fetch origin pull/<N>/head:pr-<N> && git checkout pr-<N>`
-      - For tags: `git fetch --tags` then `git tag -l "v5.8*"`
+      Branch switching:
+      - Repos are shallow clones (fetch_depth: 1). Always fetch before checkout.
+      - IMPORTANT: Never use `git checkout <branch-name>` — it fails when the branch
+        is checked out in another worktree. Instead use detached HEAD:
+          `git fetch origin <branch> && git checkout FETCH_HEAD`
+      - For PRs: `git fetch origin pull/<N>/head && git checkout FETCH_HEAD`
+      - For tags: `git fetch --tags` then `git checkout <tag>`
+      - If the question mentions a specific branch (e.g. "on the feature-x branch"),
+        switch to it FIRST before searching. Content may only exist on that branch.
 
       Delegate usage:
       - Each delegate should answer ONE specific question (not "look at the code")


### PR DESCRIPTION
## Summary
- Replace `git checkout <branch>` with `git fetch origin <branch> && git checkout FETCH_HEAD` in the explore-code prompt instructions
- The old pattern fails with "already used by worktree" when multiple code-explorers run concurrently on the same branch
- Add instruction to switch branches FIRST when the user's question references a specific branch

## Root cause
Trace `6233b4af` showed code-explorer searching on `main` for `ai-consumer.mdx` which only exists on `docs-tyk-ai-studio`. A second code-explorer tried `git checkout docs-tyk-ai-studio` but got the worktree error. Result: 37 minutes wasted before timeout.

## Test plan
- [ ] Verify code-explorer correctly uses `FETCH_HEAD` pattern when switching branches
- [ ] Verify concurrent code-explorers on the same branch no longer conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)