### PR TITLE
fix: standardize max_iterations to 50 everywhere

### DIFF
--- a/defaults/code-talk.yaml
+++ b/defaults/code-talk.yaml
@@ -473,7 +473,7 @@ steps:
       skip_code_context: true
       enableDelegate: true
       enableExecutePlan: false
-      max_iterations: 40
+      max_iterations: 50
       prompt_type: code-explorer
       allowBash: true
       bashConfig:

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -516,7 +516,7 @@ steps:
         You are a senior software engineer. Use the provided tools to explore
         the codebase. Always verify your assumptions by reading actual code.
         Be concise and cite file paths in your response.
-      max_iterations: 20
+      max_iterations: 50
     ai_custom_tools: [search-code, list-files, read-file]
     enable_bash: true       # also allow direct shell commands
     tags: [agent]


### PR DESCRIPTION
## Summary
- `defaults/code-talk.yaml`: 40 → 50
- `src/cli-main.ts`: 20 → 50
- `workflows/engineer.yaml` was already at 50

Prevents premature iteration limits that cut off long-running code exploration or engineering tasks.

## Test plan
- [x] Pre-commit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)