### PR TITLE
fix: unwrap workflow outputs in value_js + oauth2 in SSE server

### DIFF
--- a/defaults/code-talk.yaml
+++ b/defaults/code-talk.yaml
@@ -310,6 +310,7 @@ steps:
       # ──────────────────────────────────────────────────────────────────
       skip_code_context: true
       enableDelegate: true
+      enableTasks: true
       enableExecutePlan: false
       max_iterations: 100
       prompt_type: code-explorer
@@ -463,8 +464,19 @@ steps:
 
       Delegate usage:
 
+      Task protocol:
+      - Before substantive work begins, create the task or tasks first.
+      - This applies to long-running single-goal investigations too, not only multi-goal requests.
+      - If there is a clear list of independent investigation jobs, create one task per job before starting.
+      - When a task starts, mark it in_progress immediately.
+      - When a task is actually done, complete it immediately before moving on.
+      - Do not leave finished tasks pending or in_progress.
+      - Prefer one active in_progress task at a time unless work is truly parallel.
+      - Before the final answer, every created task must be completed or cancelled.
+
       - Each delegate should answer ONE specific question (not "look at the code")
       - Run multiple delegates in PARALLEL for different hypotheses or components
+      - If you spawn delegates for independent jobs, create matching tasks first and keep them updated in real time
       - Ask delegates to return specific file paths and line numbers
       - Do NOT delegate or re-search the same question twice in one investigation
       - If a delegate returns enough evidence for the current claim, stop and use it
@@ -473,6 +485,7 @@ steps:
         delegate 4 for "session context metadata" again. Use the results you have.
       - Before spawning a delegate, review results from ALL prior delegates.
         If the information is already available, use it instead of re-delegating.
+      - If jobs are not truly independent, do not parallelize them. Keep work sequential and keep task state accurate.
 
       Relay complete data from tools — do not summarize or compress tool output.
 

--- a/deploy/observability/local/Dockerfile.otelcol
+++ b/deploy/observability/local/Dockerfile.otelcol
@@ -1,0 +1,4 @@
+FROM busybox:1.36.1-musl AS busybox
+
+FROM otel/opentelemetry-collector-contrib:0.147.0
+COPY --from=busybox /bin/busybox /bin/busybox

--- a/deploy/observability/local/Dockerfile.tempo
+++ b/deploy/observability/local/Dockerfile.tempo
@@ -1,0 +1,4 @@
+FROM busybox:1.36.1-musl AS busybox
+
+FROM grafana/tempo:2.10.1
+COPY --from=busybox /bin/busybox /bin/busybox

--- a/deploy/observability/local/README.md
+++ b/deploy/observability/local/README.md
@@ -1,0 +1,41 @@
+# Visor Local Observability
+
+This is the canonical local observability stack for Visor.
+
+It replaces the single-container `grafana/otel-lgtm` setup with separate services:
+- `tempo`
+- `otelcol`
+- `prometheus`
+- `grafana`
+- `autoheal`
+
+Ports:
+- `8001` Grafana
+- `4317` OTLP gRPC
+- `4318` OTLP HTTP
+- `3200` Tempo HTTP API
+- `9091` Prometheus
+
+Start from the Visor repo root:
+
+```bash
+docker compose -f deploy/observability/local/docker-compose.yml up -d
+```
+
+Stop:
+
+```bash
+docker compose -f deploy/observability/local/docker-compose.yml down
+```
+
+If the old all-in-one LGTM container is still running, remove it first:
+
+```bash
+docker rm -f grafana-otel
+```
+
+Point Visor-based apps at this stack with:
+- `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`
+- `GRAFANA_URL=http://localhost:8001`
+
+This stack is generic Visor infrastructure. Project-specific apps like Oel should reference it rather than owning their own copy.

--- a/deploy/observability/local/docker-compose.yml
+++ b/deploy/observability/local/docker-compose.yml
@@ -1,0 +1,134 @@
+services:
+  autoheal:
+    image: willfarrell/autoheal:1.2.0
+    container_name: visor-autoheal
+    restart: unless-stopped
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: autoheal
+      AUTOHEAL_INTERVAL: 30
+      AUTOHEAL_START_PERIOD: 120
+      CURL_TIMEOUT: 10
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - observability
+
+  tempo:
+    build:
+      context: .
+      dockerfile: Dockerfile.tempo
+    image: visor/tempo-with-busybox:2.10.1
+    container_name: visor-tempo
+    restart: unless-stopped
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    labels:
+      autoheal: "true"
+    volumes:
+      - ./tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo-data:/var/tempo
+    ports:
+      - "3200:3200"
+    healthcheck:
+      test: ["CMD", "/bin/busybox", "wget", "-qO-", "http://127.0.0.1:3200/ready"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    networks:
+      - observability
+
+  otelcol:
+    build:
+      context: .
+      dockerfile: Dockerfile.otelcol
+    image: visor/otelcol-with-busybox:0.147.0
+    container_name: visor-otelcol
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol/config.yaml"]
+    labels:
+      autoheal: "true"
+    volumes:
+      - ./otelcol.yaml:/etc/otelcol/config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    depends_on:
+      tempo:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/bin/busybox", "wget", "-qO-", "http://127.0.0.1:13133/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    networks:
+      - observability
+
+  prometheus:
+    image: prom/prometheus:v3.10.0
+    container_name: visor-prometheus
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-otlp-receiver
+    labels:
+      autoheal: "true"
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "9091:9090"
+    depends_on:
+      otelcol:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:9090/-/healthy | grep -q 'Prometheus' || wget -qO- http://127.0.0.1:9090/api/v1/status/runtimeinfo >/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    networks:
+      - observability
+
+  grafana:
+    image: grafana/grafana:12.4.0
+    container_name: visor-grafana
+    restart: unless-stopped
+    environment:
+      GF_SERVER_HTTP_PORT: 3000
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+      GF_USERS_DEFAULT_THEME: light
+    labels:
+      autoheal: "true"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "8001:3000"
+    depends_on:
+      tempo:
+        condition: service_healthy
+      prometheus:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/api/health | grep -q 'ok'"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - observability
+
+volumes:
+  tempo-data:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  observability:
+    name: visor-observability

--- a/deploy/observability/local/grafana/provisioning/datasources/datasources.yaml
+++ b/deploy/observability/local/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,29 @@
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    uid: tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    isDefault: true
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true
+      tracesToMetrics:
+        datasourceUid: prometheus
+      search:
+        hide: false
+      spanBar:
+        type: none
+
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    jsonData:
+      httpMethod: POST

--- a/deploy/observability/local/otelcol.yaml
+++ b/deploy/observability/local/otelcol.yaml
@@ -1,0 +1,49 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    send_batch_size: 2048
+    timeout: 5s
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 1024
+    spike_limit_mib: 256
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:9095
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    send_timestamps: true
+    metric_expiration: 5m
+    enable_open_metrics: true
+  debug:
+    verbosity: basic
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/tempo]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [prometheus]
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [debug]

--- a/deploy/observability/local/prometheus.yaml
+++ b/deploy/observability/local/prometheus.yaml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: otelcol
+    static_configs:
+      - targets: ['otelcol:8889']
+
+  - job_name: tempo
+    static_configs:
+      - targets: ['tempo:3200']

--- a/deploy/observability/local/tempo.yaml
+++ b/deploy/observability/local/tempo.yaml
@@ -1,0 +1,65 @@
+server:
+  http_listen_port: 3200
+  grpc_listen_port: 9095
+  log_level: info
+
+query_frontend:
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s
+  max_outstanding_per_tenant: 8192
+
+querier:
+  frontend_worker:
+    frontend_address: 127.0.0.1:9095
+    parallelism: 4
+  max_concurrent_queries: 20
+
+compactor:
+  compaction:
+    block_retention: 168h
+
+metrics_generator:
+  storage:
+    path: /var/tempo/generator/wal
+  traces_storage:
+    path: /var/tempo/generator/traces
+  processor:
+    local_blocks:
+      filter_server_spans: false
+    span_metrics:
+      dimensions:
+        - service.name
+        - operation
+        - status.code
+  registry:
+    external_labels:
+      source: oel-local
+
+ingester:
+  max_block_duration: 5m
+  trace_idle_period: 10s
+  flush_check_period: 30s
+  lifecycler:
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+
+memberlist:
+  abort_if_cluster_join_fails: false
+  bind_addr:
+    - 127.0.0.1
+
+overrides:
+  max_bytes_per_trace: 5000000

--- a/docs/telemetry-setup.md
+++ b/docs/telemetry-setup.md
@@ -56,9 +56,25 @@ VISOR_TRACE_REPORT=true \
 visor --config ./.visor.yaml
 ```
 
-## Local Development with Grafana LGTM
+## Local Development with the Visor Observability Stack
 
-The easiest way to get a full observability stack locally is [Grafana LGTM](https://github.com/grafana/docker-otel-lgtm) — a single Docker container with Grafana, Tempo (traces), Loki (logs), Prometheus (metrics), and an OpenTelemetry Collector:
+The preferred local setup is the Visor-maintained multi-container stack under [`deploy/observability/local`](../deploy/observability/local). It gives you separate Tempo, OTel Collector, Prometheus, and Grafana services with health checks and automatic recovery:
+
+```bash
+# Start the Visor local observability stack
+docker compose -f deploy/observability/local/docker-compose.yml up -d
+
+# Run Visor with OTLP telemetry
+VISOR_TELEMETRY_ENABLED=true \
+VISOR_TELEMETRY_SINK=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+GRAFANA_URL=http://localhost:8001 \
+visor --config .visor.yaml
+
+# Open Grafana at http://localhost:8001
+```
+
+If you want the old all-in-one option for quick experimentation, Grafana LGTM still works:
 
 ```bash
 # Start the all-in-one observability stack

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@opentelemetry/sdk-node": "^0.203.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.30.1",
-        "@probelabs/probe": "^0.6.0-rc311",
+        "@probelabs/probe": "^0.6.0-rc312",
         "@types/commander": "^2.12.0",
         "@types/uuid": "^10.0.0",
         "@utcp/file": "^1.1.0",
@@ -5656,9 +5656,9 @@
       }
     },
     "node_modules/@probelabs/probe": {
-      "version": "0.6.0-rc311",
-      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc311.tgz",
-      "integrity": "sha512-7dT9T3CUm6aIBxq/ac85ljTQUluPUBopq/C8E1fbVHPije8pR5L3uJuREUbjeKpaBB2fY6+FqrBsSW4KAzewzw==",
+      "version": "0.6.0-rc312",
+      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc312.tgz",
+      "integrity": "sha512-LYhehKhVicD5/Ak8Rv7wLqGXPZqIDgBen+ZhgbzARa5EvgFAVOMWcN3/w7G4zzKwO2OJPUN0ekaUDUWIXMo4tA==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@opentelemetry/sdk-node": "^0.203.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.30.1",
-        "@probelabs/probe": "^0.6.0-rc313",
+        "@probelabs/probe": "^0.6.0-rc318",
         "@types/commander": "^2.12.0",
         "@types/uuid": "^10.0.0",
         "@utcp/file": "^1.1.0",
@@ -5656,9 +5656,9 @@
       }
     },
     "node_modules/@probelabs/probe": {
-      "version": "0.6.0-rc313",
-      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc313.tgz",
-      "integrity": "sha512-GwIZPw9cbcxygh8xfpwwUyFYIdPpgno1WxIwRTglbLFFUABb/au4qRZmBWD9Gxa6h6RIJ8Wkx+LjtRXkDAEyxA==",
+      "version": "0.6.0-rc318",
+      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc318.tgz",
+      "integrity": "sha512-/SzmIl86aWqofP0AtwyvzpnFg5LQXAkES0oZk11a5MTUWAQhRCc/Xq1GPUE7ZWv1b+maiildpgllcMjLEItFnw==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@opentelemetry/sdk-node": "^0.203.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.30.1",
-        "@probelabs/probe": "^0.6.0-rc312",
+        "@probelabs/probe": "^0.6.0-rc313",
         "@types/commander": "^2.12.0",
         "@types/uuid": "^10.0.0",
         "@utcp/file": "^1.1.0",
@@ -5656,9 +5656,9 @@
       }
     },
     "node_modules/@probelabs/probe": {
-      "version": "0.6.0-rc312",
-      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc312.tgz",
-      "integrity": "sha512-LYhehKhVicD5/Ak8Rv7wLqGXPZqIDgBen+ZhgbzARa5EvgFAVOMWcN3/w7G4zzKwO2OJPUN0ekaUDUWIXMo4tA==",
+      "version": "0.6.0-rc313",
+      "resolved": "https://registry.npmjs.org/@probelabs/probe/-/probe-0.6.0-rc313.tgz",
+      "integrity": "sha512-GwIZPw9cbcxygh8xfpwwUyFYIdPpgno1WxIwRTglbLFFUABb/au4qRZmBWD9Gxa6h6RIJ8Wkx+LjtRXkDAEyxA==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@opentelemetry/sdk-node": "^0.203.0",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/semantic-conventions": "^1.30.1",
-    "@probelabs/probe": "^0.6.0-rc311",
+    "@probelabs/probe": "^0.6.0-rc312",
     "@types/commander": "^2.12.0",
     "@types/uuid": "^10.0.0",
     "@utcp/file": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@opentelemetry/sdk-node": "^0.203.0",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/semantic-conventions": "^1.30.1",
-    "@probelabs/probe": "^0.6.0-rc312",
+    "@probelabs/probe": "^0.6.0-rc313",
     "@types/commander": "^2.12.0",
     "@types/uuid": "^10.0.0",
     "@utcp/file": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@opentelemetry/sdk-node": "^0.203.0",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/semantic-conventions": "^1.30.1",
-    "@probelabs/probe": "^0.6.0-rc313",
+    "@probelabs/probe": "^0.6.0-rc318",
     "@types/commander": "^2.12.0",
     "@types/uuid": "^10.0.0",
     "@utcp/file": "^1.1.0",

--- a/src/agent-protocol/task-evaluator.ts
+++ b/src/agent-protocol/task-evaluator.ts
@@ -11,7 +11,7 @@
 import crypto from 'crypto';
 import { logger } from '../logger';
 import type { SqliteTaskStore } from './task-store';
-import { serializeTraceForPrompt } from './trace-serializer';
+import { buildTraceReport } from './trace-serializer';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -226,15 +226,15 @@ export async function evaluateTask(
   if (traceFile || traceId) {
     try {
       const traceRef = traceFile || traceId!;
-      // Use full mode (1M chars) so trace is not truncated, include task response
-      traceTree = await serializeTraceForPrompt(
+      const report = await buildTraceReport(
         traceRef,
         1_000_000,
         { traceDir: config?.traceDir },
         responseText !== 'No response available' ? responseText : undefined,
         traceId
       );
-      if (traceTree === '(no trace data available)') {
+      traceTree = report?.text;
+      if (!traceTree || traceTree === '(no trace data available)') {
         traceTree = undefined;
       }
     } catch (err) {

--- a/src/agent-protocol/task-live-update-slack.ts
+++ b/src/agent-protocol/task-live-update-slack.ts
@@ -8,6 +8,8 @@ export class SlackTaskLiveUpdateSink implements TaskLiveUpdateSink {
   private messageTs?: string;
   /** Serialize all publish calls to prevent concurrent postMessage races */
   private publishQueue: Promise<{ ref?: Record<string, unknown> } | null> = Promise.resolve(null);
+  /** Count consecutive chat.update failures for observability and final-message fallback decisions */
+  private consecutiveUpdateFailures = 0;
 
   constructor(
     private readonly slack: SlackClient,
@@ -65,10 +67,23 @@ export class SlackTaskLiveUpdateSink implements TaskLiveUpdateSink {
         ts: this.messageTs,
         text: formatSlackText(text),
       });
-      if (updated?.ok) return null;
+      if (updated?.ok) {
+        this.consecutiveUpdateFailures = 0;
+        return null;
+      }
+      this.consecutiveUpdateFailures++;
       logger.warn(
-        `[TaskLiveUpdates][Slack] chat.update failed for ts=${this.messageTs} error=${updated?.error || 'unknown_error'}; falling back to chat.postMessage`
+        `[TaskLiveUpdates][Slack] chat.update failed for ts=${this.messageTs} error=${updated?.error || 'unknown_error'} (failure #${this.consecutiveUpdateFailures})`
       );
+      // Never create a new progress message when an update fails.
+      // Keeping the existing live-update message in place is less noisy than
+      // attempting a post+delete recovery that can leave orphaned messages.
+      if (mode === 'progress') {
+        logger.warn(
+          `[TaskLiveUpdates][Slack] Preserving existing live update ts=${this.messageTs}; suppressing progress post fallback to avoid Slack spam`
+        );
+        return null;
+      }
     }
     logger.info(
       `[TaskLiveUpdates][Slack] Posting live update message in channel=${this.channel} thread=${this.threadTs}`
@@ -81,7 +96,8 @@ export class SlackTaskLiveUpdateSink implements TaskLiveUpdateSink {
     if (posted?.ok && posted.ts) {
       const previousTs = this.messageTs;
       this.messageTs = posted.ts;
-      if (mode === 'final' && previousTs && previousTs !== posted.ts) {
+      // Clean up the old stale message to avoid orphaned progress messages
+      if (previousTs && previousTs !== posted.ts) {
         const deleted = await this.slack.chat.delete({
           channel: this.channel,
           ts: previousTs,
@@ -92,7 +108,7 @@ export class SlackTaskLiveUpdateSink implements TaskLiveUpdateSink {
           );
         } else {
           logger.info(
-            `[TaskLiveUpdates][Slack] Removed stale live update message ts=${previousTs} after final fallback post`
+            `[TaskLiveUpdates][Slack] Removed stale live update message ts=${previousTs} after fallback post`
           );
         }
       }

--- a/src/agent-protocol/task-live-update-slack.ts
+++ b/src/agent-protocol/task-live-update-slack.ts
@@ -6,6 +6,8 @@ import type { TaskLiveUpdateSink } from './task-live-updates';
 export class SlackTaskLiveUpdateSink implements TaskLiveUpdateSink {
   readonly kind = 'slack';
   private messageTs?: string;
+  /** Serialize all publish calls to prevent concurrent postMessage races */
+  private publishQueue: Promise<{ ref?: Record<string, unknown> } | null> = Promise.resolve(null);
 
   constructor(
     private readonly slack: SlackClient,
@@ -24,15 +26,30 @@ export class SlackTaskLiveUpdateSink implements TaskLiveUpdateSink {
   }
 
   async update(text: string): Promise<{ ref?: Record<string, unknown> } | null> {
-    return this.publish(text, 'progress');
+    return this.enqueue(text, 'progress');
   }
 
   async complete(text: string): Promise<{ ref?: Record<string, unknown> } | null> {
-    return this.publish(text, 'final');
+    return this.enqueue(text, 'final');
   }
 
   async fail(text: string): Promise<{ ref?: Record<string, unknown> } | null> {
-    return this.publish(text, 'final');
+    return this.enqueue(text, 'final');
+  }
+
+  /**
+   * Enqueue a publish call so they execute serially.
+   * This prevents the race where tick() and complete() both see messageTs=undefined
+   * and each call chat.postMessage, creating duplicate messages.
+   */
+  private enqueue(
+    text: string,
+    mode: 'progress' | 'final'
+  ): Promise<{ ref?: Record<string, unknown> } | null> {
+    this.publishQueue = this.publishQueue
+      .catch(() => {}) // don't let a prior failure block the queue
+      .then(() => this.publish(text, mode));
+    return this.publishQueue;
   }
 
   private async publish(

--- a/src/agent-protocol/task-live-updates.ts
+++ b/src/agent-protocol/task-live-updates.ts
@@ -1,7 +1,12 @@
 import crypto from 'crypto';
 import { logger } from '../logger';
 import type { TaskLiveUpdatesConfig } from '../types/config';
-import { fetchTraceSpans, serializeTraceForPrompt } from './trace-serializer';
+import {
+  extractProbeTaskSummary,
+  fetchTraceSpans,
+  serializeTraceForPrompt,
+  type ProbeTaskSummary,
+} from './trace-serializer';
 
 export const DEFAULT_TASK_LIVE_UPDATE_INTERVAL_SECONDS = 10;
 export const DEFAULT_TASK_LIVE_UPDATE_MAX_TRACE_CHARS = 12_000;
@@ -119,10 +124,12 @@ interface ProgressTimingMetadata {
   previousUpdateAt?: Date;
   secondsSincePreviousUpdate?: number;
   activatedSkills?: string[];
+  taskSummary?: ProbeTaskSummary;
 }
 
 interface TaskLiveUpdateSkillMetadata {
   activatedSkills?: string[];
+  taskSummary?: ProbeTaskSummary;
 }
 
 export interface TaskLiveUpdateContext {
@@ -378,6 +385,7 @@ export class TaskLiveUpdateManager {
             ? Math.max(0, Math.floor((Date.now() - this.lastUpdateAt.getTime()) / 1000))
             : undefined,
           activatedSkills: this.lastSkillMetadata?.activatedSkills,
+          taskSummary: this.lastSkillMetadata?.taskSummary,
         },
         traceState.traceId
       );
@@ -443,10 +451,12 @@ export class TaskLiveUpdateManager {
     traceId?: string
   ): string {
     const normalized = normalizeProgressSummary(text);
+    const taskSummary = formatTaskSummary(timing.taskSummary);
     const blocks = [
       '*Live Update*',
       '_Current task is still running. This message updates in place until the final answer is ready._',
       this.lastUpdateKind === 'stall' ? DEFAULT_TASK_LIVE_UPDATE_STALL_NOTICE : '',
+      taskSummary,
       normalized,
       formatProgressMetadata(timing),
     ].filter(Boolean);
@@ -465,6 +475,7 @@ export class TaskLiveUpdateManager {
           ? Math.max(0, Math.floor((Date.now() - this.lastUpdateAt.getTime()) / 1000))
           : undefined,
         activatedSkills: this.lastSkillMetadata?.activatedSkills,
+        taskSummary: this.lastSkillMetadata?.taskSummary,
       },
       traceState.traceId
     );
@@ -526,6 +537,7 @@ export class TaskLiveUpdateManager {
           ? Math.max(0, Math.floor((Date.now() - this.lastUpdateAt.getTime()) / 1000))
           : undefined,
         activatedSkills: this.lastSkillMetadata?.activatedSkills,
+        taskSummary: this.lastSkillMetadata?.taskSummary,
       },
       traceId
     );
@@ -648,6 +660,66 @@ function formatProgressMetadata(timing: ProgressTimingMetadata): string {
   return `_Metadata: ${parts.join(' | ')}_`;
 }
 
+function formatTaskStatusMarker(status: string): string {
+  switch (status) {
+    case 'completed':
+      return '[x]';
+    case 'in_progress':
+      return '[~]';
+    case 'blocked':
+    case 'failed':
+    case 'error':
+      return '[!]';
+    case 'deleted':
+    case 'cancelled':
+    case 'canceled':
+      return '[-]';
+    default:
+      return '[ ]';
+  }
+}
+
+function formatTaskLabel(task: { id: string; title: string; status: string }): string {
+  const title = String(task.title || '').trim();
+  return title || task.id || task.status;
+}
+
+function appendTaskScopeLines(
+  lines: string[],
+  scope: NonNullable<ProbeTaskSummary['scopes']>[number],
+  depth = 0
+): void {
+  const prefix = '  '.repeat(depth);
+  if (depth > 0 || scope.label !== 'Main Agent') {
+    lines.push(`${prefix}${scope.label}`);
+  }
+  for (const task of scope.tasks.slice(0, 8)) {
+    lines.push(`${prefix}• ${formatTaskStatusMarker(task.status)} ${formatTaskLabel(task)}`);
+  }
+  if (scope.tasks.length > 8) {
+    lines.push(`${prefix}• ... ${scope.tasks.length - 8} more`);
+  }
+  for (const child of scope.children) {
+    appendTaskScopeLines(lines, child, depth + 1);
+  }
+}
+
+function formatTaskSummary(summary?: ProbeTaskSummary): string | undefined {
+  if (!summary || summary.tasks.length === 0) return undefined;
+  const lines = ['*Tasks*'];
+  if (summary.scopes.length > 0) {
+    for (const scope of summary.scopes) appendTaskScopeLines(lines, scope);
+  } else {
+    for (const task of summary.tasks.slice(0, 8)) {
+      lines.push(`• ${formatTaskStatusMarker(task.status)} ${formatTaskLabel(task)}`);
+    }
+    if (summary.tasks.length > 8) {
+      lines.push(`• ... ${summary.tasks.length - 8} more`);
+    }
+  }
+  return lines.join('\n');
+}
+
 function formatSkillList(skills: string[]): string {
   const normalized = dedupeStrings(skills);
   if (normalized.length <= 4) return normalized.join(', ');
@@ -659,13 +731,13 @@ function dedupeStrings(values: string[] | undefined): string[] {
   return [...new Set(values.map(value => String(value || '').trim()).filter(Boolean))];
 }
 
-async function extractTraceSkillMetadata(
+export async function extractTraceSkillMetadata(
   traceRef: string,
   traceId?: string
 ): Promise<TaskLiveUpdateSkillMetadata | undefined> {
   if (!traceRef && !traceId) return undefined;
   try {
-    const spans = await fetchTraceSpans(traceId || traceRef);
+    const spans = await fetchTraceSpans(traceRef || traceId!, { targetTraceId: traceId });
     if (!spans.length) return undefined;
 
     const routeIntentSpan = spans.find(
@@ -693,8 +765,12 @@ async function extractTraceSkillMetadata(
 
     const finalActivatedSkills =
       activatedSkills.length > 0 ? activatedSkills : fallbackActivatedSkills;
-    if (!finalActivatedSkills.length) return undefined;
-    return { activatedSkills: finalActivatedSkills };
+    const taskSummary = extractProbeTaskSummary(spans);
+    if (!finalActivatedSkills.length && !taskSummary) return undefined;
+    return {
+      activatedSkills: finalActivatedSkills.length ? finalActivatedSkills : undefined,
+      taskSummary: taskSummary || undefined,
+    };
   } catch (err) {
     logger.debug(
       `[TaskLiveUpdates] Failed to extract skill metadata from trace: ${

--- a/src/agent-protocol/task-live-updates.ts
+++ b/src/agent-protocol/task-live-updates.ts
@@ -207,6 +207,7 @@ export class TaskLiveUpdateManager {
   private firstTickTimer?: ReturnType<typeof setTimeout>;
   private metadataRefreshTimer?: ReturnType<typeof setInterval>;
   private running = false;
+  private inflightTick?: Promise<void>;
   private started = false;
   private completed = false;
   private readonly startedAt = new Date();
@@ -258,6 +259,12 @@ export class TaskLiveUpdateManager {
     if (this.completed) return;
     this.completed = true;
     this.stop();
+    // Wait for any in-flight tick to finish so the sink's publish queue is drained
+    if (this.running && this.inflightTick) {
+      try {
+        await this.inflightTick;
+      } catch {}
+    }
     try {
       logger.info(`[TaskLiveUpdates] Publishing final success update for task ${this.ctx.taskId}`);
       const result = await this.ctx.sink.complete(this.decorateText(finalText));
@@ -276,6 +283,12 @@ export class TaskLiveUpdateManager {
     if (this.completed) return;
     this.completed = true;
     this.stop();
+    // Wait for any in-flight tick to finish so the sink's publish queue is drained
+    if (this.running && this.inflightTick) {
+      try {
+        await this.inflightTick;
+      } catch {}
+    }
     try {
       logger.info(`[TaskLiveUpdates] Publishing final failure update for task ${this.ctx.taskId}`);
       const result = await this.ctx.sink.fail(this.decorateText(finalText));
@@ -411,10 +424,11 @@ export class TaskLiveUpdateManager {
   private async runFirstTick(): Promise<void> {
     if (this.completed) return;
     logger.debug(`[TaskLiveUpdates] Running first scheduled tick for task ${this.ctx.taskId}`);
-    await this.tick();
+    this.inflightTick = this.tick();
+    await this.inflightTick;
     if (this.completed) return;
     this.timer = setInterval(() => {
-      void this.tick();
+      this.inflightTick = this.tick();
     }, this.ctx.config.intervalSeconds * 1000);
     if (typeof (this.timer as any)?.unref === 'function') {
       (this.timer as any).unref();

--- a/src/agent-protocol/task-live-updates.ts
+++ b/src/agent-protocol/task-live-updates.ts
@@ -208,6 +208,8 @@ export class TaskLiveUpdateManager {
   private metadataRefreshTimer?: ReturnType<typeof setInterval>;
   private running = false;
   private inflightTick?: Promise<void>;
+  private inflightMetadataRefresh?: Promise<void>;
+  private readonly inflightPublishes = new Set<Promise<unknown>>();
   private started = false;
   private completed = false;
   private readonly startedAt = new Date();
@@ -259,12 +261,7 @@ export class TaskLiveUpdateManager {
     if (this.completed) return;
     this.completed = true;
     this.stop();
-    // Wait for any in-flight tick to finish so the sink's publish queue is drained
-    if (this.running && this.inflightTick) {
-      try {
-        await this.inflightTick;
-      } catch {}
-    }
+    await this.waitForInflightSinkPublishes();
     try {
       logger.info(`[TaskLiveUpdates] Publishing final success update for task ${this.ctx.taskId}`);
       const result = await this.ctx.sink.complete(this.decorateText(finalText));
@@ -283,12 +280,7 @@ export class TaskLiveUpdateManager {
     if (this.completed) return;
     this.completed = true;
     this.stop();
-    // Wait for any in-flight tick to finish so the sink's publish queue is drained
-    if (this.running && this.inflightTick) {
-      try {
-        await this.inflightTick;
-      } catch {}
-    }
+    await this.waitForInflightSinkPublishes();
     try {
       logger.info(`[TaskLiveUpdates] Publishing final failure update for task ${this.ctx.taskId}`);
       const result = await this.ctx.sink.fail(this.decorateText(finalText));
@@ -319,6 +311,17 @@ export class TaskLiveUpdateManager {
   }
 
   async tick(): Promise<void> {
+    if (this.inflightTick) return this.inflightTick;
+    const promise = this.runTick().finally(() => {
+      if (this.inflightTick === promise) {
+        this.inflightTick = undefined;
+      }
+    });
+    this.inflightTick = promise;
+    return promise;
+  }
+
+  private async runTick(): Promise<void> {
     if (this.completed || this.running) return;
     const traceState = this.getTraceState();
     if (!traceState.traceRef && !traceState.traceId) {
@@ -402,7 +405,13 @@ export class TaskLiveUpdateManager {
         },
         traceState.traceId
       );
-      const result = await this.ctx.sink.update(message);
+      if (this.completed) {
+        logger.debug(
+          `[TaskLiveUpdates] Aborting progress publish for task ${this.ctx.taskId}: task already completed before sink update`
+        );
+        return;
+      }
+      const result = await this.trackPublish(this.ctx.sink.update(message));
       this.recordSinkRef(result);
       this.ctx.appendHistory?.(cleaned, 'progress');
       this.lastUpdateText = cleaned;
@@ -424,25 +433,41 @@ export class TaskLiveUpdateManager {
   private async runFirstTick(): Promise<void> {
     if (this.completed) return;
     logger.debug(`[TaskLiveUpdates] Running first scheduled tick for task ${this.ctx.taskId}`);
-    this.inflightTick = this.tick();
-    await this.inflightTick;
+    await this.tick();
     if (this.completed) return;
     this.timer = setInterval(() => {
-      this.inflightTick = this.tick();
+      void this.tick();
     }, this.ctx.config.intervalSeconds * 1000);
     if (typeof (this.timer as any)?.unref === 'function') {
       (this.timer as any).unref();
     }
     this.metadataRefreshTimer = setInterval(() => {
-      void this.refreshProgressMetadata();
+      void this.scheduleMetadataRefresh();
     }, DEFAULT_TASK_LIVE_UPDATE_METADATA_REFRESH_SECONDS * 1000);
     if (typeof (this.metadataRefreshTimer as any)?.unref === 'function') {
       (this.metadataRefreshTimer as any).unref();
     }
   }
 
+  private async waitForInflightSinkPublishes(): Promise<void> {
+    const pending = [...this.inflightPublishes];
+    if (pending.length === 0) return;
+    try {
+      await Promise.allSettled(pending);
+    } catch {}
+  }
+
   private recordSinkRef(result: { ref?: Record<string, unknown> } | null | undefined): void {
     if (result?.ref) this.ctx.onPostedRef?.(result.ref);
+  }
+
+  private async trackPublish<T>(publish: Promise<T>): Promise<T> {
+    this.inflightPublishes.add(publish);
+    try {
+      return await publish;
+    } finally {
+      this.inflightPublishes.delete(publish);
+    }
   }
 
   private getTraceState(): { traceRef?: string; traceId?: string } {
@@ -462,7 +487,7 @@ export class TaskLiveUpdateManager {
   private decorateProgressText(
     text: string,
     timing: ProgressTimingMetadata,
-    traceId?: string
+    _traceId?: string
   ): string {
     const normalized = normalizeProgressSummary(text);
     const taskSummary = formatTaskSummary(timing.taskSummary);
@@ -473,8 +498,21 @@ export class TaskLiveUpdateManager {
       taskSummary,
       normalized,
       formatProgressMetadata(timing),
+      `\`task_id: ${this.ctx.taskId}\``,
+      '`live_update: true`',
     ].filter(Boolean);
-    return this.decorateText(blocks.join('\n\n'), traceId);
+    return blocks.join('\n\n');
+  }
+
+  private scheduleMetadataRefresh(): Promise<void> {
+    if (this.inflightMetadataRefresh) return this.inflightMetadataRefresh;
+    const promise = this.refreshProgressMetadata().finally(() => {
+      if (this.inflightMetadataRefresh === promise) {
+        this.inflightMetadataRefresh = undefined;
+      }
+    });
+    this.inflightMetadataRefresh = promise;
+    return promise;
   }
 
   private async refreshProgressMetadata(): Promise<void> {
@@ -499,7 +537,7 @@ export class TaskLiveUpdateManager {
       logger.debug(
         `[TaskLiveUpdates] Refreshing metadata-only live update for task ${this.ctx.taskId}`
       );
-      const result = await this.ctx.sink.update(message);
+      const result = await this.trackPublish(this.ctx.sink.update(message));
       this.recordSinkRef(result);
       this.lastPostedMessage = message;
     } catch (err) {
@@ -559,7 +597,8 @@ export class TaskLiveUpdateManager {
       this.lastStallFallbackAt = now;
       return;
     }
-    const result = await this.ctx.sink.update(message);
+    if (this.completed) return;
+    const result = await this.trackPublish(this.ctx.sink.update(message));
     this.recordSinkRef(result);
     if (!this.lastUpdateText) {
       this.ctx.appendHistory?.(baseText, 'progress');
@@ -698,20 +737,28 @@ function formatTaskLabel(task: { id: string; title: string; status: string }): s
   return title || task.id || task.status;
 }
 
+function scopeHasRenderableTasks(scope: NonNullable<ProbeTaskSummary['scopes']>[number]): boolean {
+  if (scope.tasks.some(task => !task.synthetic)) return true;
+  return scope.children.some(child => scopeHasRenderableTasks(child));
+}
+
 function appendTaskScopeLines(
   lines: string[],
   scope: NonNullable<ProbeTaskSummary['scopes']>[number],
   depth = 0
 ): void {
+  if (!scopeHasRenderableTasks(scope)) return;
   const prefix = '  '.repeat(depth);
   if (depth > 0 || scope.label !== 'Main Agent') {
     lines.push(`${prefix}${scope.label}`);
   }
-  for (const task of scope.tasks.slice(0, 8)) {
+  const visibleTasks = scope.tasks.filter(task => !task.synthetic).slice(0, 8);
+  for (const task of visibleTasks) {
     lines.push(`${prefix}• ${formatTaskStatusMarker(task.status)} ${formatTaskLabel(task)}`);
   }
-  if (scope.tasks.length > 8) {
-    lines.push(`${prefix}• ... ${scope.tasks.length - 8} more`);
+  const hiddenCount = scope.tasks.filter(task => !task.synthetic).length - visibleTasks.length;
+  if (hiddenCount > 0) {
+    lines.push(`${prefix}• ... ${hiddenCount} more`);
   }
   for (const child of scope.children) {
     appendTaskScopeLines(lines, child, depth + 1);
@@ -724,14 +771,16 @@ function formatTaskSummary(summary?: ProbeTaskSummary): string | undefined {
   if (summary.scopes.length > 0) {
     for (const scope of summary.scopes) appendTaskScopeLines(lines, scope);
   } else {
-    for (const task of summary.tasks.slice(0, 8)) {
+    const visibleTasks = summary.tasks.filter(task => !task.synthetic).slice(0, 8);
+    for (const task of visibleTasks) {
       lines.push(`• ${formatTaskStatusMarker(task.status)} ${formatTaskLabel(task)}`);
     }
-    if (summary.tasks.length > 8) {
-      lines.push(`• ... ${summary.tasks.length - 8} more`);
+    const hiddenCount = summary.tasks.filter(task => !task.synthetic).length - visibleTasks.length;
+    if (hiddenCount > 0) {
+      lines.push(`• ... ${hiddenCount} more`);
     }
   }
-  return lines.join('\n');
+  return lines.length > 1 ? lines.join('\n') : undefined;
 }
 
 function formatSkillList(skills: string[]): string {

--- a/src/agent-protocol/task-trace-resolution.ts
+++ b/src/agent-protocol/task-trace-resolution.ts
@@ -27,6 +27,6 @@ export async function resolveTaskTraceReference(
   return {
     traceId,
     traceFile,
-    primaryRef: traceId || traceFile || undefined,
+    primaryRef: traceFile || traceId || undefined,
   };
 }

--- a/src/agent-protocol/tasks-cli-handler.ts
+++ b/src/agent-protocol/tasks-cli-handler.ts
@@ -890,7 +890,7 @@ async function handleTrace(
       return;
     }
 
-    const { serializeTraceForPrompt, fetchTraceSpans, readTraceIdFromFile } = await import(
+    const { buildTraceReport, fetchTraceSpans, readTraceIdFromFile } = await import(
       './trace-serializer'
     );
 
@@ -952,17 +952,16 @@ async function handleTrace(
       }
 
       let tree: string;
+      let report;
       try {
-        // Pass traceId as both primary ref (for remote lookup) and fallback.
-        // serializeTraceForPrompt tries remote first when fallbackTraceId is set,
-        // then falls back to local file.
-        tree = await serializeTraceForPrompt(
+        report = await buildTraceReport(
           traceFile || traceId!,
           maxChars,
           undefined,
           taskResponse,
           traceId
         );
+        tree = report?.tree || '(no trace data available)';
       } catch (traceErr) {
         console.error(
           `Trace rendering failed: ${traceErr instanceof Error ? traceErr.stack : traceErr}`
@@ -976,6 +975,9 @@ async function handleTrace(
         process.exitCode = 1;
         return;
       }
+      const header = report?.headerText || '';
+      if (header) console.log(header);
+      console.log('');
       console.log(tree);
     }
   });

--- a/src/agent-protocol/trace-serializer.ts
+++ b/src/agent-protocol/trace-serializer.ts
@@ -35,6 +35,8 @@ export interface TraceBackendConfig {
   traceDir?: string;
   /** Auth token for remote APIs */
   authToken?: string;
+  /** Optional trace ID to filter mixed local NDJSON files down to a single trace */
+  targetTraceId?: string;
 }
 
 type TraceBackendKind = Exclude<TraceBackendConfig['type'], 'auto'>;
@@ -49,6 +51,7 @@ function resolveBackendConfig(overrides?: Partial<TraceBackendConfig>): TraceBac
     jaegerUrl: overrides?.jaegerUrl || process.env.JAEGER_URL,
     traceDir: overrides?.traceDir || process.env.VISOR_TRACE_DIR || 'output/traces',
     authToken: overrides?.authToken || process.env.GRAFANA_TOKEN,
+    targetTraceId: overrides?.targetTraceId,
   };
 }
 
@@ -82,7 +85,7 @@ function isTraceFilePath(ref: string): boolean {
 // Unified span type (normalized from all backends)
 // ---------------------------------------------------------------------------
 
-interface NormalizedSpan {
+export interface NormalizedSpan {
   traceId: string;
   spanId: string;
   parentSpanId?: string;
@@ -98,6 +101,45 @@ interface NormalizedSpan {
 interface SpanTree {
   span: NormalizedSpan;
   children: SpanTree[];
+}
+
+export interface ResolvedTraceData {
+  spans: NormalizedSpan[];
+  source: TraceBackendKind | null;
+  remoteTraceId?: string;
+  localTracePath?: string;
+}
+
+export interface ProbeTaskSummaryItem {
+  id: string;
+  title: string;
+  status: string;
+}
+
+export interface ProbeTaskScopeSummary {
+  label: string;
+  source: 'snapshot' | 'events';
+  eventCount: number;
+  snapshotCount: number;
+  tasks: ProbeTaskSummaryItem[];
+  children: ProbeTaskScopeSummary[];
+}
+
+export interface ProbeTaskSummary {
+  tasksEnabled: boolean;
+  source: 'snapshot' | 'events';
+  eventCount: number;
+  snapshotCount: number;
+  tasks: ProbeTaskSummaryItem[];
+  scopes: ProbeTaskScopeSummary[];
+}
+
+export interface TraceReport {
+  traceData: ResolvedTraceData;
+  tree: string;
+  taskSummary: ProbeTaskSummary | null;
+  headerText: string;
+  text: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -301,6 +343,72 @@ export async function fetchTraceSpans(
   return [];
 }
 
+export async function resolveTraceSpans(
+  traceIdOrPath: string,
+  backendConfig?: Partial<TraceBackendConfig>,
+  fallbackTraceId?: string
+): Promise<ResolvedTraceData> {
+  const cfg = resolveBackendConfig(backendConfig);
+  const backendOrder = getBackendOrder(cfg);
+  const isFilePath = isTraceFilePath(traceIdOrPath);
+  const localTracePath = isFilePath ? traceIdOrPath : undefined;
+  const remoteTraceId =
+    fallbackTraceId ||
+    (!isFilePath ? traceIdOrPath : (await readTraceIdFromFile(traceIdOrPath)) || undefined);
+  const preferLocalFirst = backendOrder[0] === 'file';
+
+  logger.debug(
+    `[TraceSerializer] serializeTraceForPrompt ref=${traceIdOrPath} remoteTraceId=${remoteTraceId || '-'} backendOrder=${backendOrder.join('>')}`
+  );
+
+  if (preferLocalFirst && localTracePath) {
+    logger.debug(`[TraceSerializer] Trying local trace file first: ${localTracePath}`);
+    const spans = await fetchTraceSpans(localTracePath, {
+      ...cfg,
+      type: 'file',
+      targetTraceId: remoteTraceId,
+    });
+    if (spans.length > 0) {
+      return { spans, source: 'file', remoteTraceId, localTracePath };
+    }
+  }
+
+  if (remoteTraceId) {
+    logger.debug(`[TraceSerializer] Trying remote trace backends for trace_id=${remoteTraceId}`);
+    const remoteCfg = resolveBackendConfig(backendConfig);
+    const remoteOrder = getBackendOrder(remoteCfg).filter(kind => kind !== 'file');
+    for (const backend of remoteOrder) {
+      if (backend === 'grafana') {
+        const spans = await fetchFromGrafanaTempo(remoteTraceId, remoteCfg);
+        if (spans && spans.length > 0) {
+          return { spans, source: 'grafana', remoteTraceId, localTracePath };
+        }
+        continue;
+      }
+      if (backend === 'jaeger') {
+        const spans = await fetchFromJaeger(remoteTraceId, remoteCfg);
+        if (spans && spans.length > 0) {
+          return { spans, source: 'jaeger', remoteTraceId, localTracePath };
+        }
+      }
+    }
+  }
+
+  if (localTracePath) {
+    logger.debug(`[TraceSerializer] Falling back to local trace file: ${localTracePath}`);
+    const spans = await fetchTraceSpans(localTracePath, {
+      ...cfg,
+      type: 'file',
+      targetTraceId: remoteTraceId,
+    });
+    if (spans.length > 0) {
+      return { spans, source: 'file', remoteTraceId, localTracePath };
+    }
+  }
+
+  return { spans: [], source: null, remoteTraceId, localTracePath };
+}
+
 async function fetchFromGrafanaTempo(
   traceId: string,
   cfg: TraceBackendConfig
@@ -399,9 +507,35 @@ async function fetchFromLocalFiles(
   if (!traceFile) return null;
 
   try {
-    const { parseNDJSONTrace } = await import('../debug-visualizer/trace-reader');
-    const trace = await parseNDJSONTrace(traceFile);
-    return parseLocalNDJSONSpans(trace.spans as any[]);
+    const targetTraceId =
+      cfg.targetTraceId ||
+      (!isTraceFilePath(traceRef) ? traceRef : (await readTraceIdFromFile(traceFile)) || undefined);
+
+    const rawSpans: any[] = [];
+    const rl = readline.createInterface({
+      input: fs.createReadStream(traceFile, { encoding: 'utf8' }),
+      crlfDelay: Infinity,
+    });
+
+    try {
+      for await (const line of rl) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (!targetTraceId || parsed.traceId === targetTraceId) {
+            rawSpans.push(parsed);
+          }
+        } catch {
+          // skip malformed records
+        }
+      }
+    } finally {
+      rl.close();
+    }
+
+    if (rawSpans.length === 0) return [];
+    return parseLocalNDJSONSpans(rawSpans);
   } catch (err) {
     logger.debug(`[TraceSerializer] Local file parse failed: ${err}`);
     return null;
@@ -453,10 +587,23 @@ export async function findTraceFile(traceId: string, traceDir?: string): Promise
   for (const file of files) {
     const filePath = path.join(dir, file);
     try {
-      const firstLine = await readFirstLine(filePath);
-      if (!firstLine) continue;
-      const parsed = JSON.parse(firstLine);
-      if (parsed.traceId === traceId) return filePath;
+      const rl = readline.createInterface({
+        input: fs.createReadStream(filePath, { encoding: 'utf8' }),
+        crlfDelay: Infinity,
+      });
+
+      try {
+        for await (const line of rl) {
+          if (!line.trim()) continue;
+          const parsed = JSON.parse(line);
+          if (parsed.traceId === traceId) {
+            rl.close();
+            return filePath;
+          }
+        }
+      } finally {
+        rl.close();
+      }
     } catch {
       // skip malformed files
     }
@@ -490,26 +637,6 @@ export async function readTraceIdFromFile(traceFile: string): Promise<string | n
   }
 
   return null;
-}
-
-async function readFirstLine(filePath: string): Promise<string | null> {
-  return new Promise((resolve, reject) => {
-    const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
-    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-    let resolved = false;
-    rl.on('line', (line: string) => {
-      if (!resolved) {
-        resolved = true;
-        rl.close();
-        stream.destroy();
-        resolve(line.trim() || null);
-      }
-    });
-    rl.on('close', () => {
-      if (!resolved) resolve(null);
-    });
-    rl.on('error', reject);
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -676,6 +803,12 @@ interface LifecycleSpanInfo {
   kind: 'check' | 'sandbox-child' | 'generic' | 'engineer';
 }
 
+interface ParsedTaskStatusItem {
+  id: string;
+  status: string;
+  title: string;
+}
+
 /** Normalize text for dedup comparison: lowercase, collapse whitespace, take prefix */
 function dedupeKey(text: string): string {
   return text.replace(/\s+/g, ' ').trim().slice(0, 100).toLowerCase();
@@ -789,6 +922,376 @@ function getLifecycleSpanInfo(name: string): LifecycleSpanInfo | null {
   return null;
 }
 
+function parseTaskStatusSnapshot(raw: string): ParsedTaskStatusItem[] {
+  if (!raw || !raw.includes('<task_status>')) return [];
+
+  const items: ParsedTaskStatusItem[] = [];
+  const taskRegex =
+    /<task\s+id="([^"]+)"\s+status="([^"]+)"(?:\s+priority="[^"]*")?>([\s\S]*?)<\/task>/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = taskRegex.exec(raw)) !== null) {
+    items.push({
+      id: match[1],
+      status: match[2],
+      title: match[3].replace(/\s+/g, ' ').trim(),
+    });
+  }
+
+  return items;
+}
+
+function parseTaskIds(value: unknown): string[] {
+  if (!value) return [];
+  return String(value)
+    .split(',')
+    .map(part => part.trim())
+    .filter(Boolean);
+}
+
+function isTaskTelemetrySpan(span: NormalizedSpan): boolean {
+  const toolName = span.attributes['tool.name'] || span.attributes['visor.tool.name'];
+  if (toolName === 'task') return true;
+  return /(?:^probe\.event\.)?task\.[a-z_]+$/.test(normalizeSpanName(span.name));
+}
+
+function summarizeTaskTelemetrySpans(spans: NormalizedSpan[]): ProbeTaskSummary | null {
+  const ordered = [...spans].sort((a, b) => {
+    if (a.startTimeMs !== b.startTimeMs) return a.startTimeMs - b.startTimeMs;
+    if (a.endTimeMs !== b.endTimeMs) return a.endTimeMs - b.endTimeMs;
+    return a.spanId.localeCompare(b.spanId);
+  });
+
+  const tasks = new Map<string, ProbeTaskSummaryItem>();
+  let tasksEnabled = false;
+  let snapshotCount = 0;
+  let eventCount = 0;
+  let sawSnapshot = false;
+
+  const upsertTask = (id: string, patch: Partial<ProbeTaskSummaryItem>) => {
+    const existing = tasks.get(id) || { id, title: '', status: 'pending' };
+    const next: ProbeTaskSummaryItem = {
+      id,
+      title: patch.title ?? existing.title,
+      status: patch.status ?? existing.status,
+    };
+    tasks.set(id, next);
+  };
+
+  for (const span of ordered) {
+    const name = normalizeSpanName(span.name);
+    const attrs = span.attributes;
+
+    const toolName = attrs['tool.name'] || attrs['visor.tool.name'];
+    if (toolName === 'task') {
+      const snapshot = parseTaskStatusSnapshot(String(attrs['tool.result'] || ''));
+      if (snapshot.length > 0) {
+        tasksEnabled = true;
+        snapshotCount += 1;
+        sawSnapshot = true;
+        tasks.clear();
+        for (const task of snapshot) {
+          tasks.set(task.id, {
+            id: task.id,
+            title: task.title,
+            status: task.status,
+          });
+        }
+      }
+    }
+
+    const taskEventMatch = name.match(/(?:^probe\.event\.)?task\.([a-z_]+)$/);
+    if (!taskEventMatch) continue;
+
+    tasksEnabled = true;
+    eventCount += 1;
+
+    const eventType = taskEventMatch[1];
+    const taskId = attrs['task.id'] ? String(attrs['task.id']) : '';
+    const taskTitle = attrs['task.title'] ? String(attrs['task.title']).trim() : '';
+    const newStatus = attrs['task.new_status'] ? String(attrs['task.new_status']) : '';
+    const taskIds = parseTaskIds(attrs['task.ids']);
+
+    switch (eventType) {
+      case 'created':
+        if (taskId) upsertTask(taskId, { title: taskTitle, status: 'pending' });
+        break;
+      case 'updated':
+        if (taskId) {
+          upsertTask(taskId, {
+            title: taskTitle || undefined,
+            status: newStatus && newStatus !== 'unchanged' ? newStatus : undefined,
+          });
+        }
+        break;
+      case 'completed':
+        if (taskId) upsertTask(taskId, { title: taskTitle || undefined, status: 'completed' });
+        break;
+      case 'deleted':
+        if (taskId) upsertTask(taskId, { title: taskTitle || undefined, status: 'deleted' });
+        break;
+      case 'batch_created':
+        for (const id of taskIds) upsertTask(id, { status: 'pending' });
+        break;
+      case 'batch_updated':
+        for (const id of taskIds) {
+          upsertTask(id, {
+            status: newStatus && newStatus !== 'unchanged' ? newStatus : undefined,
+          });
+        }
+        break;
+      case 'batch_completed':
+        for (const id of taskIds) upsertTask(id, { status: 'completed' });
+        break;
+      case 'batch_deleted':
+        for (const id of taskIds) upsertTask(id, { status: 'deleted' });
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (!tasksEnabled) return null;
+
+  return {
+    tasksEnabled,
+    source: sawSnapshot ? 'snapshot' : 'events',
+    eventCount,
+    snapshotCount,
+    tasks: [...tasks.values()].sort((a, b) => a.id.localeCompare(b.id)),
+    scopes: [],
+  };
+}
+
+const ROOT_TASK_SCOPE_LABEL = 'Main Agent';
+const TASK_SCOPE_EXCLUDED_CHECKS = new Set([
+  'chat',
+  'route-intent',
+  'classify',
+  'build-config',
+  'generate-response',
+  'setup-projects',
+  'checkout-docs',
+  'route-projects',
+  'project-items',
+  'checkout-projects',
+]);
+
+function titleCaseWords(raw: string): string {
+  return raw
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function getTaskScopeCheckId(span: NormalizedSpan): string | null {
+  const concreteName = getConcreteCheckName(span);
+  if (!concreteName) return null;
+  return concreteName.replace(/^visor\.check\./, '');
+}
+
+function isTaskScopeNode(span: NormalizedSpan): boolean {
+  const checkId = getTaskScopeCheckId(span);
+  if (checkId) return !TASK_SCOPE_EXCLUDED_CHECKS.has(checkId);
+  const normalized = normalizeSpanName(span.name);
+  return normalized === 'search.delegate' || normalized.startsWith('engineer.');
+}
+
+function getTaskScopeLabel(span?: NormalizedSpan): string {
+  if (!span) return ROOT_TASK_SCOPE_LABEL;
+  const checkId = getTaskScopeCheckId(span);
+  if (checkId) {
+    if (checkId === 'explore-code') return 'Code Explorer';
+    return titleCaseWords(checkId);
+  }
+  const normalized = normalizeSpanName(span.name);
+  if (normalized === 'search.delegate') return 'Search Delegate';
+  if (normalized.startsWith('engineer.')) {
+    return `Engineer ${titleCaseWords(normalized.slice('engineer.'.length))}`;
+  }
+  return titleCaseWords(normalized);
+}
+
+function collectTaskSpansForScope(node: SpanTree, stopAtNestedScopes: boolean): NormalizedSpan[] {
+  const spans: NormalizedSpan[] = [];
+  const visit = (current: SpanTree, isRoot: boolean) => {
+    if (!isRoot && stopAtNestedScopes && isTaskScopeNode(current.span)) return;
+    if (isTaskTelemetrySpan(current.span)) spans.push(current.span);
+    for (const child of current.children) visit(child, false);
+  };
+  visit(node, true);
+  return spans;
+}
+
+function findImmediateNestedTaskScopeNodes(node: SpanTree): SpanTree[] {
+  const scopes: SpanTree[] = [];
+  const visit = (current: SpanTree, isRoot: boolean) => {
+    if (!isRoot && isTaskScopeNode(current.span)) {
+      scopes.push(current);
+      return;
+    }
+    for (const child of current.children) visit(child, false);
+  };
+  visit(node, true);
+  return scopes;
+}
+
+function buildProbeTaskScopeSummary(
+  node: SpanTree,
+  label: string,
+  isRootScope = false
+): ProbeTaskScopeSummary | null {
+  const local = summarizeTaskTelemetrySpans(collectTaskSpansForScope(node, true));
+  const children = findImmediateNestedTaskScopeNodes(node)
+    .map(child => buildProbeTaskScopeSummary(child, getTaskScopeLabel(child.span)))
+    .filter((child): child is ProbeTaskScopeSummary => child !== null);
+
+  if (!local && children.length === 0) return null;
+
+  return {
+    label: isRootScope ? ROOT_TASK_SCOPE_LABEL : label,
+    source: local?.source ?? 'events',
+    eventCount: local?.eventCount ?? 0,
+    snapshotCount: local?.snapshotCount ?? 0,
+    tasks: local?.tasks ?? [],
+    children,
+  };
+}
+
+function buildTaskSummaryRoot(spans: NormalizedSpan[]): SpanTree {
+  const nodeMap = new Map<string, SpanTree>();
+  for (const span of spans) {
+    nodeMap.set(span.spanId, { span, children: [] });
+  }
+
+  const roots: SpanTree[] = [];
+  for (const span of spans) {
+    const node = nodeMap.get(span.spanId)!;
+    if (span.parentSpanId && nodeMap.has(span.parentSpanId)) {
+      nodeMap.get(span.parentSpanId)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  const sortChildren = (node: SpanTree) => {
+    node.children.sort((a, b) => a.span.startTimeMs - b.span.startTimeMs);
+    node.children.forEach(sortChildren);
+  };
+  roots.forEach(sortChildren);
+
+  return {
+    span: {
+      traceId: spans[0]?.traceId || '',
+      spanId: '__task-root__',
+      name: '__task_root__',
+      startTimeMs: roots[0]?.span.startTimeMs || 0,
+      endTimeMs: roots[roots.length - 1]?.span.endTimeMs || 0,
+      durationMs: 0,
+      attributes: {},
+      events: [],
+      status: 'ok',
+    },
+    children: roots,
+  };
+}
+
+function flattenTaskScopes(scopes: ProbeTaskScopeSummary[]): ProbeTaskSummaryItem[] {
+  const seen = new Set<string>();
+  const items: ProbeTaskSummaryItem[] = [];
+  const visit = (scope: ProbeTaskScopeSummary) => {
+    for (const task of scope.tasks) {
+      if (seen.has(task.id)) continue;
+      seen.add(task.id);
+      items.push(task);
+    }
+    for (const child of scope.children) visit(child);
+  };
+  for (const scope of scopes) visit(scope);
+  return items;
+}
+
+function buildTemporalTaskScopes(spans: NormalizedSpan[]): ProbeTaskScopeSummary[] {
+  const ordered = [...spans].sort((a, b) => {
+    if (a.startTimeMs !== b.startTimeMs) return a.startTimeMs - b.startTimeMs;
+    if (a.endTimeMs !== b.endTimeMs) return a.endTimeMs - b.endTimeMs;
+    return a.spanId.localeCompare(b.spanId);
+  });
+
+  const grouped = new Map<string, NormalizedSpan[]>();
+  const scopeOrder: string[] = [];
+  const ensureGroup = (label: string) => {
+    if (!grouped.has(label)) {
+      grouped.set(label, []);
+      scopeOrder.push(label);
+    }
+    return grouped.get(label)!;
+  };
+
+  for (let i = 0; i < ordered.length; i += 1) {
+    const span = ordered[i];
+    if (!isTaskTelemetrySpan(span)) continue;
+
+    let label = ROOT_TASK_SCOPE_LABEL;
+    for (let j = i - 1; j >= 0; j -= 1) {
+      if (isTaskScopeNode(ordered[j])) {
+        label = getTaskScopeLabel(ordered[j]);
+        break;
+      }
+    }
+    ensureGroup(label).push(span);
+  }
+
+  if (grouped.size === 0) return [];
+
+  const rootSummary = summarizeTaskTelemetrySpans(grouped.get(ROOT_TASK_SCOPE_LABEL) || []);
+  const children: ProbeTaskScopeSummary[] = [];
+  for (const label of scopeOrder) {
+    if (label === ROOT_TASK_SCOPE_LABEL) continue;
+    const summary = summarizeTaskTelemetrySpans(grouped.get(label) || []);
+    if (!summary) continue;
+    children.push({
+      label,
+      source: summary.source,
+      eventCount: summary.eventCount,
+      snapshotCount: summary.snapshotCount,
+      tasks: summary.tasks,
+      children: [],
+    });
+  }
+
+  return [
+    {
+      label: ROOT_TASK_SCOPE_LABEL,
+      source: rootSummary?.source ?? 'events',
+      eventCount: rootSummary?.eventCount ?? 0,
+      snapshotCount: rootSummary?.snapshotCount ?? 0,
+      tasks: rootSummary?.tasks ?? [],
+      children,
+    },
+  ];
+}
+
+function formatTaskStatusMarker(status: string): string {
+  switch (status) {
+    case 'completed':
+      return '[x]';
+    case 'in_progress':
+      return '[~]';
+    case 'blocked':
+    case 'failed':
+    case 'error':
+      return '[!]';
+    case 'cancelled':
+    case 'canceled':
+    case 'deleted':
+      return '[-]';
+    default:
+      return '[ ]';
+  }
+}
+
 function buildRenderContext(allSpans: NormalizedSpan[]): TraceRenderContext {
   const realSpanNames = new Set<string>();
   let hasChildWorkSpans = false;
@@ -834,34 +1337,7 @@ export async function serializeTraceForPrompt(
   /** Trace ID to try remote backends first (preferred over local file) */
   fallbackTraceId?: string
 ): Promise<string> {
-  let spans: NormalizedSpan[] = [];
-  const cfg = resolveBackendConfig(backendConfig);
-  const backendOrder = getBackendOrder(cfg);
-  const isFilePath = isTraceFilePath(traceIdOrPath);
-  const localTracePath = isFilePath ? traceIdOrPath : undefined;
-  const remoteTraceId =
-    fallbackTraceId ||
-    (!isFilePath ? traceIdOrPath : (await readTraceIdFromFile(traceIdOrPath)) || undefined);
-  const preferLocalFirst = backendOrder[0] === 'file';
-
-  logger.debug(
-    `[TraceSerializer] serializeTraceForPrompt ref=${traceIdOrPath} remoteTraceId=${remoteTraceId || '-'} backendOrder=${backendOrder.join('>')}`
-  );
-
-  if (preferLocalFirst && localTracePath) {
-    logger.debug(`[TraceSerializer] Trying local trace file first: ${localTracePath}`);
-    spans = await fetchTraceSpans(localTracePath, { ...cfg, type: 'file' });
-  }
-
-  if (spans.length === 0 && remoteTraceId) {
-    logger.debug(`[TraceSerializer] Trying remote trace backends for trace_id=${remoteTraceId}`);
-    spans = await fetchTraceSpans(remoteTraceId, cfg);
-  }
-
-  if (spans.length === 0 && localTracePath) {
-    logger.debug(`[TraceSerializer] Falling back to local trace file: ${localTracePath}`);
-    spans = await fetchTraceSpans(localTracePath, { ...cfg, type: 'file' });
-  }
+  const { spans } = await resolveTraceSpans(traceIdOrPath, backendConfig, fallbackTraceId);
 
   if (spans.length === 0) {
     return '(no trace data available)';
@@ -881,6 +1357,131 @@ export async function serializeTraceForPrompt(
     fullOutput,
     taskResponse,
   });
+}
+
+function renderTraceTreeFromSpans(
+  spans: NormalizedSpan[],
+  maxChars?: number,
+  taskResponse?: string
+): string {
+  const tree = buildSpanTree(spans);
+  const routeIntentTopic = extractRouteIntentTopic(spans);
+  const fullOutput = (maxChars ?? 4000) > 100000;
+
+  return renderSpanYaml(tree, spans, {
+    maxChars: maxChars ?? 4000,
+    fallbackIntent: routeIntentTopic,
+    fullOutput,
+    taskResponse,
+  });
+}
+
+function formatTaskStatus(status: string): string {
+  return status === 'completed'
+    ? '[x]'
+    : status === 'in_progress'
+      ? '[~]'
+      : status === 'blocked' || status === 'failed' || status === 'error'
+        ? '[!]'
+        : status === 'deleted' || status === 'cancelled' || status === 'canceled'
+          ? '[-]'
+          : '[ ]';
+}
+
+function formatTaskLabel(task: { id: string; title: string; status: string }): string {
+  const title = String(task.title || '').trim();
+  return title || task.id || task.status;
+}
+
+function appendTaskScopeLines(lines: string[], scope: ProbeTaskScopeSummary, depth = 0): void {
+  const prefix = '  '.repeat(depth);
+  if (depth > 0 || scope.label !== ROOT_TASK_SCOPE_LABEL) {
+    lines.push(`${prefix}${scope.label}`);
+  }
+  for (const task of scope.tasks) {
+    lines.push(`${prefix}  ${formatTaskStatus(task.status)} ${formatTaskLabel(task)}`);
+  }
+  for (const child of scope.children) {
+    appendTaskScopeLines(lines, child, depth + 1);
+  }
+}
+
+export function buildTraceHeaderLines(
+  traceData: ResolvedTraceData,
+  taskSummary: ProbeTaskSummary | null
+): string[] {
+  const lines = [`Trace source: ${traceData.source || 'unknown'}`];
+  if (!taskSummary) {
+    lines.push('Tasks: no task telemetry found in this trace');
+    return lines;
+  }
+
+  const eventsSuffix =
+    taskSummary.snapshotCount > 0
+      ? `, ${taskSummary.eventCount} task events, ${taskSummary.snapshotCount} snapshots`
+      : `, ${taskSummary.eventCount} task events`;
+  lines.push(`Tasks: ${taskSummary.tasks.length} tracked (${taskSummary.source}${eventsSuffix})`);
+  if (taskSummary.scopes.length > 0) {
+    for (const scope of taskSummary.scopes) {
+      appendTaskScopeLines(lines, scope);
+    }
+  } else {
+    for (const task of taskSummary.tasks) {
+      lines.push(`  ${formatTaskStatus(task.status)} ${formatTaskLabel(task)}`);
+    }
+  }
+
+  return lines;
+}
+
+export async function buildTraceReport(
+  traceIdOrPath: string,
+  maxChars?: number,
+  backendConfig?: Partial<TraceBackendConfig>,
+  taskResponse?: string,
+  fallbackTraceId?: string
+): Promise<TraceReport | null> {
+  const traceData = await resolveTraceSpans(traceIdOrPath, backendConfig, fallbackTraceId);
+  if (traceData.spans.length === 0) {
+    return null;
+  }
+
+  const taskSummary = extractProbeTaskSummary(traceData.spans);
+  const headerLines = buildTraceHeaderLines(traceData, taskSummary);
+  const headerText = headerLines.join('\n');
+  const tree = renderTraceTreeFromSpans(traceData.spans, maxChars, taskResponse);
+
+  return {
+    traceData,
+    tree,
+    taskSummary,
+    headerText,
+    text: `${headerText}\n\n${tree}`,
+  };
+}
+
+export function extractProbeTaskSummary(spans: NormalizedSpan[]): ProbeTaskSummary | null {
+  const overall = summarizeTaskTelemetrySpans(spans);
+  if (!overall) return null;
+
+  const rootScope = buildProbeTaskScopeSummary(
+    buildTaskSummaryRoot(spans),
+    ROOT_TASK_SCOPE_LABEL,
+    true
+  );
+  let scopes = rootScope ? [rootScope] : [];
+  if (scopes.length === 0 || scopes[0].children.length === 0) {
+    const temporalScopes = buildTemporalTaskScopes(spans);
+    if (temporalScopes.length > 0 && temporalScopes[0].children.length > 0) {
+      scopes = temporalScopes;
+    }
+  }
+
+  return {
+    ...overall,
+    tasks: scopes.length > 0 ? flattenTaskScopes(scopes) : overall.tasks,
+    scopes,
+  };
 }
 
 /**
@@ -1061,6 +1662,20 @@ function renderYamlNode(
     const toolInput = extractToolInput(String(toolName), attrs);
     const toolResultLen = attrs['tool.result.length'] || attrs['tool.result.count'];
     const tn = String(toolName);
+    const taskSnapshot =
+      tn === 'task' ? parseTaskStatusSnapshot(String(attrs['tool.result'] || '')) : [];
+    if (tn === 'task' && taskSnapshot.length > 0) {
+      lines.push(`${pad}tasks snapshot${childSuffix}:`);
+      for (const task of taskSnapshot) {
+        lines.push(
+          `${pad}  ${formatTaskStatusMarker(task.status)} ${task.id}: ${truncate(task.title, 100)}`
+        );
+      }
+      return;
+    }
+    if (tn === 'task') {
+      return;
+    }
     // Detect "no results" for search tools: probe header is ~350-450 chars,
     // so result.length < 500 for search means no actual matches
     const isSearchTool = tn === 'search' || tn === 'searchCode' || tn === 'search_code';
@@ -1304,6 +1919,97 @@ function renderYamlNode(
       }
     }
     return;
+  }
+
+  // --- Probe task events ---
+  const taskEventMatch = name.match(/(?:^probe\.event\.)?task\.([a-z_]+)$/);
+  if (taskEventMatch) {
+    const eventType = taskEventMatch[1];
+    const taskId = attrs['task.id'] ? String(attrs['task.id']) : '';
+    const taskTitle = attrs['task.title'] ? truncate(String(attrs['task.title']), 80) : '';
+    const taskIds = attrs['task.ids'] ? truncate(String(attrs['task.ids']), 120) : '';
+    const count = attrs['task.count'] ? Number(attrs['task.count']) : undefined;
+    const totalCount = attrs['task.total_count'] ? Number(attrs['task.total_count']) : undefined;
+    const incompleteCount = attrs['task.incomplete_count']
+      ? Number(attrs['task.incomplete_count'])
+      : undefined;
+    const completedCount = attrs['task.completed_count']
+      ? Number(attrs['task.completed_count'])
+      : undefined;
+    const remaining = attrs['task.incomplete_remaining']
+      ? Number(attrs['task.incomplete_remaining'])
+      : undefined;
+    const newStatus = attrs['task.new_status'] ? String(attrs['task.new_status']) : '';
+    const fieldsUpdated = attrs['task.fields_updated']
+      ? truncate(String(attrs['task.fields_updated']), 80)
+      : '';
+    const error = attrs['task.error'] ? truncate(String(attrs['task.error']), 100) : '';
+    const action = attrs['task.action'] ? String(attrs['task.action']) : '';
+
+    switch (eventType) {
+      case 'session_started':
+        lines.push(`${pad}tasks enabled — ${duration}`);
+        return;
+      case 'created':
+        lines.push(`${pad}[ ] ${taskId}${taskTitle ? `: ${taskTitle}` : ''} — ${duration}`);
+        return;
+      case 'batch_created': {
+        const totalSuffix = totalCount !== undefined ? `, total ${totalCount}` : '';
+        lines.push(
+          `${pad}tasks created (${count ?? '?'}${totalSuffix}): ${taskIds || 'unknown'} — ${duration}`
+        );
+        return;
+      }
+      case 'updated': {
+        const statusSuffix = newStatus && newStatus !== 'unchanged' ? ` -> ${newStatus}` : '';
+        const fieldSuffix = fieldsUpdated ? ` [${fieldsUpdated}]` : '';
+        lines.push(`${pad}task updated: ${taskId}${statusSuffix}${fieldSuffix} — ${duration}`);
+        return;
+      }
+      case 'batch_updated':
+        lines.push(`${pad}tasks updated (${count ?? '?'}): ${taskIds || 'unknown'} — ${duration}`);
+        return;
+      case 'completed': {
+        const remainingSuffix = remaining !== undefined ? ` (${remaining} remaining)` : '';
+        lines.push(
+          `${pad}[x] ${taskId}${taskTitle ? `: ${taskTitle}` : ''}${remainingSuffix} — ${duration}`
+        );
+        return;
+      }
+      case 'batch_completed': {
+        const remainingSuffix = remaining !== undefined ? `, ${remaining} remaining` : '';
+        lines.push(
+          `${pad}tasks completed (${count ?? '?'}${remainingSuffix}): ${taskIds || 'unknown'} — ${duration}`
+        );
+        return;
+      }
+      case 'deleted':
+        lines.push(`${pad}task deleted: ${taskId} — ${duration}`);
+        return;
+      case 'batch_deleted':
+        lines.push(`${pad}tasks deleted (${count ?? '?'}): ${taskIds || 'unknown'} — ${duration}`);
+        return;
+      case 'listed': {
+        const stats: string[] = [];
+        if (totalCount !== undefined) stats.push(`${totalCount} total`);
+        if (incompleteCount !== undefined) stats.push(`${incompleteCount} incomplete`);
+        if (completedCount !== undefined) stats.push(`${completedCount} completed`);
+        lines.push(
+          `${pad}tasks listed${stats.length > 0 ? ` (${stats.join(', ')})` : ''} — ${duration}`
+        );
+        return;
+      }
+      case 'validation_error':
+      case 'error':
+        lines.push(`${pad}task.${eventType}: ${error || 'unknown error'} — ${duration}`);
+        return;
+      case 'unknown_action':
+        lines.push(`${pad}task.unknown_action: ${action || 'unknown'} — ${duration}`);
+        return;
+      default:
+        lines.push(`${pad}task.${eventType}${taskId ? `: ${taskId}` : ''} — ${duration}`);
+        return;
+    }
   }
 
   // --- Generic span ---
@@ -1977,6 +2683,83 @@ function formatSpanLine(
     const reason = attrs['graceful_stop.reason'] || attrs['reason'] || '';
     const reasonStr = reason ? `: ${truncate(String(reason), 80)}` : '';
     return { line: `graceful_stop${reasonStr} (${duration})` };
+  }
+
+  // --- Probe task events ---
+  const taskEventMatch = name.match(/(?:^probe\.event\.)?task\.([a-z_]+)$/);
+  if (taskEventMatch) {
+    const eventType = taskEventMatch[1];
+    const taskId = attrs['task.id'] ? String(attrs['task.id']) : '';
+    const taskTitle = attrs['task.title'] ? truncate(String(attrs['task.title']), 80) : '';
+    const taskIds = attrs['task.ids'] ? truncate(String(attrs['task.ids']), 120) : '';
+    const count = attrs['task.count'] ? Number(attrs['task.count']) : undefined;
+    const totalCount = attrs['task.total_count'] ? Number(attrs['task.total_count']) : undefined;
+    const incompleteCount = attrs['task.incomplete_count']
+      ? Number(attrs['task.incomplete_count'])
+      : undefined;
+    const completedCount = attrs['task.completed_count']
+      ? Number(attrs['task.completed_count'])
+      : undefined;
+    const remaining = attrs['task.incomplete_remaining']
+      ? Number(attrs['task.incomplete_remaining'])
+      : undefined;
+    const newStatus = attrs['task.new_status'] ? String(attrs['task.new_status']) : '';
+    const fieldsUpdated = attrs['task.fields_updated']
+      ? truncate(String(attrs['task.fields_updated']), 80)
+      : '';
+    const error = attrs['task.error'] ? truncate(String(attrs['task.error']), 100) : '';
+    const action = attrs['task.action'] ? String(attrs['task.action']) : '';
+    const tail = ` (${duration})`;
+
+    switch (eventType) {
+      case 'session_started':
+        return { line: `tasks enabled${tail}` };
+      case 'created':
+        return { line: `[ ] ${taskId}${taskTitle ? `: ${taskTitle}` : ''}${tail}` };
+      case 'batch_created': {
+        const totalSuffix = totalCount !== undefined ? `, total ${totalCount}` : '';
+        return {
+          line: `tasks created (${count ?? '?'}${totalSuffix}): ${taskIds || 'unknown'}${tail}`,
+        };
+      }
+      case 'updated': {
+        const statusSuffix = newStatus && newStatus !== 'unchanged' ? ` -> ${newStatus}` : '';
+        const fieldSuffix = fieldsUpdated ? ` [${fieldsUpdated}]` : '';
+        return { line: `task updated: ${taskId}${statusSuffix}${fieldSuffix}${tail}` };
+      }
+      case 'batch_updated':
+        return { line: `tasks updated (${count ?? '?'}): ${taskIds || 'unknown'}${tail}` };
+      case 'completed': {
+        const remainingSuffix = remaining !== undefined ? ` (${remaining} remaining)` : '';
+        return {
+          line: `[x] ${taskId}${taskTitle ? `: ${taskTitle}` : ''}${remainingSuffix}${tail}`,
+        };
+      }
+      case 'batch_completed': {
+        const remainingSuffix = remaining !== undefined ? `, ${remaining} remaining` : '';
+        return {
+          line: `tasks completed (${count ?? '?'}${remainingSuffix}): ${taskIds || 'unknown'}${tail}`,
+        };
+      }
+      case 'deleted':
+        return { line: `task deleted: ${taskId}${tail}` };
+      case 'batch_deleted':
+        return { line: `tasks deleted (${count ?? '?'}): ${taskIds || 'unknown'}${tail}` };
+      case 'listed': {
+        const stats: string[] = [];
+        if (totalCount !== undefined) stats.push(`${totalCount} total`);
+        if (incompleteCount !== undefined) stats.push(`${incompleteCount} incomplete`);
+        if (completedCount !== undefined) stats.push(`${completedCount} completed`);
+        return { line: `tasks listed${stats.length > 0 ? ` (${stats.join(', ')})` : ''}${tail}` };
+      }
+      case 'validation_error':
+      case 'error':
+        return { line: `task.${eventType}: ${error || 'unknown error'}${tail}` };
+      case 'unknown_action':
+        return { line: `task.unknown_action: ${action || 'unknown'}${tail}` };
+      default:
+        return { line: `task.${eventType}${taskId ? `: ${taskId}` : ''}${tail}` };
+    }
   }
 
   // --- Generic span ---

--- a/src/agent-protocol/trace-serializer.ts
+++ b/src/agent-protocol/trace-serializer.ts
@@ -949,6 +949,20 @@ function parseTaskIds(value: unknown): string[] {
     .filter(Boolean);
 }
 
+/** Parse task.items_json from enriched batch events (probe rc313+). */
+function parseBatchItemsJson(
+  value: unknown
+): Array<{ id: string; title?: string; status?: string }> {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(String(value));
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item: any) => item && typeof item.id === 'string');
+  } catch {
+    return [];
+  }
+}
+
 function isTaskTelemetrySpan(span: NormalizedSpan): boolean {
   const toolName = span.attributes['tool.name'] || span.attributes['visor.tool.name'];
   if (toolName === 'task') return true;
@@ -1030,22 +1044,53 @@ function summarizeTaskTelemetrySpans(spans: NormalizedSpan[]): ProbeTaskSummary 
       case 'deleted':
         if (taskId) upsertTask(taskId, { title: taskTitle || undefined, status: 'deleted' });
         break;
-      case 'batch_created':
-        for (const id of taskIds) upsertTask(id, { status: 'pending' });
-        break;
-      case 'batch_updated':
-        for (const id of taskIds) {
-          upsertTask(id, {
-            status: newStatus && newStatus !== 'unchanged' ? newStatus : undefined,
-          });
+      case 'batch_created': {
+        const items = parseBatchItemsJson(attrs['task.items_json']);
+        if (items.length > 0) {
+          for (const item of items)
+            upsertTask(item.id, { title: item.title || '', status: item.status || 'pending' });
+        } else {
+          for (const id of taskIds) upsertTask(id, { status: 'pending' });
         }
         break;
-      case 'batch_completed':
-        for (const id of taskIds) upsertTask(id, { status: 'completed' });
+      }
+      case 'batch_updated': {
+        const items = parseBatchItemsJson(attrs['task.items_json']);
+        if (items.length > 0) {
+          for (const item of items)
+            upsertTask(item.id, {
+              title: item.title || undefined,
+              status: item.status || undefined,
+            });
+        } else {
+          for (const id of taskIds) {
+            upsertTask(id, {
+              status: newStatus && newStatus !== 'unchanged' ? newStatus : undefined,
+            });
+          }
+        }
         break;
-      case 'batch_deleted':
-        for (const id of taskIds) upsertTask(id, { status: 'deleted' });
+      }
+      case 'batch_completed': {
+        const items = parseBatchItemsJson(attrs['task.items_json']);
+        if (items.length > 0) {
+          for (const item of items)
+            upsertTask(item.id, { title: item.title || undefined, status: 'completed' });
+        } else {
+          for (const id of taskIds) upsertTask(id, { status: 'completed' });
+        }
         break;
+      }
+      case 'batch_deleted': {
+        const items = parseBatchItemsJson(attrs['task.items_json']);
+        if (items.length > 0) {
+          for (const item of items)
+            upsertTask(item.id, { title: item.title || undefined, status: 'deleted' });
+        } else {
+          for (const id of taskIds) upsertTask(id, { status: 'deleted' });
+        }
+        break;
+      }
       default:
         break;
     }
@@ -1137,15 +1182,155 @@ function findImmediateNestedTaskScopeNodes(node: SpanTree): SpanTree[] {
   return scopes;
 }
 
+/** Checks IDs whose scopes should show a single synthesized task item
+ * from tool calls instead of their internal task.* event noise. */
+const SUB_AGENT_SCOPE_CHECKS = new Set(['engineer-task', 'explore-code']);
+
+function isSubAgentScope(span: NormalizedSpan): boolean {
+  const checkId = getTaskScopeCheckId(span);
+  if (checkId && SUB_AGENT_SCOPE_CHECKS.has(checkId)) return true;
+  const normalized = normalizeSpanName(span.name);
+  return normalized.startsWith('engineer.') || normalized === 'search.delegate';
+}
+
+// Note: when probelabs/probe#550 lands, task events will carry full agent scope
+// fields (agent.session_id, agent.parent_session_id) and proper titles, enabling
+// proper nested task tree reconstruction without relying on span ancestry.
+
+/** Determine the completion status of a sub-agent scope from its span lifecycle. */
+function getSubAgentStatus(node: SpanTree): string {
+  const normalized = normalizeSpanName(node.span.name);
+  if (normalized.endsWith('.completed')) return 'completed';
+  if (normalized.endsWith('.started') || normalized.endsWith('.progress')) return 'in_progress';
+  // Check children for completed/progress events
+  let hasCompleted = false;
+  let hasProgress = false;
+  const visit = (current: SpanTree) => {
+    const n = normalizeSpanName(current.span.name);
+    if (n.endsWith('.completed')) hasCompleted = true;
+    if (n.endsWith('.progress')) hasProgress = true;
+    for (const child of current.children) visit(child);
+  };
+  visit(node);
+  if (hasCompleted) return 'completed';
+  if (hasProgress) return 'in_progress';
+  return 'pending';
+}
+
 function buildProbeTaskScopeSummary(
   node: SpanTree,
   label: string,
-  isRootScope = false
+  isRootScope = false,
+  allSpans?: NormalizedSpan[]
 ): ProbeTaskScopeSummary | null {
+  const nestedScopeNodes = findImmediateNestedTaskScopeNodes(node);
+
+  // For sub-agent scopes, check if they have meaningful task titles from
+  // task snapshots. If not, synthesize a description from tool calls.
+  if (!isRootScope && isSubAgentScope(node.span)) {
+    const localTasks = summarizeTaskTelemetrySpans(collectTaskSpansForScope(node, true));
+    const hasMeaningfulTitles =
+      localTasks &&
+      localTasks.tasks.some(
+        t => t.title && t.title.length > 3 && !/^(task|engineer|code.?explorer)\s*/i.test(t.title)
+      );
+
+    if (hasMeaningfulTitles) {
+      // Sub-agent has proper task titles from task tool — use them
+      return {
+        label: isRootScope ? ROOT_TASK_SCOPE_LABEL : label,
+        source: localTasks!.source,
+        eventCount: localTasks!.eventCount,
+        snapshotCount: localTasks!.snapshotCount,
+        tasks: localTasks!.tasks,
+        children: [],
+      };
+    }
+
+    // No meaningful task tool titles — show scope as a single status line
+    const status = getSubAgentStatus(node);
+    const scopeLabel = getTaskScopeLabel(node.span);
+
+    return {
+      label: isRootScope ? ROOT_TASK_SCOPE_LABEL : label,
+      source: 'events',
+      eventCount: 0,
+      snapshotCount: 0,
+      tasks: [{ id: `__scope_${node.span.spanId}`, title: scopeLabel, status }],
+      children: [],
+    };
+  }
+
   const local = summarizeTaskTelemetrySpans(collectTaskSpansForScope(node, true));
-  const children = findImmediateNestedTaskScopeNodes(node)
-    .map(child => buildProbeTaskScopeSummary(child, getTaskScopeLabel(child.span)))
-    .filter((child): child is ProbeTaskScopeSummary => child !== null);
+
+  // For children that are sub-agent scopes, group repeated iterations
+  // (e.g., 13 engineer-task iterations) into a compact list
+  const children: ProbeTaskScopeSummary[] = [];
+  const subAgentGroups = new Map<string, SpanTree[]>();
+  const nonSubAgentNodes: SpanTree[] = [];
+
+  for (const child of nestedScopeNodes) {
+    if (isSubAgentScope(child.span)) {
+      const checkId = getTaskScopeCheckId(child.span) || normalizeSpanName(child.span.name);
+      const group = subAgentGroups.get(checkId) || [];
+      group.push(child);
+      subAgentGroups.set(checkId, group);
+    } else {
+      nonSubAgentNodes.push(child);
+    }
+  }
+
+  // Render non-sub-agent children normally
+  for (const child of nonSubAgentNodes) {
+    const childScope = buildProbeTaskScopeSummary(
+      child,
+      getTaskScopeLabel(child.span),
+      false,
+      allSpans
+    );
+    if (childScope) children.push(childScope);
+  }
+
+  // Render sub-agent groups as a single scope with one task per iteration.
+  // If a sub-agent has proper task titles (from task tool snapshots), use those.
+  for (const [checkId, nodes] of subAgentGroups) {
+    const scopeLabel =
+      checkId === 'engineer-task'
+        ? 'Engineer'
+        : checkId === 'explore-code'
+          ? 'Code Explorer'
+          : titleCaseWords(checkId);
+    const tasks: ProbeTaskSummaryItem[] = [];
+    for (const n of nodes) {
+      // Check if this iteration has meaningful task titles from the task tool
+      const iterScope = buildProbeTaskScopeSummary(n, scopeLabel, false, allSpans);
+      if (iterScope && iterScope.tasks.length > 0) {
+        tasks.push(...iterScope.tasks);
+      } else {
+        const status = getSubAgentStatus(n);
+        tasks.push({
+          id: `__scope_${n.span.spanId}`,
+          title: scopeLabel,
+          status,
+        });
+      }
+    }
+    // Deduplicate consecutive identical titles
+    const dedupedTasks: ProbeTaskSummaryItem[] = [];
+    for (const task of tasks) {
+      const prev = dedupedTasks[dedupedTasks.length - 1];
+      if (prev && prev.title === task.title && prev.status === task.status) continue;
+      dedupedTasks.push(task);
+    }
+    children.push({
+      label: scopeLabel,
+      source: 'events',
+      eventCount: nodes.length,
+      snapshotCount: 0,
+      tasks: dedupedTasks,
+      children: [],
+    });
+  }
 
   if (!local && children.length === 0) return null;
 
@@ -1467,7 +1652,8 @@ export function extractProbeTaskSummary(spans: NormalizedSpan[]): ProbeTaskSumma
   const rootScope = buildProbeTaskScopeSummary(
     buildTaskSummaryRoot(spans),
     ROOT_TASK_SCOPE_LABEL,
-    true
+    true,
+    spans
   );
   let scopes = rootScope ? [rootScope] : [];
   if (scopes.length === 0 || scopes[0].children.length === 0) {

--- a/src/agent-protocol/trace-serializer.ts
+++ b/src/agent-protocol/trace-serializer.ts
@@ -114,6 +114,7 @@ export interface ProbeTaskSummaryItem {
   id: string;
   title: string;
   status: string;
+  synthetic?: boolean;
 }
 
 export interface ProbeTaskScopeSummary {
@@ -1256,7 +1257,7 @@ function buildProbeTaskScopeSummary(
       source: 'events',
       eventCount: 0,
       snapshotCount: 0,
-      tasks: [{ id: `__scope_${node.span.spanId}`, title: scopeLabel, status }],
+      tasks: [{ id: `__scope_${node.span.spanId}`, title: scopeLabel, status, synthetic: true }],
       children: [],
     };
   }
@@ -1312,6 +1313,7 @@ function buildProbeTaskScopeSummary(
           id: `__scope_${n.span.spanId}`,
           title: scopeLabel,
           status,
+          synthetic: true,
         });
       }
     }
@@ -1387,6 +1389,7 @@ function flattenTaskScopes(scopes: ProbeTaskScopeSummary[]): ProbeTaskSummaryIte
   const items: ProbeTaskSummaryItem[] = [];
   const visit = (scope: ProbeTaskScopeSummary) => {
     for (const task of scope.tasks) {
+      if (task.synthetic) continue;
       if (seen.has(task.id)) continue;
       seen.add(task.id);
       items.push(task);
@@ -1578,12 +1581,18 @@ function formatTaskLabel(task: { id: string; title: string; status: string }): s
   return title || task.id || task.status;
 }
 
+function scopeHasRenderableTasks(scope: ProbeTaskScopeSummary): boolean {
+  if (scope.tasks.some(task => !task.synthetic)) return true;
+  return scope.children.some(child => scopeHasRenderableTasks(child));
+}
+
 function appendTaskScopeLines(lines: string[], scope: ProbeTaskScopeSummary, depth = 0): void {
+  if (!scopeHasRenderableTasks(scope)) return;
   const prefix = '  '.repeat(depth);
   if (depth > 0 || scope.label !== ROOT_TASK_SCOPE_LABEL) {
     lines.push(`${prefix}${scope.label}`);
   }
-  for (const task of scope.tasks) {
+  for (const task of scope.tasks.filter(task => !task.synthetic)) {
     lines.push(`${prefix}  ${formatTaskStatus(task.status)} ${formatTaskLabel(task)}`);
   }
   for (const child of scope.children) {
@@ -1596,7 +1605,7 @@ export function buildTraceHeaderLines(
   taskSummary: ProbeTaskSummary | null
 ): string[] {
   const lines = [`Trace source: ${traceData.source || 'unknown'}`];
-  if (!taskSummary) {
+  if (!taskSummary || taskSummary.tasks.length === 0) {
     lines.push('Tasks: no task telemetry found in this trace');
     return lines;
   }
@@ -1883,10 +1892,12 @@ function renderYamlNode(
     const action = attrs['dedup.action'] || '?';
     const reason = attrs['dedup.reason'] || '';
     const rewritten = attrs['dedup.rewritten'] || '';
+    const error = attrs['dedup.error'] || '';
     const prevCount = attrs['dedup.previous_count'] || '0';
     let detail = `${action}`;
     if (rewritten) detail += ` → "${truncate(String(rewritten), 60)}"`;
     if (reason) detail += ` (${truncate(String(reason), 80)})`;
+    if (error) detail += ` [error: ${truncate(String(error), 120)}]`;
     lines.push(
       `${pad}dedup("${truncate(String(query), 60)}") [${prevCount} prior]: ${detail} — ${duration}`
     );
@@ -2630,9 +2641,11 @@ function formatSpanLine(
     const action = attrs['dedup.action'] || '?';
     const reason = attrs['dedup.reason'] || '';
     const rewritten = attrs['dedup.rewritten'] || '';
+    const error = attrs['dedup.error'] || '';
     let detail = `${action}`;
     if (rewritten) detail += ` → "${truncate(String(rewritten), 50)}"`;
     if (reason) detail += ` — ${truncate(String(reason), 60)}`;
+    if (error) detail += ` [error: ${truncate(String(error), 80)}]`;
     return { line: `dedup("${truncate(String(query), 50)}") ${detail} (${duration})` };
   }
 

--- a/src/agent-protocol/track-execution.ts
+++ b/src/agent-protocol/track-execution.ts
@@ -23,6 +23,7 @@ import {
   type TaskLiveUpdateSink,
 } from './task-live-updates';
 import { resolveTaskTraceReference } from './task-trace-resolution';
+import { summarizeUserFacingIssues } from '../utils/user-facing-error';
 
 function getPackageVersion(): string {
   try {
@@ -253,6 +254,12 @@ export async function trackExecution<T>(
               }
             }
             if (responseText !== 'Execution completed') break;
+          }
+        }
+        if (responseText === 'Execution completed') {
+          const issueSummary = summarizeUserFacingIssues((result as any)?.reviewSummary?.issues);
+          if (issueSummary) {
+            responseText = issueSummary;
           }
         }
       } catch {

--- a/src/agent-protocol/track-execution.ts
+++ b/src/agent-protocol/track-execution.ts
@@ -161,8 +161,8 @@ export async function trackExecution<T>(
               }
               return {
                 traceRef:
-                  (current?.metadata?.trace_id as string | undefined) ||
                   (current?.metadata?.trace_file as string | undefined) ||
+                  (current?.metadata?.trace_id as string | undefined) ||
                   initialResolvedTrace.primaryRef,
                 traceId: current?.metadata?.trace_id as string | undefined,
               };

--- a/src/agent-protocol/track-execution.ts
+++ b/src/agent-protocol/track-execution.ts
@@ -228,10 +228,9 @@ export async function trackExecution<T>(
         // best-effort — don't fail the task over metadata
       }
 
-      // Extract AI response text from the result.
+      // Extract response text from the result.
       // result.reviewSummary.history is keyed by checkId with arrays of outputs.
-      // We want the LAST check's text output (the final AI response), not the
-      // first (which is typically the intent router).
+      // We want the LAST check's text output (the final AI response or workflow text output).
       let responseText = 'Execution completed';
       try {
         const history = (result as any)?.reviewSummary?.history as
@@ -245,7 +244,9 @@ export async function trackExecution<T>(
             if (!Array.isArray(outputs)) continue;
             // Within a check, look at the last output first too
             for (let j = outputs.length - 1; j >= 0; j--) {
-              const text = (outputs[j] as any)?.text;
+              const out = outputs[j] as any;
+              // Direct text field (AI response or workflow text output)
+              const text = out?.text;
               if (typeof text === 'string' && text.trim().length > 0) {
                 responseText = text.trim();
                 break;

--- a/src/ai-review-service.ts
+++ b/src/ai-review-service.ts
@@ -10,6 +10,7 @@ import { emitNdjsonFullSpan } from './telemetry/fallback-ndjson';
 import { initializeTracer } from './utils/tracer-init';
 import { processDiffWithOutline } from './utils/diff-processor';
 import { shouldFilterVisorReviewComment } from './utils/comment-metadata';
+import { formatUserFacingExecutionError } from './utils/user-facing-error';
 import { extractFileSections, replaceFileSections } from './slack/markdown';
 
 /**
@@ -1172,8 +1173,8 @@ export class AIReviewService {
   /**
    * Cleanup a session from the registry
    */
-  cleanupSession(sessionId: string): void {
-    this.sessionRegistry.unregisterSession(sessionId);
+  async cleanupSession(sessionId: string): Promise<void> {
+    await this.sessionRegistry.unregisterSession(sessionId);
   }
 
   /**
@@ -2972,9 +2973,7 @@ ${'='.repeat(60)}
       return { response, effectiveSchema, sessionId };
     } catch (error) {
       console.error('❌ ProbeAgent failed:', error);
-      throw new Error(
-        `ProbeAgent execution failed: ${error instanceof Error ? error.message : 'Unknown error'}`
-      );
+      throw new Error(formatUserFacingExecutionError(error));
     } finally {
       // Restore original environment variables
       Object.keys(originalEnv).forEach(key => {

--- a/src/ai-review-service.ts
+++ b/src/ai-review-service.ts
@@ -54,7 +54,7 @@ function getCurrentDateXml(): string {
   return `<current_date>${now.toISOString().split('T')[0]}</current_date>`;
 }
 
-function createProbeTracerAdapter(fallbackTracer?: any) {
+export function createProbeTracerAdapter(fallbackTracer?: any) {
   const fallback = fallbackTracer && typeof fallbackTracer === 'object' ? fallbackTracer : null;
   const LIVE_LIFECYCLE_SPANS = new Set(['visor.ai_check', 'ai.request', 'search.delegate']);
   const PROBE_LIFECYCLE_ALIASES: Record<string, string> = {
@@ -103,6 +103,8 @@ function createProbeTracerAdapter(fallbackTracer?: any) {
     'negotiated_timeout.observer_exhausted',
     'negotiated_timeout.abort_summary',
   ]);
+  const isSpanWorthyEvent = (name: string): boolean =>
+    SPAN_WORTHY_EVENTS.has(name) || name.startsWith('task.');
 
   const emitEvent = (name: string, attrs?: Record<string, unknown>) => {
     try {
@@ -110,13 +112,34 @@ function createProbeTracerAdapter(fallbackTracer?: any) {
 
       // For important events, emit a short-lived child span that ends
       // immediately so it gets exported even if the parent span never closes.
-      if (SPAN_WORTHY_EVENTS.has(name)) {
+      if (isSpanWorthyEvent(name)) {
         try {
+          const startHr = process.hrtime();
           const tracer = otTrace.getTracer('visor');
           const childSpan = tracer.startSpan(`probe.event.${name}`, {
             attributes: { 'probe.event.name': name, ...flat },
           });
           childSpan.end(); // ends immediately → gets exported by BatchSpanProcessor
+
+          // Mirror span-worthy events into the local NDJSON fallback trace too.
+          // `tasks trace` often falls back to this file when Tempo/Grafana is unavailable.
+          try {
+            const activeParent = otTrace.getActiveSpan?.();
+            const parentCtx = activeParent?.spanContext?.();
+            const childCtx = childSpan.spanContext?.();
+            const endHr = process.hrtime();
+            emitNdjsonFullSpan({
+              name: `probe.event.${name}`,
+              traceId: childCtx?.traceId || parentCtx?.traceId,
+              spanId: childCtx?.spanId,
+              parentSpanId: parentCtx?.spanId,
+              startTime: [startHr[0], startHr[1]],
+              endTime: [endHr[0], endHr[1]],
+              attributes: { 'probe.event.name': name, ...flat },
+              events: [],
+              status: { code: 1 },
+            });
+          } catch {}
         } catch {}
       }
 
@@ -307,6 +330,14 @@ function createProbeTracerAdapter(fallbackTracer?: any) {
       if (fallback && typeof fallback.recordJsonValidationEvent === 'function') {
         try {
           fallback.recordJsonValidationEvent(phase, attrs);
+        } catch {}
+      }
+    },
+    recordTaskEvent: (phase: string, attrs?: Record<string, unknown>) => {
+      emitEvent(`task.${phase}`, attrs);
+      if (fallback && typeof fallback.recordTaskEvent === 'function') {
+        try {
+          fallback.recordTaskEvent(phase, attrs);
         } catch {}
       }
     },

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+// Register global handler for transient child-process I/O errors (EIO, EPIPE)
+// before any other code runs so broken pipes from MCP servers etc. don't crash
+// the process.
+import './utils/child-process-error-handler';
+
 // Load environment variables from .env file (override existing to allow .env to take precedence)
 import * as dotenv from 'dotenv';
 dotenv.config({ override: true, quiet: true });

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -1838,6 +1838,8 @@ export async function main(): Promise<void> {
           logger.info('[Watch] Config updated');
         },
       });
+      const { SessionRegistry } = await import('./session-registry');
+      const sessionRegistry = SessionRegistry.getInstance();
 
       // Unified graceful shutdown
       let shuttingDown = false;
@@ -1855,6 +1857,7 @@ export async function main(): Promise<void> {
         forceTimer.unref();
         try {
           await configReloadRuntime.cleanup();
+          await sessionRegistry.clearAllSessions();
           await host.stopAll();
           if (sharedTaskStore) {
             try {
@@ -2669,7 +2672,7 @@ export async function main(): Promise<void> {
       logger.debug(
         `🧹 Cleaning up ${sessionRegistry.getActiveSessionIds().length} active AI sessions...`
       );
-      sessionRegistry.clearAllSessions();
+      await sessionRegistry.clearAllSessions();
     }
 
     // Force exit to prevent hanging from unclosed resources (MCP connections, etc.)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -395,8 +395,11 @@ Subcommands:
   visor test                                                 # Run YAML tests
   visor review                                               # Run built-in code review
   visor build <agent.yaml>                                   # Run agent builder
+  visor process list|restart|reload|stop                     # Manage running Visor processes
+  visor tasks list|show|logs                                 # Inspect tracked agent tasks
   visor config snapshots                                     # Manage config snapshots
   visor schedule start                                       # Start scheduler
+  visor policy-check                                         # Run policy evaluation helpers
 
 Examples:
   visor --check performance --output table

--- a/src/email/polling-runner.ts
+++ b/src/email/polling-runner.ts
@@ -13,7 +13,7 @@ import { StateMachineExecutionEngine } from '../state-machine-execution-engine';
 import { EmailClient, type EmailMessage } from './client';
 import { EmailAdapter } from './adapter';
 import { createHash } from 'crypto';
-import { WorkspaceManager } from '../utils/workspace-manager';
+import { startPeriodicStorageCleanup } from '../utils/worktree-cleanup';
 
 export type EmailPollingConfig = {
   receive?: {
@@ -59,6 +59,7 @@ export class EmailPollingRunner implements Runner {
   private resendLastSeenId?: string; // cursor for Resend polling
   private hasWebhookSecret: boolean;
   private activeProcessing = 0;
+  private storageCleanupStop?: () => void;
 
   constructor(engine: StateMachineExecutionEngine, cfg: VisorConfig, opts: EmailPollingConfig) {
     this.receiveType = (opts.receive?.type as 'imap' | 'resend') || 'imap';
@@ -104,11 +105,13 @@ export class EmailPollingRunner implements Runner {
       await this.startResendPolling();
     }
 
-    // Clean up stale workspace directories
-    WorkspaceManager.cleanupStale().catch(() => {});
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = startPeriodicStorageCleanup('EmailPolling');
   }
 
   async stopListening(): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     this.stopped = true;
     if (this.pollTimer) {
       clearInterval(this.pollTimer);
@@ -118,6 +121,8 @@ export class EmailPollingRunner implements Runner {
   }
 
   async drain(timeoutMs = 0): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     if (!this.stopped) {
       await this.stopListening();
     }
@@ -137,6 +142,8 @@ export class EmailPollingRunner implements Runner {
   }
 
   async stop(): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     this.stopped = true;
     if (this.pollTimer) {
       clearInterval(this.pollTimer);

--- a/src/frontends/email-frontend.ts
+++ b/src/frontends/email-frontend.ts
@@ -9,7 +9,10 @@
 import type { Frontend, FrontendContext } from './host';
 import { EmailClient, type EmailSendOptions } from '../email/client';
 import { formatEmailText, wrapInEmailTemplate, addRePrefix } from '../email/markdown';
-import { formatUserFacingExecutionMessage } from '../utils/user-facing-error';
+import {
+  formatUserFacingExecutionMessage,
+  summarizeUserFacingIssues,
+} from '../utils/user-facing-error';
 
 type EmailFrontendConfig = {
   send?: {
@@ -198,18 +201,9 @@ export class EmailFrontend implements Frontend {
       }
 
       if (!text) {
-        const issues: any[] = (result as any)?.issues || [];
-        const errorIssues = issues.filter(
-          (i: any) =>
-            i.severity === 'error' &&
-            (i.ruleId?.startsWith('system/') || i.ruleId?.endsWith('/error'))
-        );
-        if (errorIssues.length > 0) {
-          text = errorIssues
-            .map((i: any) =>
-              formatUserFacingExecutionMessage(String(i.message || 'Execution error'))
-            )
-            .join('\n');
+        const issueSummary = summarizeUserFacingIssues((result as any)?.issues || []);
+        if (issueSummary) {
+          text = issueSummary;
           this.errorNotified = true;
         }
       }

--- a/src/frontends/email-frontend.ts
+++ b/src/frontends/email-frontend.ts
@@ -9,6 +9,7 @@
 import type { Frontend, FrontendContext } from './host';
 import { EmailClient, type EmailSendOptions } from '../email/client';
 import { formatEmailText, wrapInEmailTemplate, addRePrefix } from '../email/markdown';
+import { formatUserFacingExecutionMessage } from '../utils/user-facing-error';
 
 type EmailFrontendConfig = {
   send?: {
@@ -117,13 +118,15 @@ export class EmailFrontend implements Frontend {
 
     let text = `${title}`;
     if (checkId) text += `\nCheck: ${checkId}`;
-    if (message) text += `\n${message}`;
+    if (message) text += `\n${formatUserFacingExecutionMessage(message)}`;
 
     const sendOpts: EmailSendOptions = {
       to: ev.from,
       subject: ev.subject ? addRePrefix(ev.subject) : `Visor: ${title}`,
       text,
-      html: wrapInEmailTemplate(`<p><strong>${title}</strong></p><p>${message}</p>`),
+      html: wrapInEmailTemplate(
+        `<p><strong>${title}</strong></p><p>${formatUserFacingExecutionMessage(message)}</p>`
+      ),
     };
 
     // Thread the reply
@@ -192,6 +195,23 @@ export class EmailFrontend implements Frontend {
       // Append raw output
       if (out && typeof out._rawOutput === 'string' && out._rawOutput.trim().length > 0) {
         text = (text || '') + '\n\n' + out._rawOutput.trim();
+      }
+
+      if (!text) {
+        const issues: any[] = (result as any)?.issues || [];
+        const errorIssues = issues.filter(
+          (i: any) =>
+            i.severity === 'error' &&
+            (i.ruleId?.startsWith('system/') || i.ruleId?.endsWith('/error'))
+        );
+        if (errorIssues.length > 0) {
+          text = errorIssues
+            .map((i: any) =>
+              formatUserFacingExecutionMessage(String(i.message || 'Execution error'))
+            )
+            .join('\n');
+          this.errorNotified = true;
+        }
       }
 
       if (!text) {

--- a/src/frontends/slack-frontend.ts
+++ b/src/frontends/slack-frontend.ts
@@ -32,6 +32,7 @@ import {
 import { context as otContext, trace } from '../telemetry/lazy-otel';
 import { isFrontendLiveUpdatesEnabled } from '../agent-protocol/task-live-updates';
 import { logger as sharedLogger } from '../logger';
+import { formatUserFacingExecutionMessage } from '../utils/user-facing-error';
 
 type SlackFrontendConfig = {
   defaultChannel?: string;
@@ -344,7 +345,7 @@ export class SlackFrontend implements Frontend {
 
     let text = `❌ ${title}`;
     if (checkId) text += `\nCheck: ${checkId}`;
-    if (message) text += `\n${message}`;
+    if (message) text += `\n${formatUserFacingExecutionMessage(message)}`;
 
     if (this.isTelemetryEnabled(ctx)) {
       const suffix = this.getExecutionReferenceSuffix();
@@ -594,7 +595,11 @@ export class SlackFrontend implements Frontend {
             (i.ruleId?.startsWith('system/') || i.ruleId?.endsWith('/error'))
         );
         if (errorIssues.length > 0) {
-          const errorMessages = errorIssues.map((i: any) => i.message).join('\n');
+          const errorMessages = errorIssues
+            .map((i: any) =>
+              formatUserFacingExecutionMessage(String(i.message || 'Execution error'))
+            )
+            .join('\n');
           text = `:warning: Something went wrong while processing your request:\n${errorMessages}`;
           // Prevent maybePostExecutionFailure from double-posting the same error
           this.errorNotified = true;

--- a/src/frontends/slack-frontend.ts
+++ b/src/frontends/slack-frontend.ts
@@ -32,7 +32,10 @@ import {
 import { context as otContext, trace } from '../telemetry/lazy-otel';
 import { isFrontendLiveUpdatesEnabled } from '../agent-protocol/task-live-updates';
 import { logger as sharedLogger } from '../logger';
-import { formatUserFacingExecutionMessage } from '../utils/user-facing-error';
+import {
+  formatUserFacingExecutionMessage,
+  summarizeUserFacingIssues,
+} from '../utils/user-facing-error';
 
 type SlackFrontendConfig = {
   defaultChannel?: string;
@@ -588,23 +591,13 @@ export class SlackFrontend implements Frontend {
       // Fallback: if no text was extracted, check for error issues (e.g. timeout)
       // and post an error message so the user isn't left with silence.
       if (!text) {
-        const issues: any[] = (result as any)?.issues || [];
-        const errorIssues = issues.filter(
-          (i: any) =>
-            i.severity === 'error' &&
-            (i.ruleId?.startsWith('system/') || i.ruleId?.endsWith('/error'))
-        );
-        if (errorIssues.length > 0) {
-          const errorMessages = errorIssues
-            .map((i: any) =>
-              formatUserFacingExecutionMessage(String(i.message || 'Execution error'))
-            )
-            .join('\n');
+        const errorMessages = summarizeUserFacingIssues((result as any)?.issues || []);
+        if (errorMessages) {
           text = `:warning: Something went wrong while processing your request:\n${errorMessages}`;
           // Prevent maybePostExecutionFailure from double-posting the same error
           this.errorNotified = true;
           ctx.logger.warn(
-            `[slack-frontend] posting error fallback for ${checkId}: ${errorIssues.length} system error(s)`
+            `[slack-frontend] posting error fallback for ${checkId}: issue-derived error message`
           );
         }
       }

--- a/src/frontends/teams-frontend.ts
+++ b/src/frontends/teams-frontend.ts
@@ -11,7 +11,10 @@ import { TeamsClient } from '../teams/client';
 import { formatTeamsText } from '../teams/markdown';
 import type { ConversationReference } from 'botbuilder';
 import { isFrontendLiveUpdatesEnabled } from '../agent-protocol/task-live-updates';
-import { formatUserFacingExecutionMessage } from '../utils/user-facing-error';
+import {
+  formatUserFacingExecutionMessage,
+  summarizeUserFacingIssues,
+} from '../utils/user-facing-error';
 
 type TeamsFrontendConfig = {
   appId?: string;
@@ -195,18 +198,9 @@ export class TeamsFrontend implements Frontend {
       }
 
       if (!text) {
-        const issues: any[] = (result as any)?.issues || [];
-        const errorIssues = issues.filter(
-          (i: any) =>
-            i.severity === 'error' &&
-            (i.ruleId?.startsWith('system/') || i.ruleId?.endsWith('/error'))
-        );
-        if (errorIssues.length > 0) {
-          text = errorIssues
-            .map((i: any) =>
-              formatUserFacingExecutionMessage(String(i.message || 'Execution error'))
-            )
-            .join('\n');
+        const issueSummary = summarizeUserFacingIssues((result as any)?.issues || []);
+        if (issueSummary) {
+          text = issueSummary;
           this.errorNotified = true;
         }
       }

--- a/src/frontends/teams-frontend.ts
+++ b/src/frontends/teams-frontend.ts
@@ -11,6 +11,7 @@ import { TeamsClient } from '../teams/client';
 import { formatTeamsText } from '../teams/markdown';
 import type { ConversationReference } from 'botbuilder';
 import { isFrontendLiveUpdatesEnabled } from '../agent-protocol/task-live-updates';
+import { formatUserFacingExecutionMessage } from '../utils/user-facing-error';
 
 type TeamsFrontendConfig = {
   appId?: string;
@@ -120,7 +121,7 @@ export class TeamsFrontend implements Frontend {
 
     let text = `${title}`;
     if (_checkId) text += `\nCheck: ${_checkId}`;
-    if (message) text += `\n${message}`;
+    if (message) text += `\n${formatUserFacingExecutionMessage(message)}`;
 
     await teams.sendMessage({
       conversationReference: conversationRef,
@@ -191,6 +192,23 @@ export class TeamsFrontend implements Frontend {
       // Append raw output
       if (out && typeof out._rawOutput === 'string' && out._rawOutput.trim().length > 0) {
         text = (text || '') + '\n\n' + out._rawOutput.trim();
+      }
+
+      if (!text) {
+        const issues: any[] = (result as any)?.issues || [];
+        const errorIssues = issues.filter(
+          (i: any) =>
+            i.severity === 'error' &&
+            (i.ruleId?.startsWith('system/') || i.ruleId?.endsWith('/error'))
+        );
+        if (errorIssues.length > 0) {
+          text = errorIssues
+            .map((i: any) =>
+              formatUserFacingExecutionMessage(String(i.message || 'Execution error'))
+            )
+            .join('\n');
+          this.errorNotified = true;
+        }
       }
 
       if (!text) {

--- a/src/frontends/telegram-frontend.ts
+++ b/src/frontends/telegram-frontend.ts
@@ -10,7 +10,10 @@ import type { Frontend, FrontendContext } from './host';
 import { TelegramClient } from '../telegram/client';
 import { formatTelegramText } from '../telegram/markdown';
 import { isFrontendLiveUpdatesEnabled } from '../agent-protocol/task-live-updates';
-import { formatUserFacingExecutionMessage } from '../utils/user-facing-error';
+import {
+  formatUserFacingExecutionMessage,
+  summarizeUserFacingIssues,
+} from '../utils/user-facing-error';
 
 type TelegramFrontendConfig = {
   defaultChatId?: string | number;
@@ -273,18 +276,9 @@ export class TelegramFrontend implements Frontend {
       }
 
       if (!text) {
-        const issues: any[] = (result as any)?.issues || [];
-        const errorIssues = issues.filter(
-          (i: any) =>
-            i.severity === 'error' &&
-            (i.ruleId?.startsWith('system/') || i.ruleId?.endsWith('/error'))
-        );
-        if (errorIssues.length > 0) {
-          text = errorIssues
-            .map((i: any) =>
-              formatUserFacingExecutionMessage(String(i.message || 'Execution error'))
-            )
-            .join('\n');
+        const issueSummary = summarizeUserFacingIssues((result as any)?.issues || []);
+        if (issueSummary) {
+          text = issueSummary;
           this.errorNotified = true;
         }
       }

--- a/src/frontends/telegram-frontend.ts
+++ b/src/frontends/telegram-frontend.ts
@@ -10,6 +10,7 @@ import type { Frontend, FrontendContext } from './host';
 import { TelegramClient } from '../telegram/client';
 import { formatTelegramText } from '../telegram/markdown';
 import { isFrontendLiveUpdatesEnabled } from '../agent-protocol/task-live-updates';
+import { formatUserFacingExecutionMessage } from '../utils/user-facing-error';
 
 type TelegramFrontendConfig = {
   defaultChatId?: string | number;
@@ -200,7 +201,7 @@ export class TelegramFrontend implements Frontend {
 
     let text = `❌ ${title}`;
     if (checkId) text += `\nCheck: ${checkId}`;
-    if (message) text += `\n${message}`;
+    if (message) text += `\n${formatUserFacingExecutionMessage(message)}`;
 
     await telegram.sendMessage({
       chat_id: chatId,
@@ -269,6 +270,23 @@ export class TelegramFrontend implements Frontend {
       // Append raw output
       if (out && typeof out._rawOutput === 'string' && out._rawOutput.trim().length > 0) {
         text = (text || '') + '\n\n' + out._rawOutput.trim();
+      }
+
+      if (!text) {
+        const issues: any[] = (result as any)?.issues || [];
+        const errorIssues = issues.filter(
+          (i: any) =>
+            i.severity === 'error' &&
+            (i.ruleId?.startsWith('system/') || i.ruleId?.endsWith('/error'))
+        );
+        if (errorIssues.length > 0) {
+          text = errorIssues
+            .map((i: any) =>
+              formatUserFacingExecutionMessage(String(i.message || 'Execution error'))
+            )
+            .join('\n');
+          this.errorNotified = true;
+        }
       }
 
       if (!text) {

--- a/src/frontends/whatsapp-frontend.ts
+++ b/src/frontends/whatsapp-frontend.ts
@@ -9,6 +9,7 @@
 import type { Frontend, FrontendContext } from './host';
 import { WhatsAppClient } from '../whatsapp/client';
 import { formatWhatsAppText } from '../whatsapp/markdown';
+import { formatUserFacingExecutionMessage } from '../utils/user-facing-error';
 
 type WhatsAppFrontendConfig = {
   accessToken?: string;
@@ -115,7 +116,7 @@ export class WhatsAppFrontend implements Frontend {
 
     let text = `${title}`;
     if (checkId) text += `\nCheck: ${checkId}`;
-    if (message) text += `\n${message}`;
+    if (message) text += `\n${formatUserFacingExecutionMessage(message)}`;
 
     await whatsapp.sendMessage({
       to: from,
@@ -184,6 +185,23 @@ export class WhatsAppFrontend implements Frontend {
       // Append raw output
       if (out && typeof out._rawOutput === 'string' && out._rawOutput.trim().length > 0) {
         text = (text || '') + '\n\n' + out._rawOutput.trim();
+      }
+
+      if (!text) {
+        const issues: any[] = (result as any)?.issues || [];
+        const errorIssues = issues.filter(
+          (i: any) =>
+            i.severity === 'error' &&
+            (i.ruleId?.startsWith('system/') || i.ruleId?.endsWith('/error'))
+        );
+        if (errorIssues.length > 0) {
+          text = errorIssues
+            .map((i: any) =>
+              formatUserFacingExecutionMessage(String(i.message || 'Execution error'))
+            )
+            .join('\n');
+          this.errorNotified = true;
+        }
       }
 
       if (!text) {

--- a/src/frontends/whatsapp-frontend.ts
+++ b/src/frontends/whatsapp-frontend.ts
@@ -9,7 +9,10 @@
 import type { Frontend, FrontendContext } from './host';
 import { WhatsAppClient } from '../whatsapp/client';
 import { formatWhatsAppText } from '../whatsapp/markdown';
-import { formatUserFacingExecutionMessage } from '../utils/user-facing-error';
+import {
+  formatUserFacingExecutionMessage,
+  summarizeUserFacingIssues,
+} from '../utils/user-facing-error';
 
 type WhatsAppFrontendConfig = {
   accessToken?: string;
@@ -188,18 +191,9 @@ export class WhatsAppFrontend implements Frontend {
       }
 
       if (!text) {
-        const issues: any[] = (result as any)?.issues || [];
-        const errorIssues = issues.filter(
-          (i: any) =>
-            i.severity === 'error' &&
-            (i.ruleId?.startsWith('system/') || i.ruleId?.endsWith('/error'))
-        );
-        if (errorIssues.length > 0) {
-          text = errorIssues
-            .map((i: any) =>
-              formatUserFacingExecutionMessage(String(i.message || 'Execution error'))
-            )
-            .join('\n');
+        const issueSummary = summarizeUserFacingIssues((result as any)?.issues || []);
+        if (issueSummary) {
+          text = issueSummary;
           this.errorNotified = true;
         }
       }

--- a/src/generated/config-schema.ts
+++ b/src/generated/config-schema.ts
@@ -1147,7 +1147,7 @@ export const configSchema = {
           description: 'Arguments/inputs for the workflow',
         },
         overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62422%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495%3E%3E',
           description: 'Override specific step configurations in the workflow',
         },
         output_mapping: {
@@ -1164,7 +1164,7 @@ export const configSchema = {
             'Config file path - alternative to workflow ID (loads a Visor config file as workflow)',
         },
         workflow_overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62422%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495%3E%3E',
           description: 'Alias for overrides - workflow step overrides (backward compatibility)',
         },
         ref: {
@@ -1908,7 +1908,7 @@ export const configSchema = {
           description: 'Custom output name (defaults to workflow name)',
         },
         overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62422%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495%3E%3E',
           description: 'Step overrides',
         },
         output_mapping: {
@@ -1923,14 +1923,14 @@ export const configSchema = {
         '^x-': {},
       },
     },
-    'Record<string,Partial<interface-src_types_config.ts-15521-30601-src_types_config.ts-0-62422>>':
+    'Record<string,Partial<interface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495>>':
       {
         type: 'object',
         additionalProperties: {
-          $ref: '#/definitions/Partial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62422%3E',
+          $ref: '#/definitions/Partial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495%3E',
         },
       },
-    'Partial<interface-src_types_config.ts-15521-30601-src_types_config.ts-0-62422>': {
+    'Partial<interface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495>': {
       type: 'object',
       additionalProperties: false,
     },
@@ -3316,7 +3316,8 @@ export const configSchema = {
         },
         workflow: {
           type: 'string',
-          description: 'Workflow/check ID to run',
+          description:
+            'Workflow/check ID to run. Omit to treat inputs.text as a user message through the full pipeline.',
         },
         inputs: {
           $ref: '#/definitions/Record%3Cstring%2Cunknown%3E',
@@ -3359,7 +3360,7 @@ export const configSchema = {
           description: 'Timezone for schedule (default: UTC or scheduler default)',
         },
       },
-      required: ['schedule', 'workflow'],
+      required: ['schedule'],
       additionalProperties: false,
       description:
         'Static cron job defined in YAML configuration These are always executed by the scheduler daemon',

--- a/src/generated/config-schema.ts
+++ b/src/generated/config-schema.ts
@@ -926,6 +926,16 @@ export const configSchema = {
           description:
             'Tags for categorizing and filtering checks (e.g., ["local", "fast", "security"])',
         },
+        debounce: {
+          type: 'number',
+          description:
+            "Debounce window in milliseconds. When set, multiple invocations of this step (across concurrent engine instances) within the window are coalesced — only the last invocation actually executes after the window expires. Useful for steps that should run once after a burst of triggers settles.\n\nThe debounce key defaults to the step's fully-qualified check ID. Use `debounce_key` to group different steps under the same debounce.",
+        },
+        debounce_key: {
+          type: 'string',
+          description:
+            'Custom debounce key. Steps sharing the same key share the same debounce window.',
+        },
         criticality: {
           type: 'string',
           enum: ['external', 'internal', 'policy', 'info'],
@@ -1147,7 +1157,7 @@ export const configSchema = {
           description: 'Arguments/inputs for the workflow',
         },
         overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-31208-src_types_config.ts-0-63102%3E%3E',
           description: 'Override specific step configurations in the workflow',
         },
         output_mapping: {
@@ -1164,7 +1174,7 @@ export const configSchema = {
             'Config file path - alternative to workflow ID (loads a Visor config file as workflow)',
         },
         workflow_overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-31208-src_types_config.ts-0-63102%3E%3E',
           description: 'Alias for overrides - workflow step overrides (backward compatibility)',
         },
         ref: {
@@ -1908,7 +1918,7 @@ export const configSchema = {
           description: 'Custom output name (defaults to workflow name)',
         },
         overrides: {
-          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495%3E%3E',
+          $ref: '#/definitions/Record%3Cstring%2CPartial%3Cinterface-src_types_config.ts-15521-31208-src_types_config.ts-0-63102%3E%3E',
           description: 'Step overrides',
         },
         output_mapping: {
@@ -1923,14 +1933,14 @@ export const configSchema = {
         '^x-': {},
       },
     },
-    'Record<string,Partial<interface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495>>':
+    'Record<string,Partial<interface-src_types_config.ts-15521-31208-src_types_config.ts-0-63102>>':
       {
         type: 'object',
         additionalProperties: {
-          $ref: '#/definitions/Partial%3Cinterface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495%3E',
+          $ref: '#/definitions/Partial%3Cinterface-src_types_config.ts-15521-31208-src_types_config.ts-0-63102%3E',
         },
       },
-    'Partial<interface-src_types_config.ts-15521-30601-src_types_config.ts-0-62495>': {
+    'Partial<interface-src_types_config.ts-15521-31208-src_types_config.ts-0-63102>': {
       type: 'object',
       additionalProperties: false,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,7 +306,7 @@ export async function run(): Promise<void> {
       console.log(
         `🧹 Cleaning up ${sessionRegistry.getActiveSessionIds().length} active AI sessions...`
       );
-      sessionRegistry.clearAllSessions();
+      await sessionRegistry.clearAllSessions();
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,11 @@
 // GitHub event objects have complex dynamic structures that are difficult to fully type
 // Using 'any' for these objects is acceptable as they come from external GitHub webhooks
 
+// Register global handler for transient child-process I/O errors (EIO, EPIPE)
+// before any other code runs so broken pipes from MCP servers etc. don't crash
+// the process.
+import './utils/child-process-error-handler';
+
 // Load environment variables from .env file (override existing to allow .env to take precedence)
 import * as dotenv from 'dotenv';
 dotenv.config({ override: true, quiet: true });

--- a/src/providers/ai-check-provider.ts
+++ b/src/providers/ai-check-provider.ts
@@ -29,6 +29,7 @@ import { getScheduleToolDefinition } from '../scheduler/schedule-tool';
 import { getTaskProgressToolDefinition } from '../agent-protocol/task-progress-tool';
 // Legacy Slack context extraction for backwards compatibility
 import { extractSlackContext } from '../slack/schedule-tool-handler';
+import { formatUserFacingExecutionError } from '../utils/user-facing-error';
 
 /**
  * AI-powered check provider using probe agent
@@ -2133,6 +2134,7 @@ export class AICheckProvider extends CheckProvider {
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
+      const userFacingMessage = formatUserFacingExecutionError(error);
 
       // Log detailed error information
       console.error(`❌ AI Check Provider Error for check: ${errorMessage}`);
@@ -2151,7 +2153,7 @@ export class AICheckProvider extends CheckProvider {
       }
 
       // Re-throw with more context
-      throw new Error(`AI analysis failed: ${errorMessage}`);
+      throw new Error(userFacingMessage);
     } finally {
       // Cleanup custom tools server
       // When AI check is complete (success or error), stop immediately without grace period.

--- a/src/providers/mcp-check-provider.ts
+++ b/src/providers/mcp-check-provider.ts
@@ -597,6 +597,18 @@ export class McpCheckProvider extends CheckProvider {
 
       const transport = createTransport();
 
+      // Attach error handler on the transport's stderr stream (if piped) so
+      // that EIO / EPIPE errors from a dying child process don't become
+      // uncaught exceptions that crash the whole visor process.
+      if ('stderr' in transport && transport.stderr) {
+        const stderrStream = transport.stderr as any;
+        if (typeof stderrStream.on === 'function') {
+          stderrStream.on('error', (err: Error) => {
+            logger.debug(`MCP transport stderr error (${transportName}): ${err.message}`);
+          });
+        }
+      }
+
       try {
         // Connect with timeout
         let timeoutId: NodeJS.Timeout | undefined;

--- a/src/providers/mcp-custom-sse-server.ts
+++ b/src/providers/mcp-custom-sse-server.ts
@@ -1377,6 +1377,11 @@ export class CustomToolsSSEServer implements CustomMCPServer {
       if (authType === 'bearer' && tool.auth.token) {
         const token = String(EnvironmentResolver.resolveValue(tool.auth.token));
         resolvedHeaders['Authorization'] = `Bearer ${token}`;
+      } else if (authType === 'oauth2_client_credentials' && tool.auth.token_url) {
+        const { OAuth2TokenCache } = await import('../utils/oauth2-token-cache');
+        const tokenCache = OAuth2TokenCache.getInstance();
+        const token = await tokenCache.getToken(tool.auth as any);
+        resolvedHeaders['Authorization'] = `Bearer ${token}`;
       }
     }
 

--- a/src/providers/script-check-provider.ts
+++ b/src/providers/script-check-provider.ts
@@ -382,6 +382,12 @@ export class ScriptCheckProvider extends CheckProvider {
             env,
             stderr: 'pipe',
           });
+          // Prevent EIO errors on the stderr pipe from crashing the process
+          if (transport.stderr) {
+            transport.stderr.on('error', (err: Error) => {
+              logger.debug(`MCP transport stderr error: ${err.message}`);
+            });
+          }
           await Promise.race([
             client.connect(transport),
             new Promise((_, reject) =>

--- a/src/providers/workflow-check-provider.ts
+++ b/src/providers/workflow-check-provider.ts
@@ -17,6 +17,7 @@ import { Liquid } from 'liquidjs';
 import { createExtendedLiquid } from '../liquid-extensions';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
+import { formatUserFacingExecutionMessage } from '../utils/user-facing-error';
 
 /**
  * Provider that executes workflows as checks
@@ -911,6 +912,19 @@ export class WorkflowCheckProvider extends CheckProvider {
       if (typedResult.score) {
         totalScore += typedResult.score;
         scoreCount++;
+      }
+    }
+
+    for (const checkStats of result.statistics?.checks || []) {
+      if (checkStats.errorMessage) {
+        allIssues.push({
+          file: 'system',
+          line: 0,
+          ruleId: 'system/error',
+          message: formatUserFacingExecutionMessage(checkStats.errorMessage),
+          severity: 'error',
+          category: 'logic',
+        } as any);
       }
     }
 

--- a/src/runners/mcp-server-runner.ts
+++ b/src/runners/mcp-server-runner.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import * as crypto from 'crypto';
 import { validateBearerToken, SERVER_INFO } from '../mcp-server';
 import { withVisorRun, getVisorRunAttributes } from '../telemetry/trace-helpers';
+import { summarizeUserFacingIssues } from '../utils/user-facing-error';
 
 export interface McpFrontendOptions {
   /** Port for HTTP transport (default: 8080). */
@@ -617,6 +618,9 @@ export class McpServerRunner implements Runner {
     // Direct properties on result
     if (result?.text) return String(result.text);
     if (result?.output?.text) return String(result.output.text);
+
+    const issueSummary = summarizeUserFacingIssues(result?.reviewSummary?.issues);
+    if (issueSummary) return issueSummary;
 
     // Fallback: JSON dump (compact to avoid huge responses)
     try {

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -289,8 +289,13 @@ export class Scheduler {
       throw new Error(`Invalid cron expression: ${job.schedule}`);
     }
 
-    // Check if workflow exists ("default" is a special alias for "run all checks")
-    if (job.workflow !== 'default') {
+    // If no workflow is set, treat as a reminder (runs inputs.text through full pipeline)
+    if (!job.workflow) {
+      if (!job.inputs?.text) {
+        throw new Error('Cron job without a workflow must have inputs.text set');
+      }
+      // No workflow validation needed — executeWorkflow will route to executeSimpleReminder
+    } else if (job.workflow !== 'default') {
       const allChecks = Object.keys(this.visorConfig.checks || {});
       if (!allChecks.includes(job.workflow)) {
         throw new Error(`Workflow "${job.workflow}" not found in configuration`);
@@ -320,7 +325,7 @@ export class Scheduler {
       const nextRun = getNextRunTime(job.schedule, job.timezone || this.defaultTimezone);
       const description = job.description ? ` (${job.description})` : '';
       logger.debug(
-        `[Scheduler] Scheduled static cron job '${jobId}'${description}: ${job.schedule} → ${job.workflow}, next run: ${nextRun.toISOString()}`
+        `[Scheduler] Scheduled static cron job '${jobId}'${description}: ${job.schedule} → ${job.workflow || '(reminder)'}, next run: ${nextRun.toISOString()}`
       );
     } catch {
       // Best effort logging

--- a/src/session-registry.ts
+++ b/src/session-registry.ts
@@ -1,4 +1,5 @@
 import { ProbeAgent } from '@probelabs/probe';
+import { logger } from './logger';
 
 /**
  * Extended ProbeAgent interface that includes tracing properties
@@ -15,12 +16,8 @@ interface TracedProbeAgent extends ProbeAgent {
 export class SessionRegistry {
   private static instance: SessionRegistry;
   private sessions: Map<string, TracedProbeAgent> = new Map();
-  private exitHandlerRegistered = false;
 
-  private constructor() {
-    // Register process exit handlers to cleanup sessions
-    this.registerExitHandlers();
-  }
+  private constructor() {}
 
   /**
    * Get the singleton instance of SessionRegistry
@@ -36,7 +33,7 @@ export class SessionRegistry {
    * Register a ProbeAgent session
    */
   public registerSession(sessionId: string, agent: TracedProbeAgent): void {
-    console.error(`🔄 Registering AI session: ${sessionId}`);
+    logger.debug(`[SessionRegistry] Registering AI session: ${sessionId}`);
     this.sessions.set(sessionId, agent);
   }
 
@@ -46,7 +43,7 @@ export class SessionRegistry {
   public getSession(sessionId: string): TracedProbeAgent | undefined {
     const agent = this.sessions.get(sessionId);
     if (agent) {
-      console.error(`♻️  Reusing AI session: ${sessionId}`);
+      logger.debug(`[SessionRegistry] Reusing AI session: ${sessionId}`);
     }
     return agent;
   }
@@ -54,9 +51,8 @@ export class SessionRegistry {
   /**
    * Remove a session from the registry
    */
-  public unregisterSession(sessionId: string): void {
+  public async unregisterSession(sessionId: string): Promise<void> {
     if (this.sessions.has(sessionId)) {
-      console.error(`🗑️  Unregistering AI session: ${sessionId}`);
       const agent = this.sessions.get(sessionId);
       this.sessions.delete(sessionId);
 
@@ -65,9 +61,11 @@ export class SessionRegistry {
       if (agent && typeof (agent as any).cleanup === 'function') {
         try {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (agent as any).cleanup();
+          await (agent as any).cleanup();
         } catch (error) {
-          console.error(`⚠️  Warning: Failed to cleanup ProbeAgent: ${error}`);
+          logger.warn(
+            `[SessionRegistry] Failed to cleanup ProbeAgent session ${sessionId}: ${error}`
+          );
         }
       }
     }
@@ -76,23 +74,32 @@ export class SessionRegistry {
   /**
    * Clear all sessions (useful for cleanup)
    */
-  public clearAllSessions(): void {
-    console.error(`🧹 Clearing all AI sessions (${this.sessions.size} sessions)`);
-
-    // Cleanup each ProbeAgent instance before clearing
-    for (const [, agent] of this.sessions.entries()) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if (agent && typeof (agent as any).cleanup === 'function') {
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (agent as any).cleanup();
-        } catch {
-          // Silent fail during bulk cleanup
-        }
-      }
+  public async clearAllSessions(): Promise<void> {
+    if (this.sessions.size === 0) {
+      return;
     }
 
+    logger.debug(`[SessionRegistry] Clearing all AI sessions (${this.sessions.size} sessions)`);
+
+    // Cleanup each ProbeAgent instance before clearing
+    const sessions = Array.from(this.sessions.entries());
     this.sessions.clear();
+
+    await Promise.allSettled(
+      sessions.map(async ([sessionId, agent]) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (agent && typeof (agent as any).cleanup === 'function') {
+          try {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await (agent as any).cleanup();
+          } catch (error) {
+            logger.warn(
+              `[SessionRegistry] Failed to cleanup ProbeAgent session ${sessionId}: ${error}`
+            );
+          }
+        }
+      })
+    );
   }
 
   /**
@@ -124,7 +131,7 @@ export class SessionRegistry {
   ): Promise<ProbeAgent | undefined> {
     const sourceAgent = this.sessions.get(sourceSessionId);
     if (!sourceAgent) {
-      console.error(`⚠️  Cannot clone session: ${sourceSessionId} not found`);
+      logger.warn(`[SessionRegistry] Cannot clone session: ${sourceSessionId} not found`);
       return undefined;
     }
 
@@ -150,9 +157,8 @@ export class SessionRegistry {
             clonedAgent._traceFilePath = tracerResult.filePath;
           }
         } catch (traceError) {
-          console.error(
-            '⚠️  Warning: Failed to initialize tracing for cloned session:',
-            traceError
+          logger.warn(
+            `[SessionRegistry] Failed to initialize tracing for cloned session ${newSessionId}: ${traceError}`
           );
         }
       }
@@ -164,17 +170,21 @@ export class SessionRegistry {
       ) {
         try {
           await (clonedAgent as any).initialize();
-          console.error(`🔧 Initialized MCP tools for cloned session`);
+          logger.debug(
+            `[SessionRegistry] Initialized MCP tools for cloned session ${newSessionId}`
+          );
         } catch (initError) {
-          console.error(`⚠️  Warning: Failed to initialize cloned agent: ${initError}`);
+          logger.warn(
+            `[SessionRegistry] Failed to initialize cloned agent ${newSessionId}: ${initError}`
+          );
         }
       }
 
       // Get history length for logging
       const historyLength = (clonedAgent as any).history?.length || 0;
 
-      console.error(
-        `📋 Cloned session ${sourceSessionId} → ${newSessionId} using ProbeAgent.clone() (${historyLength} messages, internal messages filtered)`
+      logger.debug(
+        `[SessionRegistry] Cloned session ${sourceSessionId} -> ${newSessionId} using ProbeAgent.clone() (${historyLength} messages, internal messages filtered)`
       );
 
       // Register the cloned session
@@ -182,58 +192,8 @@ export class SessionRegistry {
 
       return clonedAgent;
     } catch (error) {
-      console.error(`⚠️  Failed to clone session ${sourceSessionId}:`, error);
+      logger.warn(`[SessionRegistry] Failed to clone session ${sourceSessionId}: ${error}`);
       return undefined;
     }
-  }
-
-  /**
-   * Register process exit handlers to cleanup sessions on exit
-   */
-  private registerExitHandlers(): void {
-    if (this.exitHandlerRegistered) {
-      return;
-    }
-
-    const cleanupAndExit = (signal: string) => {
-      if (this.sessions.size > 0) {
-        console.error(`\n🧹 [${signal}] Cleaning up ${this.sessions.size} active AI sessions...`);
-        this.clearAllSessions();
-      }
-    };
-
-    // Handle normal process exit
-    process.on('exit', () => {
-      if (this.sessions.size > 0) {
-        console.error(`🧹 [exit] Cleaning up ${this.sessions.size} active AI sessions...`);
-        // Note: async operations won't complete here, but sync cleanup methods will
-        for (const [, agent] of this.sessions.entries()) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          if (agent && typeof (agent as any).cleanup === 'function') {
-            try {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (agent as any).cleanup();
-            } catch {
-              // Silent fail on exit
-            }
-          }
-        }
-        this.sessions.clear();
-      }
-    });
-
-    // Handle SIGINT (Ctrl+C)
-    process.on('SIGINT', () => {
-      cleanupAndExit('SIGINT');
-      process.exit(0);
-    });
-
-    // Handle SIGTERM
-    process.on('SIGTERM', () => {
-      cleanupAndExit('SIGTERM');
-      process.exit(0);
-    });
-
-    this.exitHandlerRegistered = true;
   }
 }

--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -165,8 +165,13 @@ export class SlackClient {
       console.warn('Slack auth.test failed (non-fatal); bot user id unavailable');
       return 'UNKNOWN_BOT';
     }
+    // Cache bot_id (different from user_id) for self-message detection on bot_message events
+    if (resp.bot_id) this._botId = String(resp.bot_id);
     return String(resp.user_id);
   }
+
+  /** The bot's bot_id (from auth.test), used to detect own bot_message events */
+  _botId?: string;
 
   /**
    * Fetch user info from Slack API.
@@ -219,6 +224,35 @@ export class SlackClient {
    * Open a DM channel with a user.
    * Returns the DM channel ID.
    */
+  /**
+   * Resolve a channel name (e.g. "function-cve-alerts") to a channel ID.
+   * Uses conversations.list with pagination. Results are cached for the process lifetime.
+   */
+  private channelNameCache = new Map<string, string>();
+
+  async resolveChannelName(name: string): Promise<string | undefined> {
+    const normalized = name.startsWith('#') ? name.slice(1) : name;
+    if (this.channelNameCache.has(normalized)) return this.channelNameCache.get(normalized);
+
+    let cursor: string | undefined;
+    do {
+      const params: Record<string, unknown> = {
+        types: 'public_channel,private_channel',
+        limit: 200,
+      };
+      if (cursor) params.cursor = cursor;
+      const resp: any = await this.api('conversations.list', params);
+      if (!resp?.ok) break;
+      for (const ch of resp.channels || []) {
+        this.channelNameCache.set(ch.name, ch.id);
+        if (ch.name === normalized) return ch.id;
+      }
+      cursor = resp.response_metadata?.next_cursor;
+    } while (cursor);
+
+    return undefined;
+  }
+
   async openDM(userId: string): Promise<{ ok: boolean; channel?: string }> {
     try {
       const resp: any = await this.api('conversations.open', { users: userId });

--- a/src/slack/markdown.ts
+++ b/src/slack/markdown.ts
@@ -135,6 +135,9 @@ export async function renderMermaidToPng(mermaidCode: string): Promise<Buffer | 
       proc.stderr?.on('data', data => {
         stderr += data.toString();
       });
+      // Prevent EIO errors on stderr from becoming uncaught exceptions
+      proc.stderr?.on('error', () => {});
+      proc.stdout?.on('error', () => {});
 
       proc.on('close', code => {
         if (code === 0) {

--- a/src/slack/slack-output-adapter.ts
+++ b/src/slack/slack-output-adapter.ts
@@ -109,8 +109,12 @@ export class SlackOutputAdapter implements ScheduleOutputAdapter {
         return target;
       }
 
-      // Try to resolve channel name to ID
-      // For now, just return the target and let Slack API handle it
+      // Resolve channel name to ID via conversations.list
+      if (this.client.resolveChannelName) {
+        const resolved = await this.client.resolveChannelName(target);
+        if (resolved) return resolved;
+        logger.warn(`[SlackOutputAdapter] Could not resolve channel name '${target}', using as-is`);
+      }
       return target;
     }
 

--- a/src/slack/socket-runner.ts
+++ b/src/slack/socket-runner.ts
@@ -649,6 +649,7 @@ export class SlackSocketRunner implements Runner {
     } catch {}
 
     // Evaluate message triggers (before mention gate so non-@mention messages can trigger workflows)
+    let triggerMatched = false;
     if (this.messageTriggerEvaluator) {
       try {
         const matches = this.messageTriggerEvaluator.evaluate({
@@ -664,6 +665,7 @@ export class SlackSocketRunner implements Runner {
           const triggerKey = `trigger:${match.id}:${String(ev.channel || '-')}:${String(ev.ts || ev.event_ts || '-')}`;
           if (!this.processedKeys.has(triggerKey)) {
             this.processedKeys.set(triggerKey, Date.now());
+            triggerMatched = true;
             this.dispatchMessageTrigger(match, env.payload).catch(err => {
               logger.error(
                 `[SlackSocket] Message trigger dispatch failed (${match.id}): ${err instanceof Error ? err.message : err}`
@@ -676,6 +678,13 @@ export class SlackSocketRunner implements Runner {
           `[SlackSocket] Message trigger evaluation error: ${err instanceof Error ? err.message : err}`
         );
       }
+    }
+
+    // If a message trigger matched and dispatched, do not also process as a normal chat message.
+    // This prevents double execution (trigger workflow + chat check for the same message).
+    if (triggerMatched) {
+      logger.info('[SlackSocket] Message handled by trigger — skipping normal chat dispatch');
+      return;
     }
 
     // If this is a bot message that was only allowed through for trigger evaluation,
@@ -1055,11 +1064,22 @@ export class SlackSocketRunner implements Runner {
         logger.error(`[SlackSocket] Message trigger '${id}': no checks configured`);
         return;
       }
+      // If trigger.workflow isn't a check name, check if it's an imported workflow
+      // and dynamically create a check that wraps it
       if (trigger.workflow !== 'default' && !allChecks.includes(trigger.workflow)) {
-        logger.error(
-          `[SlackSocket] Message trigger '${id}': workflow "${trigger.workflow}" not found in configuration`
-        );
-        return;
+        const { WorkflowRegistry } = await import('../workflow-registry');
+        const registry = WorkflowRegistry.getInstance();
+        if (registry.has(trigger.workflow)) {
+          logger.info(
+            `[SlackSocket] Message trigger '${id}': creating dynamic check for imported workflow "${trigger.workflow}"`
+          );
+          // Will inject the check into cfgForRun later (after it's created)
+        } else {
+          logger.error(
+            `[SlackSocket] Message trigger '${id}': workflow "${trigger.workflow}" not found in checks or imported workflows`
+          );
+          return;
+        }
       }
 
       // Build conversation context
@@ -1192,6 +1212,22 @@ export class SlackSocketRunner implements Runner {
           return this.cfg;
         }
       })();
+
+      // If trigger.workflow is an imported workflow (not a check), inject a dynamic check
+      if (trigger.workflow !== 'default' && !(cfgForRun.checks || ({} as any))[trigger.workflow]) {
+        if (!cfgForRun.checks) (cfgForRun as any).checks = {};
+        (cfgForRun as any).checks[trigger.workflow] = {
+          type: 'workflow',
+          on: ['slack_message'],
+          criticality: 'external',
+          workflow: trigger.workflow,
+          assume: ['true'],
+          args: trigger.inputs || {},
+        };
+        logger.info(
+          `[SlackSocket] Injected dynamic check '${trigger.workflow}' into config for trigger '${id}'`
+        );
+      }
 
       // Derive stable workspace name from thread identity
       const wsThreadTs = threadTs || ts;

--- a/src/slack/socket-runner.ts
+++ b/src/slack/socket-runner.ts
@@ -13,7 +13,7 @@ import { Scheduler } from '../scheduler/scheduler';
 import { ScheduleStore, type Schedule } from '../scheduler/schedule-store';
 import { createHash } from 'crypto';
 import { createSlackOutputAdapter } from './slack-output-adapter';
-import { WorkspaceManager } from '../utils/workspace-manager';
+import { startPeriodicStorageCleanup } from '../utils/worktree-cleanup';
 import { MessageTriggerEvaluator, type MatchedTrigger } from '../scheduler/message-trigger';
 import type { SlackMessageTrigger } from '../types/config';
 import { toSlackMessageTrigger, type MessageTrigger } from '../scheduler/store/types';
@@ -84,6 +84,7 @@ export class SlackSocketRunner implements Runner {
   private taskStore?: import('../agent-protocol/task-store').TaskStore;
   private configPath?: string;
   private staleTaskTimer?: ReturnType<typeof setInterval>;
+  private storageCleanupStop?: () => void;
 
   constructor(engine: StateMachineExecutionEngine, cfg: VisorConfig, opts: SlackSocketConfig) {
     const app = opts.appToken || process.env.SLACK_APP_TOKEN || '';
@@ -280,8 +281,8 @@ export class SlackSocketRunner implements Runner {
     const url = await this.openConnection();
     await this.connect(url);
 
-    // Clean up stale workspace directories from previous runs
-    WorkspaceManager.cleanupStale().catch(() => {});
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = startPeriodicStorageCleanup('SlackSocket');
 
     // Periodic stale task sweep — fail 'working' tasks with no heartbeat.
     // Tasks send a heartbeat every 60s, so 5 minutes without an update means
@@ -1504,6 +1505,8 @@ export class SlackSocketRunner implements Runner {
    */
   async stopListening(): Promise<void> {
     this.draining = true;
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     logger.info(
       `[SlackSocket] Stopping listener (${this.activeThreads.size} active thread(s) will continue)`
     );
@@ -1559,6 +1562,8 @@ export class SlackSocketRunner implements Runner {
    * Stop the socket runner and clean up resources
    */
   async stop(): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     // Stop stale task sweep timer
     if (this.staleTaskTimer) {
       clearInterval(this.staleTaskTimer);

--- a/src/slack/socket-runner.ts
+++ b/src/slack/socket-runner.ts
@@ -611,7 +611,13 @@ export class SlackSocketRunner implements Runner {
       return;
     }
     // Only skip our own bot messages, allow other bots to trigger Visor
-    if (this.botUserId && ev.user && String(ev.user) === String(this.botUserId)) {
+    const isSelfByUser = this.botUserId && ev.user && String(ev.user) === String(this.botUserId);
+    const isSelfByBotId =
+      !isSelfByUser &&
+      ev.bot_id &&
+      this.client?._botId &&
+      String(ev.bot_id) === String(this.client._botId);
+    if (isSelfByUser || isSelfByBotId) {
       if (process.env.VISOR_DEBUG === 'true') {
         logger.debug('[SlackSocket] Dropping self-bot message');
       }
@@ -1124,6 +1130,27 @@ export class SlackSocketRunner implements Runner {
         }
       } catch {}
 
+      // If trigger has inputs.text, use it as the message the AI sees
+      // (the original Slack message is still available in conversation context).
+      // This allows on_message triggers to give the AI specific instructions.
+      const triggerInputText = trigger.inputs?.text as string | undefined;
+      const messageForAI = triggerInputText
+        ? `${triggerInputText}\n\n---\nOriginal message:\n${conversationContext?.current?.text || String(ev.text || '')}`
+        : conversationContext?.current?.text || String(ev.text || '');
+
+      // Override conversation.current.text with the trigger's instructions
+      if (triggerInputText && conversationContext?.current) {
+        conversationContext.current.text = messageForAI;
+        // Also update the messages array if the current message is there
+        if (
+          Array.isArray(conversationContext.messages) &&
+          conversationContext.messages.length > 0
+        ) {
+          const last = conversationContext.messages[conversationContext.messages.length - 1];
+          if (last && last.ts === ts) last.text = messageForAI;
+        }
+      }
+
       // Build synthetic webhook payload
       const triggerPayload = {
         ...payload,
@@ -1142,6 +1169,16 @@ export class SlackSocketRunner implements Runner {
       if (this.taskStore) {
         webhookData.set('__taskStore', this.taskStore);
       }
+
+      // Seed the first message for human_input checks — same as normal message path.
+      // Without this, the chat workflow's human_input check blocks waiting for input
+      // and never reaches the intent router / tool-loading checks.
+      try {
+        const { getPromptStateManager } = await import('./prompt-state');
+        const mgr = getPromptStateManager();
+        const rootTs = threadTs || ts;
+        if (channel && rootTs && messageForAI) mgr.setFirstMessage(channel, rootTs, messageForAI);
+      } catch {}
 
       // Clone config for this run with Slack frontend
       const cfgForRun: VisorConfig = (() => {

--- a/src/state-machine-execution-engine.ts
+++ b/src/state-machine-execution-engine.ts
@@ -575,7 +575,7 @@ export class StateMachineExecutionEngine {
       try {
         const { SessionRegistry } = await import('./session-registry');
         const sessionRegistry = SessionRegistry.getInstance();
-        sessionRegistry.clearAllSessions();
+        await sessionRegistry.clearAllSessions();
       } catch (error) {
         logger.debug(`[StateMachine] Failed to cleanup sessions: ${error}`);
       }
@@ -1430,7 +1430,7 @@ export async function resumeFromSnapshot(
   try {
     const { SessionRegistry } = await import('./session-registry');
     const sessionRegistry = SessionRegistry.getInstance();
-    sessionRegistry.clearAllSessions();
+    await sessionRegistry.clearAllSessions();
   } catch (error) {
     logger.debug(`[StateMachine] Failed to cleanup sessions: ${error}`);
   }

--- a/src/state-machine/dispatch/debounce-manager.ts
+++ b/src/state-machine/dispatch/debounce-manager.ts
@@ -14,7 +14,7 @@ interface PendingEntry {
   timer: ReturnType<typeof setTimeout>;
   invocations: number;
   firstInvocationTime: number;
-  resolve: (value: 'executed' | 'debounced') => void;
+  resolve: (value: { outcome: 'executed'; result: unknown } | { outcome: 'debounced' }) => void;
   reject: (err: unknown) => void;
   fn: () => Promise<unknown>;
 }
@@ -26,6 +26,9 @@ interface PendingEntry {
  * window are coalesced — only the LAST invocation actually executes, after
  * the window expires with no new invocations.
  *
+ * Additionally, if the function is currently executing, new invocations are
+ * skipped (resolved as 'debounced') to prevent parallel executions.
+ *
  * Key: typically `workflow:stepId` — callers decide the grouping.
  *
  * Earlier invocations resolve with 'debounced' (skipped).
@@ -34,73 +37,91 @@ interface PendingEntry {
 export class DebounceManager {
   private pending = new Map<string, PendingEntry>();
   /** Waiters that were superseded and should resolve as 'debounced' */
-  private superseded = new Map<string, Array<(v: 'debounced') => void>>();
+  private superseded = new Map<string, Array<(v: { outcome: 'debounced' }) => void>>();
+  /** Keys currently executing — prevents parallel runs */
+  private executing = new Set<string>();
 
   /**
    * Enqueue an execution. Returns 'executed' if this invocation won the
-   * debounce race, or 'debounced' if it was superseded by a later one.
+   * debounce race, or 'debounced' if it was superseded by a later one
+   * or if the function is already executing for this key.
    */
   enqueue(
     key: string,
     debounceMs: number,
     fn: () => Promise<unknown>
-  ): Promise<'executed' | 'debounced'> {
+  ): Promise<{ outcome: 'executed'; result: unknown } | { outcome: 'debounced' }> {
+    // If already executing for this key, skip immediately
+    if (this.executing.has(key)) {
+      logger.info(`[DebounceManager] ${key}: already executing, skipping this invocation`);
+      return Promise.resolve({ outcome: 'debounced' });
+    }
+
     const actualMs = effectiveDebounceMs(debounceMs);
-    return new Promise<'executed' | 'debounced'>((resolve, reject) => {
-      const existing = this.pending.get(key);
+    return new Promise<{ outcome: 'executed'; result: unknown } | { outcome: 'debounced' }>(
+      (resolve, reject) => {
+        const existing = this.pending.get(key);
 
-      if (existing) {
-        // Supersede previous invocation — it resolves as 'debounced'
-        clearTimeout(existing.timer);
-        // Move the previous resolve to superseded list
-        if (!this.superseded.has(key)) {
-          this.superseded.set(key, []);
+        if (existing) {
+          // Supersede previous invocation — it resolves as 'debounced'
+          clearTimeout(existing.timer);
+          // Move the previous resolve to superseded list
+          if (!this.superseded.has(key)) {
+            this.superseded.set(key, []);
+          }
+          this.superseded.get(key)!.push(existing.resolve as (v: { outcome: 'debounced' }) => void);
+          existing.invocations++;
+
+          logger.info(
+            `[DebounceManager] ${key}: invocation #${existing.invocations}, resetting ${actualMs}ms timer`
+          );
+        } else {
+          logger.info(
+            `[DebounceManager] ${key}: first invocation, starting ${actualMs}ms debounce`
+          );
         }
-        this.superseded.get(key)!.push(existing.resolve as (v: 'debounced') => void);
-        existing.invocations++;
 
-        logger.info(
-          `[DebounceManager] ${key}: invocation #${existing.invocations}, resetting ${actualMs}ms timer`
-        );
-      } else {
-        logger.info(`[DebounceManager] ${key}: first invocation, starting ${actualMs}ms debounce`);
+        const invocations = existing ? existing.invocations : 1;
+        const firstTime = existing ? existing.firstInvocationTime : Date.now();
+
+        const timer = setTimeout(async () => {
+          this.pending.delete(key);
+
+          // Resolve all superseded waiters as 'debounced'
+          const waiters = this.superseded.get(key) || [];
+          this.superseded.delete(key);
+          for (const w of waiters) {
+            w({ outcome: 'debounced' });
+          }
+
+          const elapsed = Date.now() - firstTime;
+          logger.info(
+            `[DebounceManager] ${key}: executing after ${invocations} invocation(s) over ${elapsed}ms`
+          );
+
+          // Mark as executing so concurrent invocations are skipped
+          this.executing.add(key);
+          try {
+            const result = await fn();
+            resolve({ outcome: 'executed', result });
+          } catch (err) {
+            reject(err);
+          } finally {
+            this.executing.delete(key);
+            logger.info(`[DebounceManager] ${key}: execution finished`);
+          }
+        }, actualMs);
+
+        this.pending.set(key, {
+          timer,
+          invocations,
+          firstInvocationTime: firstTime,
+          resolve,
+          reject,
+          fn,
+        });
       }
-
-      const invocations = existing ? existing.invocations : 1;
-      const firstTime = existing ? existing.firstInvocationTime : Date.now();
-
-      const timer = setTimeout(async () => {
-        this.pending.delete(key);
-
-        // Resolve all superseded waiters as 'debounced'
-        const waiters = this.superseded.get(key) || [];
-        this.superseded.delete(key);
-        for (const w of waiters) {
-          w('debounced');
-        }
-
-        const elapsed = Date.now() - firstTime;
-        logger.info(
-          `[DebounceManager] ${key}: executing after ${invocations} invocation(s) over ${elapsed}ms`
-        );
-
-        try {
-          await fn();
-          resolve('executed');
-        } catch (err) {
-          reject(err);
-        }
-      }, actualMs);
-
-      this.pending.set(key, {
-        timer,
-        invocations,
-        firstInvocationTime: firstTime,
-        resolve,
-        reject,
-        fn,
-      });
-    });
+    );
   }
 
   /** Cancel a pending debounce. All waiters resolve as 'debounced'. */
@@ -109,11 +130,11 @@ export class DebounceManager {
     if (!entry) return false;
     clearTimeout(entry.timer);
     this.pending.delete(key);
-    entry.resolve('debounced');
+    entry.resolve({ outcome: 'debounced' });
     const waiters = this.superseded.get(key) || [];
     this.superseded.delete(key);
     for (const w of waiters) {
-      w('debounced');
+      w({ outcome: 'debounced' });
     }
     return true;
   }
@@ -128,6 +149,11 @@ export class DebounceManager {
   /** Number of pending debounce keys. */
   get size(): number {
     return this.pending.size;
+  }
+
+  /** Check if a key is currently executing. */
+  isExecuting(key: string): boolean {
+    return this.executing.has(key);
   }
 }
 

--- a/src/state-machine/dispatch/debounce-manager.ts
+++ b/src/state-machine/dispatch/debounce-manager.ts
@@ -1,0 +1,146 @@
+import { logger } from '../../logger';
+
+/** Resolve effective debounce time, respecting VISOR_DEBOUNCE_OVERRIDE env var for testing */
+function effectiveDebounceMs(requested: number): number {
+  const override = process.env.VISOR_DEBOUNCE_OVERRIDE;
+  if (override !== undefined) {
+    const ms = parseInt(override, 10);
+    if (!isNaN(ms) && ms >= 0) return ms;
+  }
+  return requested;
+}
+
+interface PendingEntry {
+  timer: ReturnType<typeof setTimeout>;
+  invocations: number;
+  firstInvocationTime: number;
+  resolve: (value: 'executed' | 'debounced') => void;
+  reject: (err: unknown) => void;
+  fn: () => Promise<unknown>;
+}
+
+/**
+ * Global debounce manager for step execution.
+ *
+ * When a step has `debounce: <ms>`, multiple invocations within the debounce
+ * window are coalesced — only the LAST invocation actually executes, after
+ * the window expires with no new invocations.
+ *
+ * Key: typically `workflow:stepId` — callers decide the grouping.
+ *
+ * Earlier invocations resolve with 'debounced' (skipped).
+ * The final invocation resolves with 'executed' after the real execution.
+ */
+export class DebounceManager {
+  private pending = new Map<string, PendingEntry>();
+  /** Waiters that were superseded and should resolve as 'debounced' */
+  private superseded = new Map<string, Array<(v: 'debounced') => void>>();
+
+  /**
+   * Enqueue an execution. Returns 'executed' if this invocation won the
+   * debounce race, or 'debounced' if it was superseded by a later one.
+   */
+  enqueue(
+    key: string,
+    debounceMs: number,
+    fn: () => Promise<unknown>
+  ): Promise<'executed' | 'debounced'> {
+    const actualMs = effectiveDebounceMs(debounceMs);
+    return new Promise<'executed' | 'debounced'>((resolve, reject) => {
+      const existing = this.pending.get(key);
+
+      if (existing) {
+        // Supersede previous invocation — it resolves as 'debounced'
+        clearTimeout(existing.timer);
+        // Move the previous resolve to superseded list
+        if (!this.superseded.has(key)) {
+          this.superseded.set(key, []);
+        }
+        this.superseded.get(key)!.push(existing.resolve as (v: 'debounced') => void);
+        existing.invocations++;
+
+        logger.info(
+          `[DebounceManager] ${key}: invocation #${existing.invocations}, resetting ${actualMs}ms timer`
+        );
+      } else {
+        logger.info(`[DebounceManager] ${key}: first invocation, starting ${actualMs}ms debounce`);
+      }
+
+      const invocations = existing ? existing.invocations : 1;
+      const firstTime = existing ? existing.firstInvocationTime : Date.now();
+
+      const timer = setTimeout(async () => {
+        this.pending.delete(key);
+
+        // Resolve all superseded waiters as 'debounced'
+        const waiters = this.superseded.get(key) || [];
+        this.superseded.delete(key);
+        for (const w of waiters) {
+          w('debounced');
+        }
+
+        const elapsed = Date.now() - firstTime;
+        logger.info(
+          `[DebounceManager] ${key}: executing after ${invocations} invocation(s) over ${elapsed}ms`
+        );
+
+        try {
+          await fn();
+          resolve('executed');
+        } catch (err) {
+          reject(err);
+        }
+      }, actualMs);
+
+      this.pending.set(key, {
+        timer,
+        invocations,
+        firstInvocationTime: firstTime,
+        resolve,
+        reject,
+        fn,
+      });
+    });
+  }
+
+  /** Cancel a pending debounce. All waiters resolve as 'debounced'. */
+  cancel(key: string): boolean {
+    const entry = this.pending.get(key);
+    if (!entry) return false;
+    clearTimeout(entry.timer);
+    this.pending.delete(key);
+    entry.resolve('debounced');
+    const waiters = this.superseded.get(key) || [];
+    this.superseded.delete(key);
+    for (const w of waiters) {
+      w('debounced');
+    }
+    return true;
+  }
+
+  /** Cancel all pending debounces. */
+  clear(): void {
+    for (const [key] of this.pending) {
+      this.cancel(key);
+    }
+  }
+
+  /** Number of pending debounce keys. */
+  get size(): number {
+    return this.pending.size;
+  }
+}
+
+let __instance: DebounceManager | undefined;
+
+export function getDebounceManager(): DebounceManager {
+  if (!__instance) __instance = new DebounceManager();
+  return __instance;
+}
+
+export function resetDebounceManager(): void {
+  if (__instance) {
+    __instance.clear();
+    __instance = undefined;
+  }
+}

--- a/src/state-machine/states/level-dispatch.ts
+++ b/src/state-machine/states/level-dispatch.ts
@@ -1110,7 +1110,7 @@ async function executeCheckWithForEachItems(
             // Debounce support: coalesce rapid invocations of the same step
             if (checkConfig.debounce && checkConfig.debounce > 0) {
               const debounceKey = checkConfig.debounce_key || checkId;
-              const outcome = await getDebounceManager().enqueue(
+              const debounceResult = await getDebounceManager().enqueue(
                 debounceKey,
                 checkConfig.debounce,
                 async () => {
@@ -1130,14 +1130,14 @@ async function executeCheckWithForEachItems(
                   return r;
                 }
               );
-              if (outcome === 'debounced') {
+              if (debounceResult.outcome === 'debounced') {
                 logger.info(
                   `[LevelDispatch] ${checkId}: debounced (superseded by later invocation)`
                 );
                 return { issues: [], output: { debounced: true } };
               }
-              // outcome === 'executed' — the fn above already ran
-              return { issues: [], output: { debounced: false } };
+              // outcome === 'executed' — return the actual result
+              return debounceResult.result as any;
             }
             const res = await executeWithSandboxRouting(
               checkId,
@@ -2604,7 +2604,7 @@ async function executeSingleCheck(
           // Debounce support: coalesce rapid invocations of the same step
           if (checkConfig.debounce && checkConfig.debounce > 0) {
             const debounceKey = checkConfig.debounce_key || checkId;
-            const outcome = await getDebounceManager().enqueue(
+            const debounceResult = await getDebounceManager().enqueue(
               debounceKey,
               checkConfig.debounce,
               async () => {
@@ -2624,11 +2624,12 @@ async function executeSingleCheck(
                 return r;
               }
             );
-            if (outcome === 'debounced') {
+            if (debounceResult.outcome === 'debounced') {
               logger.info(`[LevelDispatch] ${checkId}: debounced (superseded by later invocation)`);
               return { issues: [], output: { debounced: true } };
             }
-            return { issues: [], output: { debounced: false } };
+            // outcome === 'executed' — return the actual result
+            return debounceResult.result as any;
           }
           const res = await executeWithSandboxRouting(
             checkId,
@@ -2782,15 +2783,10 @@ async function executeSingleCheck(
     let isForEach = (result as any).isForEach;
     let forEachItems = (result as any).forEachItems;
 
-    // DEBUG: Log forEach handling
-    logger.info(
-      `[LevelDispatch][DEBUG] After execution ${checkId}: checkConfig.forEach=${checkConfig.forEach}, output type=${typeof (result as any).output}, isArray=${Array.isArray((result as any).output)}`
-    );
-
     if (checkConfig.forEach === true) {
       const output = (result as any).output;
-      logger.info(
-        `[LevelDispatch][DEBUG] Processing forEach=true for ${checkId}, output=${JSON.stringify(output)?.substring(0, 200)}`
+      logger.debug(
+        `[LevelDispatch] Processing forEach=true for ${checkId}, output=${JSON.stringify(output)?.substring(0, 200)}`
       );
 
       // Validate forEach output (must not be undefined)

--- a/src/state-machine/states/level-dispatch.ts
+++ b/src/state-machine/states/level-dispatch.ts
@@ -39,6 +39,7 @@ import { FailureConditionEvaluator } from '../../failure-condition-evaluator';
 import { resolveWorkflowInputs } from '../context/workflow-inputs';
 import { executeWithSandboxRouting } from '../dispatch/sandbox-routing';
 import { applyPolicyGate } from '../dispatch/policy-gate';
+import { getDebounceManager } from '../dispatch/debounce-manager';
 import { createExtendedLiquid } from '../../liquid-extensions';
 
 function isEngineerCheck(checkId: string): boolean {
@@ -1106,6 +1107,38 @@ async function executeCheckWithForEachItems(
             wave: state.wave,
           },
           async span => {
+            // Debounce support: coalesce rapid invocations of the same step
+            if (checkConfig.debounce && checkConfig.debounce > 0) {
+              const debounceKey = checkConfig.debounce_key || checkId;
+              const outcome = await getDebounceManager().enqueue(
+                debounceKey,
+                checkConfig.debounce,
+                async () => {
+                  const r = await executeWithSandboxRouting(
+                    checkId,
+                    checkConfig,
+                    context,
+                    prInfo,
+                    dependencyResults,
+                    checkConfig.timeout || checkConfig.ai?.timeout || 1800000,
+                    () =>
+                      provider.execute(prInfo, providerConfig, dependencyResults, executionContext)
+                  );
+                  try {
+                    captureCheckOutput(span, (r as any).output);
+                  } catch {}
+                  return r;
+                }
+              );
+              if (outcome === 'debounced') {
+                logger.info(
+                  `[LevelDispatch] ${checkId}: debounced (superseded by later invocation)`
+                );
+                return { issues: [], output: { debounced: true } };
+              }
+              // outcome === 'executed' — the fn above already ran
+              return { issues: [], output: { debounced: false } };
+            }
             const res = await executeWithSandboxRouting(
               checkId,
               checkConfig,
@@ -2568,6 +2601,35 @@ async function executeSingleCheck(
           wave: state.wave,
         },
         async span => {
+          // Debounce support: coalesce rapid invocations of the same step
+          if (checkConfig.debounce && checkConfig.debounce > 0) {
+            const debounceKey = checkConfig.debounce_key || checkId;
+            const outcome = await getDebounceManager().enqueue(
+              debounceKey,
+              checkConfig.debounce,
+              async () => {
+                const r = await executeWithSandboxRouting(
+                  checkId,
+                  checkConfig,
+                  context,
+                  prInfo,
+                  dependencyResults,
+                  checkConfig.timeout || checkConfig.ai?.timeout || 1800000,
+                  () =>
+                    provider.execute(prInfo, providerConfig, dependencyResults, executionContext)
+                );
+                try {
+                  captureCheckOutput(span, (r as any).output);
+                } catch {}
+                return r;
+              }
+            );
+            if (outcome === 'debounced') {
+              logger.info(`[LevelDispatch] ${checkId}: debounced (superseded by later invocation)`);
+              return { issues: [], output: { debounced: true } };
+            }
+            return { issues: [], output: { debounced: false } };
+          }
           const res = await executeWithSandboxRouting(
             checkId,
             checkConfig,

--- a/src/teams/webhook-runner.ts
+++ b/src/teams/webhook-runner.ts
@@ -11,7 +11,7 @@ import type { VisorConfig } from '../types/config';
 import { StateMachineExecutionEngine } from '../state-machine-execution-engine';
 import { TeamsClient } from './client';
 import { TeamsAdapter, type TeamsMessageInfo } from './adapter';
-import { WorkspaceManager } from '../utils/workspace-manager';
+import { startPeriodicStorageCleanup } from '../utils/worktree-cleanup';
 
 export type TeamsWebhookConfig = {
   appId?: string;
@@ -37,6 +37,7 @@ export class TeamsWebhookRunner implements Runner {
   private taskStore?: import('../agent-protocol/task-store').TaskStore;
   private configPath?: string;
   private activeRequests = 0;
+  private storageCleanupStop?: () => void;
 
   constructor(engine: StateMachineExecutionEngine, cfg: VisorConfig, opts: TeamsWebhookConfig) {
     const appId = opts.appId || process.env.TEAMS_APP_ID || '';
@@ -132,14 +133,16 @@ export class TeamsWebhookRunner implements Runner {
     return new Promise<void>(resolve => {
       this.server!.listen(this.port, this.host, () => {
         logger.info(`[TeamsWebhook] Server listening on ${this.host}:${this.port}`);
-        // Clean up stale workspace directories
-        WorkspaceManager.cleanupStale().catch(() => {});
+        this.storageCleanupStop?.();
+        this.storageCleanupStop = startPeriodicStorageCleanup('TeamsWebhook');
         resolve();
       });
     });
   }
 
   async stopListening(): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     if (this.server) {
       const srv = this.server;
       if (typeof (srv as any).closeAllConnections === 'function') {
@@ -152,6 +155,8 @@ export class TeamsWebhookRunner implements Runner {
   }
 
   async drain(timeoutMs = 0): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     if (this.server) {
       this.server.close();
       this.server = undefined;
@@ -169,6 +174,8 @@ export class TeamsWebhookRunner implements Runner {
   }
 
   async stop(): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     if (this.server) {
       return new Promise<void>(resolve => {
         this.server!.close(() => {

--- a/src/telegram/polling-runner.ts
+++ b/src/telegram/polling-runner.ts
@@ -12,7 +12,7 @@ import { TelegramClient } from './client';
 import { TelegramAdapter, type TelegramMessageInfo } from './adapter';
 import { createHash } from 'crypto';
 import { run, type RunnerHandle } from '@grammyjs/runner';
-import { WorkspaceManager } from '../utils/workspace-manager';
+import { startPeriodicStorageCleanup } from '../utils/worktree-cleanup';
 
 export type TelegramPollingConfig = {
   botToken?: string;
@@ -35,6 +35,7 @@ export class TelegramPollingRunner implements Runner {
   private activeChats = new Set<string>();
   private taskStore?: import('../agent-protocol/task-store').TaskStore;
   private configPath?: string;
+  private storageCleanupStop?: () => void;
 
   constructor(engine: StateMachineExecutionEngine, cfg: VisorConfig, opts: TelegramPollingConfig) {
     const token = opts.botToken || process.env.TELEGRAM_BOT_TOKEN || '';
@@ -121,11 +122,13 @@ export class TelegramPollingRunner implements Runner {
     this.runnerHandle = run(bot);
     logger.info('[TelegramPolling] Polling started');
 
-    // Clean up stale workspace directories
-    WorkspaceManager.cleanupStale().catch(() => {});
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = startPeriodicStorageCleanup('TelegramPolling');
   }
 
   async stopListening(): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     if (this.runnerHandle) {
       this.runnerHandle.stop();
       logger.info('[TelegramPolling] Polling stopped');
@@ -133,6 +136,8 @@ export class TelegramPollingRunner implements Runner {
   }
 
   async drain(timeoutMs = 0): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     if (this.runnerHandle) {
       this.runnerHandle.stop();
     }
@@ -148,6 +153,8 @@ export class TelegramPollingRunner implements Runner {
   }
 
   async stop(): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     if (this.runnerHandle) {
       this.runnerHandle.stop();
       logger.info('[TelegramPolling] Polling stopped');

--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -425,7 +425,7 @@ export class VisorTestRunner {
     } catch {}
     // Always clear AI sessions between cases to prevent cross-case leakage
     try {
-      SessionRegistry.getInstance().clearAllSessions();
+      void SessionRegistry.getInstance().clearAllSessions();
     } catch {}
     // Always use StateMachineExecutionEngine
     const engine = new StateMachineExecutionEngine(undefined as any, recorder as unknown as any);
@@ -1662,7 +1662,7 @@ export class VisorTestRunner {
         } catch {}
         // Clear AI sessions before each stage to avoid leakage across stages
         try {
-          SessionRegistry.getInstance().clearAllSessions();
+          await SessionRegistry.getInstance().clearAllSessions();
         } catch {}
         // Prepare default tag filters for this flow (inherit suite defaults)
         const parseTags = (v: unknown): string[] | undefined => {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1424,8 +1424,8 @@ export interface SlackMessageTrigger {
 export interface StaticCronJob {
   /** Cron expression (e.g., "0 9 * * 1" for every Monday at 9am) */
   schedule: string;
-  /** Workflow/check ID to run */
-  workflow: string;
+  /** Workflow/check ID to run. Omit to treat inputs.text as a user message through the full pipeline. */
+  workflow?: string;
   /** Optional workflow inputs */
   inputs?: Record<string, unknown>;
   /** Output destination configuration */

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -654,6 +654,18 @@ export interface CheckConfig {
   /** Tags for categorizing and filtering checks (e.g., ["local", "fast", "security"]) */
   tags?: string[];
   /**
+   * Debounce window in milliseconds. When set, multiple invocations of this
+   * step (across concurrent engine instances) within the window are coalesced
+   * — only the last invocation actually executes after the window expires.
+   * Useful for steps that should run once after a burst of triggers settles.
+   *
+   * The debounce key defaults to the step's fully-qualified check ID.
+   * Use `debounce_key` to group different steps under the same debounce.
+   */
+  debounce?: number;
+  /** Custom debounce key. Steps sharing the same key share the same debounce window. */
+  debounce_key?: string;
+  /**
    * Operational criticality of this step. Drives default safety policies
    * (contracts, retries, loop budgets) at load time. Behavior can still be
    * overridden explicitly per step via on_*, fail_if, assume/guarantee, etc.

--- a/src/utils/child-process-error-handler.ts
+++ b/src/utils/child-process-error-handler.ts
@@ -1,0 +1,53 @@
+/**
+ * Global handler for transient child-process I/O errors.
+ *
+ * When a child process (MCP server, probe agent, sandbox command, etc.) dies
+ * unexpectedly, its stdio streams may emit `read EIO`, `write EPIPE`, or
+ * similar errors.  If no listener is attached to the stream's `error` event
+ * the error bubbles up as an uncaught exception and crashes the entire visor
+ * process.
+ *
+ * Importing this module installs a single, idempotent `uncaughtException`
+ * handler that recognises these transient I/O errors, logs a warning, and
+ * swallows them so the rest of the process can continue.
+ *
+ * Usage: import once, as early as possible in every entry point.
+ *
+ *   import './utils/child-process-error-handler';
+ */
+
+import { logger } from '../logger';
+
+const TRANSIENT_IO_CODES = new Set(['EIO', 'EPIPE', 'ECONNRESET']);
+
+export function isChildProcessIOError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const errno = (error as NodeJS.ErrnoException).code;
+  if (errno && TRANSIENT_IO_CODES.has(errno)) return true;
+  const msg = error.message;
+  if (msg.includes('read EIO') || msg.includes('write EPIPE')) return true;
+  if (msg.includes('ERR_STREAM_DESTROYED')) return true;
+  return false;
+}
+
+// Guard: register at most once per process, even if the module is loaded
+// multiple times (ESM + CJS dual-instance, or re-imported).
+const GUARD = Symbol.for('visor.childProcessErrorHandler');
+if (!(globalThis as any)[GUARD]) {
+  (globalThis as any)[GUARD] = true;
+
+  process.on('uncaughtException', (error: Error, origin: string) => {
+    if (isChildProcessIOError(error)) {
+      // Log but do NOT crash.  The broken pipe is from a child process that
+      // already exited; crashing here would be collateral damage.
+      logger.warn(
+        `[child-process-error-handler] Suppressed transient I/O error (${origin}): ${error.message}`
+      );
+      return;
+    }
+    // Not our error — let other handlers (or the default behaviour) deal with it.
+    // Note: Node.js invokes all registered handlers; if none of them call
+    // process.exit() the process will continue.  The worktree-manager handler
+    // already calls process.exit(1) for non-IO errors.
+  });
+}

--- a/src/utils/config-loader.ts
+++ b/src/utils/config-loader.ts
@@ -325,35 +325,10 @@ export class ConfigLoader {
     if (defaultConfigPath) {
       // Always log to stderr to avoid contaminating formatted output
       console.error(`📦 Loading bundled default configuration from ${defaultConfigPath}`);
-      const content = fs.readFileSync(defaultConfigPath, 'utf8');
-      let config = yaml.load(content) as Partial<VisorConfig>;
-
-      if (!config || typeof config !== 'object') {
-        throw new Error('Invalid default configuration');
-      }
-
-      // Alias: support 'include' as 'extends' in packaged defaults
-      if ((config as any).include && !(config as any).extends) {
-        const inc = (config as any).include;
-        (config as any).extends = Array.isArray(inc) ? inc : [inc];
-        delete (config as any).include;
-      }
-
+      const defaultConfigDir = path.dirname(defaultConfigPath);
+      let config = await this.fetchBundledConfigFile(defaultConfigPath, defaultConfigDir);
       // Normalize 'checks' and 'steps' for backward compatibility
       config = this.normalizeStepsAndChecks(config);
-
-      // Default configs shouldn't have extends, but handle it just in case
-      if (config.extends) {
-        // Ensure relative paths (e.g., ./code-review.yaml) resolve from the defaults directory
-        const previousBaseDir = this.options.baseDir;
-        try {
-          this.options.baseDir = path.dirname(defaultConfigPath);
-          return await this.processExtends(config);
-        } finally {
-          this.options.baseDir = previousBaseDir;
-        }
-      }
-
       return config;
     }
 
@@ -370,6 +345,90 @@ export class ConfigLoader {
         },
       },
     };
+  }
+
+  /**
+   * Load a bundled config and its includes without using project-local path resolution.
+   *
+   * `extends: default` is a built-in source. Its sibling includes are part of the Visor
+   * package/action bundle, so they must resolve inside that bundle rather than inside the
+   * caller's repository root.
+   */
+  private async fetchBundledConfigFile(
+    filePath: string,
+    bundledRoot: string,
+    currentDepth: number = 0,
+    seen: Set<string> = new Set()
+  ): Promise<Partial<VisorConfig>> {
+    if (currentDepth >= (this.options.maxDepth || 10)) {
+      throw new Error(
+        `Maximum bundled default include depth (${this.options.maxDepth}) exceeded. Check for circular dependencies.`
+      );
+    }
+
+    const resolvedPath = path.resolve(filePath);
+    this.validateBundledPath(resolvedPath, bundledRoot);
+
+    if (seen.has(resolvedPath)) {
+      throw new Error(`Circular dependency detected in bundled defaults: ${resolvedPath}`);
+    }
+
+    seen.add(resolvedPath);
+
+    try {
+      const content = fs.readFileSync(resolvedPath, 'utf8');
+      const config = yaml.load(content) as Partial<VisorConfig>;
+
+      if (!config || typeof config !== 'object') {
+        throw new Error(`Invalid default configuration: ${resolvedPath}`);
+      }
+
+      const extendsValue = (config as any).extends || (config as any).include;
+      delete (config as any).extends;
+      delete (config as any).include;
+
+      this.annotateToolsBaseDir(config, path.dirname(resolvedPath));
+
+      if (!extendsValue) {
+        return config;
+      }
+
+      const { ConfigMerger } = await import('./config-merger');
+      const merger = new ConfigMerger();
+      const sources = Array.isArray(extendsValue) ? extendsValue : [extendsValue];
+      let mergedParents: Partial<VisorConfig> = {};
+
+      for (const source of sources) {
+        if (typeof source !== 'string' || this.getSourceType(source) !== ConfigSourceType.LOCAL) {
+          throw new Error(
+            `Bundled default configuration can only include local bundled files: ${String(source)}`
+          );
+        }
+
+        const parentPath = path.isAbsolute(source)
+          ? source
+          : path.resolve(path.dirname(resolvedPath), source);
+        const parentConfig = await this.fetchBundledConfigFile(
+          parentPath,
+          bundledRoot,
+          currentDepth + 1,
+          seen
+        );
+        mergedParents = merger.merge(mergedParents, parentConfig);
+      }
+
+      return merger.merge(mergedParents, config);
+    } catch (error: any) {
+      if (error && (error.code === 'ENOENT' || error.code === 'ENOTDIR')) {
+        throw new Error(`Bundled default configuration file not found: ${resolvedPath}`);
+      }
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw error;
+    } finally {
+      seen.delete(resolvedPath);
+    }
   }
 
   /**
@@ -489,6 +548,31 @@ export class ConfigLoader {
       if (lowerPath.includes(pattern)) {
         throw new Error(`Security error: Cannot access potentially sensitive file: ${pattern}`);
       }
+    }
+  }
+
+  /**
+   * Validate that bundled default includes stay inside the Visor package/action bundle.
+   */
+  private validateBundledPath(resolvedPath: string, bundledRoot: string): void {
+    const canonicalize = (p: string): string => {
+      const resolved = path.resolve(p);
+      try {
+        return path.normalize(fs.realpathSync.native(resolved));
+      } catch {
+        return path.normalize(resolved);
+      }
+    };
+    const normalizedPath = canonicalize(resolvedPath);
+    const normalizedRoot = canonicalize(bundledRoot);
+
+    if (
+      normalizedPath !== normalizedRoot &&
+      !normalizedPath.startsWith(`${normalizedRoot}${path.sep}`)
+    ) {
+      throw new Error(
+        `Security error: Bundled default include resolves outside bundled defaults directory: ${bundledRoot}`
+      );
     }
   }
 

--- a/src/utils/user-facing-error.ts
+++ b/src/utils/user-facing-error.ts
@@ -1,0 +1,111 @@
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function stripWrapperPrefixes(text: string): string {
+  let cleaned = text.trim();
+  const wrapperPatterns = [
+    /^AI analysis failed:\s*/i,
+    /^Claude Code analysis failed:\s*/i,
+    /^ProbeAgent execution failed:\s*/i,
+    /^Workflow step '[^']+' failed:\s*/i,
+    /^Error:\s*/i,
+  ];
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const pattern of wrapperPatterns) {
+      const next = cleaned.replace(pattern, '');
+      if (next !== cleaned) {
+        cleaned = next.trim();
+        changed = true;
+      }
+    }
+  }
+
+  return cleaned;
+}
+
+function collectErrorStrings(
+  value: unknown,
+  seen = new WeakSet<object>(),
+  depth = 0,
+  out: string[] = []
+): string[] {
+  if (value == null || depth > 3) return out;
+
+  if (typeof value === 'string') {
+    if (value.trim()) out.push(value.trim());
+    return out;
+  }
+
+  if (typeof value !== 'object') {
+    out.push(String(value));
+    return out;
+  }
+
+  if (seen.has(value)) return out;
+  seen.add(value);
+
+  const obj = value as Record<string, unknown>;
+  const candidateKeys = ['message', 'responseBody', 'error', 'details', 'body', 'cause'];
+
+  for (const key of candidateKeys) {
+    if (key in obj) collectErrorStrings(obj[key], seen, depth + 1, out);
+  }
+
+  return out;
+}
+
+function matchUserFacingErrorMessage(raw: string): string | null {
+  if (/no api key provided and neither claude nor codex command found/i.test(raw)) {
+    return 'No API key provided and neither claude nor codex command found.';
+  }
+
+  if (/budget limit exceeded|budget exceeded/i.test(raw)) {
+    return 'The AI provider budget limit was exceeded before a response could be generated. Please retry later or switch model/provider.';
+  }
+
+  if (/rate limit/i.test(raw)) {
+    return 'The AI provider rate limit was reached before a response could be generated. Please retry shortly.';
+  }
+
+  if (/401|authentication|api key|invalid api key|unauthorized/i.test(raw)) {
+    return 'The AI provider request was rejected before a response could be generated. Please check credentials and provider access.';
+  }
+
+  if (/403|forbidden/i.test(raw)) {
+    return 'The AI provider rejected the request before a response could be generated. This is usually caused by budget limits, access policy, or model permissions.';
+  }
+
+  if (
+    /^request timed out$/i.test(raw) ||
+    (/timed out|timeout/i.test(raw) &&
+      /(failed to get response from ai model|ai request|probeagent|provider|model|streamtext)/i.test(
+        raw
+      ))
+  ) {
+    return 'The AI request timed out before a response could be generated. Please retry.';
+  }
+
+  if (/no output generated|failed to get response from ai model/i.test(raw)) {
+    return 'The AI provider failed before generating any response. This is usually caused by a provider-side limit, rate limit, or outage. Please retry.';
+  }
+
+  return null;
+}
+
+export function formatUserFacingExecutionError(error: unknown): string {
+  const collected = collectErrorStrings(error);
+  const raw = normalizeWhitespace(collected.join(' | ') || String(error ?? 'Unknown error'));
+  const matched = matchUserFacingErrorMessage(raw);
+  if (matched) return matched;
+
+  const cleaned = normalizeWhitespace(stripWrapperPrefixes(raw));
+  return cleaned || 'The request failed before a response could be generated. Please retry.';
+}
+
+export function formatUserFacingExecutionMessage(message: string): string {
+  return formatUserFacingExecutionError(message);
+}

--- a/src/utils/user-facing-error.ts
+++ b/src/utils/user-facing-error.ts
@@ -67,6 +67,14 @@ function matchUserFacingErrorMessage(raw: string): string | null {
     return 'The AI provider budget limit was exceeded before a response could be generated. Please retry later or switch model/provider.';
   }
 
+  if (
+    /currently experiencing high demand|status.?unavailable|spikes in demand are usually temporary/i.test(
+      raw
+    )
+  ) {
+    return 'The AI provider is currently experiencing high demand and did not generate a response. Please retry shortly.';
+  }
+
   if (/rate limit/i.test(raw)) {
     return 'The AI provider rate limit was reached before a response could be generated. Please retry shortly.';
   }
@@ -108,4 +116,63 @@ export function formatUserFacingExecutionError(error: unknown): string {
 
 export function formatUserFacingExecutionMessage(message: string): string {
   return formatUserFacingExecutionError(message);
+}
+
+type IssueLike = {
+  ruleId?: string;
+  message?: string;
+  severity?: string;
+};
+
+function issuePriority(issue: IssueLike): number {
+  const ruleId = String(issue.ruleId || '');
+  const message = String(issue.message || '');
+
+  if (ruleId.startsWith('system/') || ruleId.endsWith('/error')) return 0;
+  if (ruleId.includes('timeout') || /timed out|timeout/i.test(message)) return 1;
+  if (
+    ruleId.includes('contract/guarantee_failed') &&
+    /output\??\.\s*text|\btext\b.*length\s*>\s*0|\btext\b.*trim/i.test(message)
+  ) {
+    return 2;
+  }
+  return 3;
+}
+
+function formatGuaranteeFailureMessage(issue: IssueLike): string | null {
+  const ruleId = String(issue.ruleId || '');
+  const message = String(issue.message || '');
+  if (!ruleId.includes('contract/guarantee_failed')) return null;
+  if (/output\??\.\s*text|\btext\b.*length\s*>\s*0|\btext\b.*trim/i.test(message)) {
+    return 'The assistant failed to produce a response. This is usually caused by a provider-side limit, outage, or invalid structured output. Please retry.';
+  }
+  return null;
+}
+
+export function summarizeUserFacingIssues(issues: unknown): string | null {
+  if (!Array.isArray(issues) || issues.length === 0) return null;
+
+  const candidates = issues.filter(
+    (issue): issue is IssueLike =>
+      !!issue &&
+      typeof issue === 'object' &&
+      String((issue as IssueLike).severity || '').toLowerCase() === 'error'
+  );
+  if (candidates.length === 0) return null;
+
+  const prioritized = [...candidates].sort((a, b) => issuePriority(a) - issuePriority(b));
+  const seen = new Set<string>();
+  const messages: string[] = [];
+
+  for (const issue of prioritized) {
+    const formatted =
+      formatGuaranteeFailureMessage(issue) ||
+      formatUserFacingExecutionMessage(String(issue.message || 'Execution error'));
+    if (!formatted || seen.has(formatted)) continue;
+    seen.add(formatted);
+    messages.push(formatted);
+    if (messages.length >= 2) break;
+  }
+
+  return messages.length > 0 ? messages.join('\n') : null;
 }

--- a/src/utils/workspace-manager.ts
+++ b/src/utils/workspace-manager.ts
@@ -5,6 +5,7 @@
  * Each run gets its own workspace in /tmp containing worktrees for all projects.
  */
 
+import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { commandExecutor } from './command-executor';
@@ -318,16 +319,10 @@ export class WorkspaceManager {
       }
     }
 
-    // Scan existing entries in the workspace directory to populate usedNames.
-    // This handles reused workspaces (e.g. Slack threads) where a previous run
-    // left symlinks on disk but the in-memory state was cleared by cleanup().
+    // Rehydrate existing entries in persisted workspaces (e.g. Slack threads)
+    // so repeated runs update the same symlink names instead of growing suffixes.
     try {
-      const entries = await fsp.readdir(this.workspacePath, { withFileTypes: true });
-      for (const entry of entries) {
-        if (entry.name !== mainProjectName) {
-          this.usedNames.add(entry.name);
-        }
-      }
+      await this.loadExistingProjects(mainProjectName);
     } catch {
       // Best-effort — workspace just created, nothing to scan
     }
@@ -523,6 +518,51 @@ export class WorkspaceManager {
       return true;
     } catch {
       return false;
+    }
+  }
+
+  /**
+   * Rehydrate existing symlinked projects in a persisted workspace so future
+   * runs update them in place instead of allocating project-2, project-3, etc.
+   */
+  private async loadExistingProjects(mainProjectName: string): Promise<void> {
+    const entries = await fsp.readdir(this.workspacePath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === mainProjectName) {
+        continue;
+      }
+
+      const entryPath = path.join(this.workspacePath, entry.name);
+      this.usedNames.add(entry.name);
+
+      if (!entry.isSymbolicLink()) {
+        continue;
+      }
+
+      try {
+        const targetPath = await fsp.realpath(entryPath);
+        const metadataPath = `${targetPath.replace(/\/?$/, '')}.metadata.json`;
+        if (!fs.existsSync(metadataPath)) {
+          continue;
+        }
+
+        const metadata = JSON.parse(await fsp.readFile(metadataPath, 'utf8')) as {
+          repository?: string;
+          worktree_path?: string;
+        };
+        if (!metadata.repository) {
+          continue;
+        }
+
+        this.projects.set(entry.name, {
+          name: entry.name,
+          path: entryPath,
+          worktreePath: metadata.worktree_path || targetPath,
+          repository: metadata.repository,
+        });
+      } catch {
+        // Best-effort — leave unknown entries untouched.
+      }
     }
   }
 

--- a/src/utils/worktree-cleanup.ts
+++ b/src/utils/worktree-cleanup.ts
@@ -6,6 +6,12 @@
 
 import { worktreeManager, WorktreeManager } from './worktree-manager';
 import { logger } from '../logger';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+
+const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+const DEFAULT_PRESERVE_REPOSITORIES = ['probelabs/visor', 'probelabs/probe'];
 
 /**
  * Cleanup worktrees for a specific workflow
@@ -43,7 +49,7 @@ export async function cleanupCurrentProcessWorktrees(): Promise<void> {
  */
 export async function cleanupStaleWorktrees(): Promise<void> {
   logger.info('Cleaning up stale worktrees');
-  await worktreeManager.cleanupStaleWorktrees();
+  await cleanupStaleWorktreesPreservingRecentWorkspaces();
 }
 
 /**
@@ -137,4 +143,278 @@ export function initializeCleanupHandlers(): void {
   // The worktree manager already registers cleanup handlers in its constructor
   // This function is kept for explicit initialization if needed
   WorktreeManager.getInstance();
+}
+
+function isPathWithin(parentPath: string, targetPath: string): boolean {
+  const relative = path.relative(parentPath, targetPath);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+async function inspectWorkspaceEntry(
+  entryPath: string,
+  managedWorktreesDir: string,
+  managedReposDir: string,
+  preserveRepositories: Set<string>,
+  preservePathPrefixes: string[]
+): Promise<{ protectWorkspace: boolean; protectedWorktreePath?: string }> {
+  try {
+    const stat = await fsp.lstat(entryPath);
+
+    if (stat.isSymbolicLink()) {
+      const targetPath = await fsp.realpath(entryPath);
+      const metadataPath = `${targetPath.replace(/\/?$/, '')}.metadata.json`;
+      let repository: string | undefined;
+
+      try {
+        const metadata = JSON.parse(await fsp.readFile(metadataPath, 'utf8')) as {
+          repository?: string;
+        };
+        repository = metadata.repository;
+      } catch {
+        // Best-effort: metadata may not exist for non-managed symlinks.
+      }
+
+      return {
+        protectWorkspace:
+          preserveRepositories.has(repository || '') ||
+          preservePathPrefixes.some(prefix => isPathWithin(prefix, targetPath)),
+        protectedWorktreePath: targetPath,
+      };
+    }
+
+    if (stat.isDirectory()) {
+      const gitFilePath = path.join(entryPath, '.git');
+      const gitContent = await fsp.readFile(gitFilePath, 'utf8').catch(() => null);
+      if (!gitContent) {
+        return { protectWorkspace: false };
+      }
+
+      const match = gitContent.match(/gitdir:\s*(.+)/);
+      if (!match) {
+        return { protectWorkspace: false };
+      }
+
+      const gitDir = match[1].trim();
+      const resolvedGitDir = path.resolve(entryPath, gitDir);
+      const repoGitDir = resolvedGitDir.replace(/\/worktrees\/.*$/, '');
+      return {
+        protectWorkspace: preservePathPrefixes.some(prefix => isPathWithin(prefix, repoGitDir)),
+      };
+    }
+  } catch {
+    // Best-effort: broken workspace entries should not block cleanup.
+  }
+
+  return { protectWorkspace: false };
+}
+
+async function collectWorkspaceProtection(
+  workspaceBasePath: string,
+  maxAgeMs: number,
+  preserveRepositories: Set<string>,
+  preservePathPrefixes: string[]
+): Promise<{ protectedWorkspacePaths: Set<string>; protectedWorktreePaths: Set<string> }> {
+  const managedBasePath = worktreeManager.getConfig().base_path;
+  const managedWorktreesDir = path.join(managedBasePath, 'worktrees');
+  const managedReposDir = path.join(managedBasePath, 'repos');
+  const protectedWorkspacePaths = new Set<string>();
+  const protectedPaths = new Set<string>();
+
+  try {
+    const entries = await fsp.readdir(workspaceBasePath, { withFileTypes: true });
+    const now = Date.now();
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const workspacePath = path.join(workspaceBasePath, entry.name);
+      const stat = await fsp.stat(workspacePath);
+      const children = await fsp.readdir(workspacePath, { withFileTypes: true });
+      const isRecent = now - stat.mtimeMs <= maxAgeMs;
+      let protectWorkspace = isRecent;
+
+      for (const child of children) {
+        const childPath = path.join(workspacePath, child.name);
+        const result = await inspectWorkspaceEntry(
+          childPath,
+          managedWorktreesDir,
+          managedReposDir,
+          preserveRepositories,
+          preservePathPrefixes
+        );
+
+        if (result.protectWorkspace) {
+          protectWorkspace = true;
+        }
+        if (result.protectedWorktreePath) {
+          protectedPaths.add(result.protectedWorktreePath);
+        }
+      }
+
+      if (protectWorkspace) {
+        protectedWorkspacePaths.add(workspacePath);
+      }
+    }
+  } catch {
+    // Best-effort — no workspace protection available
+  }
+
+  return {
+    protectedWorkspacePaths,
+    protectedWorktreePaths: protectedPaths,
+  };
+}
+
+export async function cleanupStaleWorkspaceDirectories(options?: {
+  workspaceBasePath?: string;
+  maxAgeMs?: number;
+  preserveRepositories?: string[];
+  preservePathPrefixes?: string[];
+}): Promise<number> {
+  const workspaceBasePath =
+    options?.workspaceBasePath || process.env.VISOR_WORKSPACE_PATH || '/tmp/visor-workspaces';
+  const maxAgeMs = options?.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const preserveRepositories = new Set(
+    options?.preserveRepositories || DEFAULT_PRESERVE_REPOSITORIES
+  );
+  const preservePathPrefixes = options?.preservePathPrefixes || [];
+  const { protectedWorkspacePaths } = await collectWorkspaceProtection(
+    workspaceBasePath,
+    maxAgeMs,
+    preserveRepositories,
+    preservePathPrefixes
+  );
+
+  let cleaned = 0;
+  try {
+    const entries = await fsp.readdir(workspaceBasePath, { withFileTypes: true });
+    const now = Date.now();
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const dirPath = path.join(workspaceBasePath, entry.name);
+      const stat = await fsp.stat(dirPath);
+      if (now - stat.mtimeMs <= maxAgeMs) {
+        continue;
+      }
+      if (protectedWorkspacePaths.has(dirPath)) {
+        continue;
+      }
+
+      await fsp.rm(dirPath, { recursive: true, force: true });
+      cleaned++;
+    }
+  } catch (error) {
+    logger.debug(`[Workspace] Stale cleanup error: ${error}`);
+  }
+
+  if (cleaned > 0) {
+    logger.info(`[Workspace] Cleaned up ${cleaned} stale workspace(s) from ${workspaceBasePath}`);
+  }
+
+  return cleaned;
+}
+
+export async function cleanupStaleWorktreesPreservingRecentWorkspaces(options?: {
+  workspaceBasePath?: string;
+  maxAgeMs?: number;
+  preserveRepositories?: string[];
+  preservePathPrefixes?: string[];
+}): Promise<number> {
+  const workspaceBasePath =
+    options?.workspaceBasePath || process.env.VISOR_WORKSPACE_PATH || '/tmp/visor-workspaces';
+  const maxAgeMs = options?.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const preserveRepositories = new Set(
+    options?.preserveRepositories || DEFAULT_PRESERVE_REPOSITORIES
+  );
+  const preservePathPrefixes = options?.preservePathPrefixes || [];
+  const { protectedWorktreePaths } = await collectWorkspaceProtection(
+    workspaceBasePath,
+    maxAgeMs,
+    preserveRepositories,
+    preservePathPrefixes
+  );
+  const worktrees = await worktreeManager.listWorktrees();
+  const now = Date.now();
+  let cleaned = 0;
+
+  for (const worktree of worktrees) {
+    const createdAt = new Date(worktree.metadata.created_at).getTime();
+    if (!Number.isFinite(createdAt) || now - createdAt <= maxAgeMs) {
+      continue;
+    }
+    if (protectedWorktreePaths.has(worktree.path)) {
+      continue;
+    }
+    if (preserveRepositories.has(worktree.metadata.repository)) {
+      continue;
+    }
+
+    try {
+      await worktreeManager.removeWorktree(worktree.id);
+      cleaned++;
+    } catch (error) {
+      logger.error(`Failed to remove stale worktree ${worktree.id}: ${error}`);
+    }
+  }
+
+  if (cleaned > 0) {
+    logger.info(`Cleaned up ${cleaned} stale worktree(s)`);
+  }
+  return cleaned;
+}
+
+export async function runPeriodicStorageCleanup(options?: {
+  workspaceBasePath?: string;
+  workspaceMaxAgeMs?: number;
+  preserveRepositories?: string[];
+  preservePathPrefixes?: string[];
+}): Promise<{ workspaces: number; worktrees: number }> {
+  const workspaceBasePath =
+    options?.workspaceBasePath || process.env.VISOR_WORKSPACE_PATH || '/tmp/visor-workspaces';
+  const workspaceMaxAgeMs = options?.workspaceMaxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const workspaces = await cleanupStaleWorkspaceDirectories({
+    workspaceBasePath,
+    maxAgeMs: workspaceMaxAgeMs,
+    preserveRepositories: options?.preserveRepositories,
+    preservePathPrefixes: options?.preservePathPrefixes,
+  });
+  const worktrees = await cleanupStaleWorktreesPreservingRecentWorkspaces({
+    workspaceBasePath,
+    maxAgeMs: workspaceMaxAgeMs,
+    preserveRepositories: options?.preserveRepositories,
+    preservePathPrefixes: options?.preservePathPrefixes,
+  });
+  return { workspaces, worktrees };
+}
+
+export function startPeriodicStorageCleanup(
+  label: string,
+  options?: {
+    intervalMs?: number;
+    workspaceBasePath?: string;
+    workspaceMaxAgeMs?: number;
+    preserveRepositories?: string[];
+    preservePathPrefixes?: string[];
+  }
+): () => void {
+  const intervalMs = options?.intervalMs ?? DEFAULT_CLEANUP_INTERVAL_MS;
+  const run = async () => {
+    try {
+      const result = await runPeriodicStorageCleanup(options);
+      if (result.workspaces > 0 || result.worktrees > 0) {
+        logger.info(
+          `[${label}] periodic cleanup removed ${result.workspaces} workspace(s) and ${result.worktrees} worktree(s)`
+        );
+      }
+    } catch (error) {
+      logger.warn(`[${label}] periodic cleanup failed: ${error}`);
+    }
+  };
+
+  run().catch(() => {});
+  const timer = setInterval(() => {
+    run().catch(() => {});
+  }, intervalMs);
+  timer.unref?.();
+
+  return () => clearInterval(timer);
 }

--- a/src/utils/worktree-manager.ts
+++ b/src/utils/worktree-manager.ts
@@ -828,10 +828,14 @@ export class WorktreeManager {
    * Remove a worktree
    */
   async removeWorktree(worktreeId: string): Promise<void> {
-    const metadata = this.activeWorktrees.get(worktreeId);
+    let metadata = this.activeWorktrees.get(worktreeId);
+    if (!metadata) {
+      const worktreePath = path.join(this.getWorktreesDir(), worktreeId);
+      metadata = (await this.loadMetadata(worktreePath)) || undefined;
+    }
 
     if (!metadata) {
-      logger.warn(`Worktree not found in active list: ${worktreeId}`);
+      logger.warn(`Worktree metadata not found: ${worktreeId}`);
       return;
     }
 

--- a/src/utils/worktree-manager.ts
+++ b/src/utils/worktree-manager.ts
@@ -10,6 +10,7 @@ import * as fsp from 'fs/promises';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import { commandExecutor } from './command-executor';
+import { isChildProcessIOError } from './child-process-error-handler';
 import { logger } from '../logger';
 import type {
   WorktreeMetadata,
@@ -1041,6 +1042,12 @@ export class WorktreeManager {
 
       // Cleanup on uncaught exception
       process.on('uncaughtException', async error => {
+        // EIO errors from child process stdio streams (e.g. MCP servers dying)
+        // are transient and should not crash the entire process.
+        if (isChildProcessIOError(error)) {
+          logger.warn(`Ignoring transient child-process I/O error: ${error.message}`);
+          return;
+        }
         logger.error(`Uncaught exception, cleaning up worktrees: ${error}`);
         await this.cleanupProcessWorktrees();
         process.exit(1);

--- a/src/whatsapp/webhook-runner.ts
+++ b/src/whatsapp/webhook-runner.ts
@@ -10,7 +10,7 @@ import type { VisorConfig } from '../types/config';
 import { StateMachineExecutionEngine } from '../state-machine-execution-engine';
 import { WhatsAppClient } from './client';
 import { WhatsAppAdapter, type WhatsAppMessageInfo } from './adapter';
-import { WorkspaceManager } from '../utils/workspace-manager';
+import { startPeriodicStorageCleanup } from '../utils/worktree-cleanup';
 
 export type WhatsAppWebhookConfig = {
   accessToken?: string;
@@ -38,6 +38,7 @@ export class WhatsAppWebhookRunner implements Runner {
   private taskStore?: import('../agent-protocol/task-store').TaskStore;
   private configPath?: string;
   private activeRequests = 0;
+  private storageCleanupStop?: () => void;
 
   constructor(engine: StateMachineExecutionEngine, cfg: VisorConfig, opts: WhatsAppWebhookConfig) {
     const token = opts.accessToken || process.env.WHATSAPP_ACCESS_TOKEN || '';
@@ -123,14 +124,16 @@ export class WhatsAppWebhookRunner implements Runner {
     return new Promise<void>(resolve => {
       this.server!.listen(this.port, this.host, () => {
         logger.info(`[WhatsAppWebhook] Server listening on ${this.host}:${this.port}`);
-        // Clean up stale workspace directories
-        WorkspaceManager.cleanupStale().catch(() => {});
+        this.storageCleanupStop?.();
+        this.storageCleanupStop = startPeriodicStorageCleanup('WhatsAppWebhook');
         resolve();
       });
     });
   }
 
   async stopListening(): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     if (this.server) {
       const srv = this.server;
       if (typeof (srv as any).closeAllConnections === 'function') {
@@ -143,6 +146,8 @@ export class WhatsAppWebhookRunner implements Runner {
   }
 
   async drain(timeoutMs = 0): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     if (this.server) {
       this.server.close();
       this.server = undefined;
@@ -162,6 +167,8 @@ export class WhatsAppWebhookRunner implements Runner {
   }
 
   async stop(): Promise<void> {
+    this.storageCleanupStop?.();
+    this.storageCleanupStop = undefined;
     if (this.server) {
       return new Promise<void>(resolve => {
         this.server!.close(() => {

--- a/src/workflow-executor.ts
+++ b/src/workflow-executor.ts
@@ -109,7 +109,7 @@ export class WorkflowExecutor {
         if (step.if) {
           const shouldRun = this.evaluateCondition(step.if, {
             inputs: executionContext.inputs,
-            outputs: Object.fromEntries(stepResults),
+            outputs: this.unwrapOutputs(stepResults),
             pr: runOptions.prInfo,
           });
 
@@ -324,18 +324,14 @@ export class WorkflowExecutor {
             throw new Error('Expression mapping requires expression field');
           }
           const sandbox = createSecureSandbox();
+          const unwrappedExpr = this.unwrapOutputs(stepResults);
           return compileAndRun(
             sandbox,
             typedMapping.expression,
             {
               inputs: executionContext.inputs,
-              outputs: Object.fromEntries(stepResults),
-              steps: Object.fromEntries(
-                Array.from(stepResults.entries()).map(([id, result]) => [
-                  id,
-                  (result as any).output,
-                ])
-              ),
+              outputs: unwrappedExpr,
+              steps: unwrappedExpr,
             },
             { injectLog: true, logPrefix: 'workflow.input.expression' }
           );
@@ -351,7 +347,7 @@ export class WorkflowExecutor {
       if (typedMapping.template) {
         return await this.liquid.parseAndRender(typedMapping.template, {
           inputs: executionContext.inputs,
-          outputs: Object.fromEntries(stepResults),
+          outputs: this.unwrapOutputs(stepResults),
         });
       }
     }
@@ -396,33 +392,46 @@ export class WorkflowExecutor {
       if (output.value_js) {
         // JavaScript expression
         const sandbox = createSecureSandbox();
+        const unwrapped = this.unwrapOutputs(stepResults);
         outputs[output.name] = compileAndRun(
           sandbox,
           output.value_js,
           {
             inputs: executionContext.inputs,
-            steps: Object.fromEntries(
-              Array.from(stepResults.entries()).map(([id, result]) => [id, (result as any).output])
-            ),
-            outputs: Object.fromEntries(stepResults),
+            steps: unwrapped,
+            outputs: unwrapped,
             pr: prInfo,
           },
           { injectLog: true, logPrefix: `workflow.output.${output.name}` }
         );
       } else if (output.value) {
         // Liquid template
+        const unwrappedLiquid = this.unwrapOutputs(stepResults);
         outputs[output.name] = await this.liquid.parseAndRender(output.value, {
           inputs: executionContext.inputs,
-          steps: Object.fromEntries(
-            Array.from(stepResults.entries()).map(([id, result]) => [id, (result as any).output])
-          ),
-          outputs: Object.fromEntries(stepResults),
+          steps: unwrappedLiquid,
+          outputs: unwrappedLiquid,
           pr: prInfo,
         });
       }
     }
 
     return outputs;
+  }
+
+  /**
+   * Unwrap step outputs from ReviewSummary wrappers.
+   * Script steps and MCP steps store results as { issues: [], output: <actual> }.
+   * Workflow value_js/if/Liquid should see the unwrapped output, consistent with
+   * how script step contexts already unwrap via buildProviderTemplateContext.
+   */
+  private unwrapOutputs(stepResults: Map<string, ReviewSummary>): Record<string, unknown> {
+    const unwrapped: Record<string, unknown> = {};
+    for (const [id, result] of stepResults.entries()) {
+      const summary = result as ReviewSummary & { output?: unknown };
+      unwrapped[id] = summary.output !== undefined ? summary.output : summary;
+    }
+    return unwrapped;
   }
 
   /**

--- a/tests/frontends/email-frontend.test.ts
+++ b/tests/frontends/email-frontend.test.ts
@@ -172,7 +172,9 @@ describe('EmailFrontend (event-bus)', () => {
     const call = emailClient.sendEmail.mock.calls[0][0];
     expect(call.to).toBe('user@test.com');
     expect(call.text).toContain('Check failed');
-    expect(call.text).toContain('AI provider timeout');
+    expect(call.text).toContain(
+      'The AI request timed out before a response could be generated. Please retry.'
+    );
     // Should still thread the error
     expect(call.inReplyTo).toBe('<msg1@test>');
   });

--- a/tests/frontends/slack-frontend.test.ts
+++ b/tests/frontends/slack-frontend.test.ts
@@ -289,6 +289,52 @@ describe('SlackFrontend (event-bus)', () => {
     expect(req.text).toContain('timed out');
   });
 
+  test('posts error fallback when workflow output.text is empty and only a guarantee failure is present', async () => {
+    const bus = new EventBus();
+    const slack = makeFakeSlack();
+    const fe = new SlackFrontend({ defaultChannel: 'C1', debounceMs: 0 });
+    const map = new Map<string, unknown>();
+    map.set('/bots/slack/support', {
+      event: { type: 'app_mention', channel: 'C1', ts: '888.2', text: 'do something else' },
+    });
+    fe.start({
+      eventBus: bus,
+      logger: console as any,
+      config: {
+        slack: { endpoint: '/bots/slack/support' },
+        checks: {
+          chat: { type: 'workflow', workflow: 'assistant' },
+        },
+      },
+      run: { runId: 'r5b' },
+      webhookContext: { webhookData: map },
+    } as any);
+    (fe as any).getSlack = () => slack;
+
+    await bus.emit({
+      type: 'CheckCompleted',
+      checkId: 'chat',
+      scope: [],
+      result: {
+        issues: [
+          {
+            file: 'contract',
+            line: 0,
+            ruleId: 'contract/guarantee_failed',
+            message: "Guarantee failed: (output?.text ?? '').length > 0",
+            severity: 'error',
+            category: 'logic',
+          },
+        ],
+        output: { text: '', intent: 'chat' },
+      },
+    });
+
+    expect(slack.chat.postMessage).toHaveBeenCalledTimes(1);
+    const [req] = slack.chat.postMessage.mock.calls[0];
+    expect(req.text).toContain('failed to produce a response');
+  });
+
   test('posts error notice for execution failures on completed checks', async () => {
     const bus = new EventBus();
     const slack = makeFakeSlack();

--- a/tests/frontends/slack-frontend.test.ts
+++ b/tests/frontends/slack-frontend.test.ts
@@ -333,4 +333,44 @@ describe('SlackFrontend (event-bus)', () => {
     expect(req.text).toContain('Check failed');
     expect(req.text).toContain('Command execution timed out');
   });
+
+  test('sanitizes raw AI provider failures before posting error notices', async () => {
+    const bus = new EventBus();
+    const slack = makeFakeSlack();
+    const fe = new SlackFrontend({ defaultChannel: 'C1', debounceMs: 0 });
+    const map = new Map<string, unknown>();
+    map.set('/bots/slack/support', {
+      event: { type: 'app_mention', channel: 'C1', ts: '111.222', text: 'hi' },
+    });
+    fe.start({
+      eventBus: bus,
+      logger: console as any,
+      config: {
+        slack: { endpoint: '/bots/slack/support' },
+        checks: {
+          chat: { type: 'workflow', workflow: 'assistant' },
+        },
+      },
+      run: { runId: 'r6' },
+      webhookContext: { webhookData: map },
+    } as any);
+    (fe as any).getSlack = () => slack;
+
+    await bus.emit({
+      type: 'CheckErrored',
+      checkId: 'generate-response',
+      scope: [],
+      error: {
+        message:
+          'AI analysis failed: ProbeAgent execution failed: Error: Failed to get response from AI model. No output generated. Check the stream for errors.',
+      },
+    });
+
+    expect(slack.chat.postMessage).toHaveBeenCalledTimes(1);
+    const [req] = slack.chat.postMessage.mock.calls[0];
+    expect(req.text).toContain(
+      'The AI provider failed before generating any response. This is usually caused by a provider-side limit, rate limit, or outage. Please retry.'
+    );
+    expect(req.text).not.toContain('ProbeAgent execution failed');
+  });
 });

--- a/tests/frontends/teams-frontend.test.ts
+++ b/tests/frontends/teams-frontend.test.ts
@@ -228,7 +228,9 @@ describe('TeamsFrontend (event-bus)', () => {
     const call = teams.sendMessage.mock.calls[0][0];
     expect(call.conversationReference).toEqual(fakeConversationRef);
     expect(call.text).toContain('Check failed');
-    expect(call.text).toContain('AI provider timeout');
+    expect(call.text).toContain(
+      'The AI request timed out before a response could be generated. Please retry.'
+    );
     expect(call.replyToActivityId).toBe('act.msg1');
   });
 

--- a/tests/frontends/telegram-frontend.test.ts
+++ b/tests/frontends/telegram-frontend.test.ts
@@ -190,7 +190,9 @@ describe('TelegramFrontend (event-bus)', () => {
     expect(telegram.sendMessage).toHaveBeenCalledTimes(1);
     const call = telegram.sendMessage.mock.calls[0][0];
     expect(call.text).toContain('Check failed');
-    expect(call.text).toContain('AI provider timeout');
+    expect(call.text).toContain(
+      'The AI request timed out before a response could be generated. Please retry.'
+    );
     expect(call.reply_to_message_id).toBe(42);
   });
 

--- a/tests/frontends/whatsapp-frontend.test.ts
+++ b/tests/frontends/whatsapp-frontend.test.ts
@@ -142,7 +142,9 @@ describe('WhatsAppFrontend (event-bus)', () => {
     const call = whatsapp.sendMessage.mock.calls[0][0];
     expect(call.to).toBe('15551234567');
     expect(call.text).toContain('Check failed');
-    expect(call.text).toContain('AI provider timeout');
+    expect(call.text).toContain(
+      'The AI request timed out before a response could be generated. Please retry.'
+    );
     expect(call.replyToMessageId).toBe('wamid.msg1');
   });
 

--- a/tests/integration/cli-workflow.test.ts
+++ b/tests/integration/cli-workflow.test.ts
@@ -201,6 +201,8 @@ SELECT * FROM users WHERE id = '\${process.argv[2]}';
         expect(result.stdout).toContain('Visor - AI-powered code review tool');
         expect(result.stdout).toContain('--check');
         expect(result.stdout).toContain('--output');
+        expect(result.stdout).toContain('visor process list|restart|reload|stop');
+        expect(result.stdout).toContain('visor tasks list|show|logs');
         expect(result.stdout).toContain('Examples:');
       },
       timeout

--- a/tests/integration/debounce-integration.test.ts
+++ b/tests/integration/debounce-integration.test.ts
@@ -1,0 +1,173 @@
+import { StateMachineExecutionEngine } from '../../src/state-machine-execution-engine';
+import { VisorConfig } from '../../src/types/config';
+import { resetDebounceManager } from '../../src/state-machine/dispatch/debounce-manager';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { execSync } from 'child_process';
+
+describe('Debounce integration', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    process.env.VISOR_DEBOUNCE_OVERRIDE = '0';
+    resetDebounceManager();
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'visor-debounce-int-'));
+    execSync('git init -q', { cwd: tempDir });
+    execSync('git config user.email "test@example.com"', { cwd: tempDir });
+    execSync('git config user.name "Test User"', { cwd: tempDir });
+    fs.writeFileSync(path.join(tempDir, 'file.txt'), 'x');
+    execSync('git add .', { cwd: tempDir });
+    execSync('git -c core.hooksPath=/dev/null commit -q -m "init"', { cwd: tempDir });
+  });
+
+  afterEach(() => {
+    delete process.env.VISOR_DEBOUNCE_OVERRIDE;
+    resetDebounceManager();
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('debounced step executes and returns actual result', async () => {
+    const config: VisorConfig = {
+      version: '1.0',
+      checks: {
+        producer: {
+          type: 'command',
+          exec: 'echo "produced"',
+        },
+        'debounced-step': {
+          type: 'command',
+          depends_on: ['producer'],
+          debounce: 60000,
+          debounce_key: 'test-debounce',
+          exec: 'echo "debounce-output-42"',
+        },
+      },
+      output: {
+        pr_comment: { format: 'markdown', group_by: 'check', collapse: false },
+      },
+    };
+
+    const engine = new StateMachineExecutionEngine();
+    const result = await engine.executeChecks({
+      checks: ['producer', 'debounced-step'],
+      workingDirectory: tempDir,
+      config,
+    });
+
+    // The debounced step should have executed (single invocation, no coalescing needed)
+    expect(result).toBeDefined();
+    expect(result.reviewSummary).toBeDefined();
+
+    // Check that history contains the debounced step's actual output
+    const history = (result.reviewSummary as any).history;
+    if (history && history['debounced-step']) {
+      const outputs = history['debounced-step'];
+      expect(outputs.length).toBeGreaterThan(0);
+      // The output should contain the actual command result, not { debounced: false }
+      const lastOutput = outputs[outputs.length - 1];
+      // Command output should contain our echo text
+      const outputStr = typeof lastOutput === 'string' ? lastOutput : JSON.stringify(lastOutput);
+      expect(outputStr).toContain('debounce-output-42');
+    }
+  });
+
+  it('concurrent engine runs with same debounce key coalesce correctly', async () => {
+    const config: VisorConfig = {
+      version: '1.0',
+      checks: {
+        debounced: {
+          type: 'command',
+          debounce: 60000,
+          debounce_key: 'shared-key',
+          exec: 'echo "executed"',
+        },
+      },
+      output: {
+        pr_comment: { format: 'markdown', group_by: 'check', collapse: false },
+      },
+    };
+
+    // Run two engines concurrently with the same debounce key
+    const engine1 = new StateMachineExecutionEngine();
+    const engine2 = new StateMachineExecutionEngine();
+
+    const [r1, r2] = await Promise.all([
+      engine1.executeChecks({
+        checks: ['debounced'],
+        workingDirectory: tempDir,
+        config,
+      }),
+      engine2.executeChecks({
+        checks: ['debounced'],
+        workingDirectory: tempDir,
+        config,
+      }),
+    ]);
+
+    // Both should complete without error
+    expect(r1).toBeDefined();
+    expect(r2).toBeDefined();
+
+    // One should have executed, the other debounced
+    const h1 = (r1.reviewSummary as any).history?.['debounced'];
+    const h2 = (r2.reviewSummary as any).history?.['debounced'];
+
+    // At least one result should exist with actual output
+    const allOutputs = [...(h1 || []), ...(h2 || [])];
+    const hasExecuted = allOutputs.some((o: any) => {
+      const s = typeof o === 'string' ? o : JSON.stringify(o);
+      return s.includes('executed');
+    });
+    const hasDebounced = allOutputs.some((o: any) => {
+      return o && typeof o === 'object' && o.debounced === true;
+    });
+
+    // We expect one executed and one debounced
+    expect(hasExecuted || hasDebounced).toBe(true);
+  });
+
+  it('debounced step with depends_on runs after dependency completes', async () => {
+    const markerFile = path.join(tempDir, 'marker.txt');
+
+    const config: VisorConfig = {
+      version: '1.0',
+      checks: {
+        setup: {
+          type: 'command',
+          exec: `echo "setup-done" > "${markerFile}"`,
+        },
+        'debounced-consumer': {
+          type: 'command',
+          depends_on: ['setup'],
+          debounce: 60000,
+          debounce_key: 'consumer-key',
+          exec: `cat "${markerFile}"`,
+        },
+      },
+      output: {
+        pr_comment: { format: 'markdown', group_by: 'check', collapse: false },
+      },
+    };
+
+    const engine = new StateMachineExecutionEngine();
+    const result = await engine.executeChecks({
+      checks: ['setup', 'debounced-consumer'],
+      workingDirectory: tempDir,
+      config,
+    });
+
+    expect(result).toBeDefined();
+
+    // The consumer should have run after setup created the file
+    const history = (result.reviewSummary as any).history;
+    if (history?.['debounced-consumer']) {
+      const outputs = history['debounced-consumer'];
+      const outputStr = JSON.stringify(outputs);
+      expect(outputStr).toContain('setup-done');
+    }
+  });
+});

--- a/tests/integration/session-reuse-integration.test.ts
+++ b/tests/integration/session-reuse-integration.test.ts
@@ -59,7 +59,7 @@ describe('Session Reuse Integration', () => {
     engine = new CheckExecutionEngine(tempDir);
     configManager = new ConfigManager();
     sessionRegistry = SessionRegistry.getInstance();
-    sessionRegistry.clearAllSessions();
+    await sessionRegistry.clearAllSessions();
 
     // Setup mock clone() to return a cloned agent with the same answer behavior
     mockProbeAgent.clone.mockImplementation(options => ({
@@ -101,13 +101,13 @@ describe('Session Reuse Integration', () => {
       );
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     // Clean up temp directory
     if (tempDir && fs.existsSync(tempDir)) {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
 
-    sessionRegistry.clearAllSessions();
+    await sessionRegistry.clearAllSessions();
 
     // Clean up environment
     delete process.env.GOOGLE_API_KEY;

--- a/tests/integration/slack-live-task-updates.test.ts
+++ b/tests/integration/slack-live-task-updates.test.ts
@@ -45,7 +45,7 @@ jest.mock('../../src/agent-protocol/task-trace-resolution', () => ({
     async (metadata?: { trace_id?: string; trace_file?: string }) => ({
       traceId: metadata?.trace_id,
       traceFile: metadata?.trace_file,
-      primaryRef: metadata?.trace_id || metadata?.trace_file,
+      primaryRef: metadata?.trace_file || metadata?.trace_id,
     })
   ),
 }));
@@ -141,6 +141,9 @@ describe('Slack live task updates integration', () => {
       model: 'gemini-3.1-flash-lite-preview',
       frontends: { slack: { enabled: true } },
     };
+    serializeTraceForPrompt.mockImplementation(async (ref: string) =>
+      ref === traceFile ? 'trace snapshot' : '(no trace data available)'
+    );
 
     const pending = deferred<any>();
     executeChecksSpy.mockImplementation(() => pending.promise as any);
@@ -168,6 +171,8 @@ describe('Slack live task updates integration', () => {
     await flushAsyncWork();
 
     expect(serializeTraceForPrompt).toHaveBeenCalled();
+    expect(serializeTraceForPrompt.mock.calls.some(call => call[0] === traceFile)).toBe(true);
+    expect(serializeTraceForPrompt.mock.calls.some(call => call[0] !== traceFile)).toBe(false);
     expect(
       probeAnswer.mock.calls.some(call => String(call[0] || '').includes('<execution_trace>'))
     ).toBe(true);

--- a/tests/integration/slack-socket-message-triggers.test.ts
+++ b/tests/integration/slack-socket-message-triggers.test.ts
@@ -428,7 +428,7 @@ describe('Slack socket message triggers', () => {
     expect(triggerCalls.length).toBe(0);
   });
 
-  test('trigger and mention path can both fire for the same message', async () => {
+  test('trigger dispatch suppresses the normal mention path for the same message', async () => {
     const cfg: VisorConfig = {
       ...baseCfg,
       scheduler: {
@@ -464,13 +464,13 @@ describe('Slack socket message triggers', () => {
     );
     await new Promise(r => setTimeout(r, 50));
 
-    // Should have both: trigger dispatch (handle-cicd only) + mention dispatch (all checks)
+    // Trigger dispatch should win and prevent a second normal mention dispatch.
     const triggerCalls = spy.mock.calls.filter(
       (call: any[]) => call[0]?.checks?.length === 1 && call[0]?.checks?.[0] === 'handle-cicd'
     );
     const mentionCalls = spy.mock.calls.filter((call: any[]) => call[0]?.checks?.length > 1);
     expect(triggerCalls.length).toBe(1);
-    expect(mentionCalls.length).toBe(1);
+    expect(mentionCalls.length).toBe(0);
   });
 
   test('workflow "default" resolves to all checks', async () => {

--- a/tests/integration/teams-live-task-updates.test.ts
+++ b/tests/integration/teams-live-task-updates.test.ts
@@ -24,7 +24,7 @@ jest.mock('../../src/agent-protocol/task-trace-resolution', () => ({
     async (metadata?: { trace_id?: string; trace_file?: string }) => ({
       traceId: metadata?.trace_id,
       traceFile: metadata?.trace_file,
-      primaryRef: metadata?.trace_id || metadata?.trace_file,
+      primaryRef: metadata?.trace_file || metadata?.trace_id,
     })
   ),
 }));

--- a/tests/integration/telegram-live-task-updates.test.ts
+++ b/tests/integration/telegram-live-task-updates.test.ts
@@ -47,7 +47,7 @@ jest.mock('../../src/agent-protocol/task-trace-resolution', () => ({
     async (metadata?: { trace_id?: string; trace_file?: string }) => ({
       traceId: metadata?.trace_id,
       traceFile: metadata?.trace_file,
-      primaryRef: metadata?.trace_id || metadata?.trace_file,
+      primaryRef: metadata?.trace_file || metadata?.trace_id,
     })
   ),
 }));

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -61,7 +61,7 @@ beforeEach(() => {
   for (const k of gitVars) delete (process.env as NodeJS.ProcessEnv)[k];
 });
 
-afterEach(() => {
+afterEach(async () => {
   // Reset environment (individual tests may override this)
   Object.keys(process.env).forEach(key => {
     if (key.includes('API_KEY') || key === 'MODEL_NAME') {
@@ -81,7 +81,7 @@ afterEach(() => {
     MemoryStore.resetInstance();
   } catch {}
   try {
-    SessionRegistry.getInstance().clearAllSessions();
+    await SessionRegistry.getInstance().clearAllSessions();
   } catch {}
 });
 

--- a/tests/unit/agent-protocol/task-evaluator.test.ts
+++ b/tests/unit/agent-protocol/task-evaluator.test.ts
@@ -16,7 +16,7 @@ jest.mock('@probelabs/probe', () => ({
 jest.mock('../../../src/agent-protocol/trace-serializer', () => ({
   findTraceFile: jest.fn().mockResolvedValue(null),
   fetchTraceSpans: jest.fn().mockResolvedValue([]),
-  serializeTraceForPrompt: jest.fn().mockResolvedValue('(no trace data available)'),
+  buildTraceReport: jest.fn().mockResolvedValue(null),
 }));
 
 import {
@@ -24,7 +24,7 @@ import {
   evaluateAndStore,
   type TaskEvaluationResult,
 } from '../../../src/agent-protocol/task-evaluator';
-import { serializeTraceForPrompt } from '../../../src/agent-protocol/trace-serializer';
+import { buildTraceReport } from '../../../src/agent-protocol/trace-serializer';
 
 // ---------------------------------------------------------------------------
 // Mock task store
@@ -86,7 +86,7 @@ function createMockStore(taskData: {
 describe('evaluateTask', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (serializeTraceForPrompt as jest.Mock).mockResolvedValue('(no trace data available)');
+    (buildTraceReport as jest.Mock).mockResolvedValue(null);
   });
 
   const sampleEvalResult: TaskEvaluationResult = {
@@ -146,9 +146,18 @@ describe('evaluateTask', () => {
   });
 
   it('includes trace in prompt when available', async () => {
-    (serializeTraceForPrompt as jest.Mock).mockResolvedValue(
-      'visor.run (5.0s)\n└── check-a (2.0s)'
-    );
+    (buildTraceReport as jest.Mock).mockResolvedValue({
+      traceData: {
+        spans: [],
+        source: 'file',
+        remoteTraceId: 'trace-abc',
+        localTracePath: undefined,
+      },
+      taskSummary: null,
+      headerText: 'Trace source: file\nTasks: no task telemetry found in this trace',
+      tree: 'visor.run (5.0s)\n└── check-a (2.0s)',
+      text: 'Trace source: file\nTasks: no task telemetry found in this trace\n\nvisor.run (5.0s)\n└── check-a (2.0s)',
+    });
 
     const evalWithExec: TaskEvaluationResult = {
       ...sampleEvalResult,
@@ -170,8 +179,7 @@ describe('evaluateTask', () => {
 
     const result = await evaluateTask('task-003', store as any);
 
-    // Verify serializeTraceForPrompt called with full mode and task response
-    expect(serializeTraceForPrompt).toHaveBeenCalledWith(
+    expect(buildTraceReport).toHaveBeenCalledWith(
       'trace-abc',
       1_000_000,
       expect.objectContaining({}),
@@ -185,6 +193,7 @@ describe('evaluateTask', () => {
     // Verify trace is in XML tags, no separate agent_response
     const prompt = mockAnswer.mock.calls[0][0];
     expect(prompt).toContain('<execution_trace>');
+    expect(prompt).toContain('Trace source: file');
     expect(prompt).toContain('visor.run (5.0s)');
     expect(prompt).toContain('</execution_trace>');
     expect(prompt).not.toContain('<agent_response>');
@@ -246,7 +255,7 @@ describe('evaluateTask', () => {
 describe('evaluateAndStore', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (serializeTraceForPrompt as jest.Mock).mockResolvedValue('(no trace data available)');
+    (buildTraceReport as jest.Mock).mockResolvedValue(null);
   });
 
   it('stores evaluation result as artifact', async () => {
@@ -303,7 +312,7 @@ describe('provider/model resolution', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (serializeTraceForPrompt as jest.Mock).mockResolvedValue('(no trace data available)');
+    (buildTraceReport as jest.Mock).mockResolvedValue(null);
     mockAnswer.mockResolvedValue(JSON.stringify(sampleResult));
     delete process.env.VISOR_EVAL_MODEL;
     delete process.env.VISOR_EVAL_PROVIDER;

--- a/tests/unit/agent-protocol/task-live-update-slack.test.ts
+++ b/tests/unit/agent-protocol/task-live-update-slack.test.ts
@@ -55,14 +55,11 @@ describe('SlackTaskLiveUpdateSink', () => {
     expect(slack.chat.delete).not.toHaveBeenCalled();
   });
 
-  it('falls back to a new Slack post when a progress update fails', async () => {
+  it('does not repost a new progress message when chat.update fails', async () => {
     const slack = {
       chat: {
-        postMessage: jest
-          .fn()
-          .mockResolvedValueOnce({ ok: true, ts: '111.222' })
-          .mockResolvedValueOnce({ ok: true, ts: '333.444' }),
-        update: jest.fn(async () => ({ ok: false })),
+        postMessage: jest.fn().mockResolvedValueOnce({ ok: true, ts: '111.222' }),
+        update: jest.fn(async () => ({ ok: false, error: 'cant_update_message' })),
         delete: jest.fn(async () => ({ ok: true })),
       },
     } as any;
@@ -78,12 +75,64 @@ describe('SlackTaskLiveUpdateSink', () => {
       ts: '111.222',
       text: 'Still working again',
     });
-    expect(slack.chat.postMessage).toHaveBeenNthCalledWith(2, {
+    expect(slack.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(slack.chat.delete).not.toHaveBeenCalled();
+  });
+
+  it('keeps suppressing reposts across repeated progress update failures', async () => {
+    const slack = {
+      chat: {
+        postMessage: jest.fn().mockResolvedValueOnce({ ok: true, ts: '111.222' }),
+        update: jest.fn(async () => ({ ok: false, error: 'cant_update_message' })),
+        delete: jest.fn(async () => ({ ok: true })),
+      },
+    } as any;
+
+    const sink = new SlackTaskLiveUpdateSink(slack, 'C123', '999.000');
+
+    await sink.start();
+    await sink.update('Progress 1');
+    await sink.update('Progress 2');
+    await sink.update('Progress 3');
+    await sink.update('Progress 4');
+    await sink.update('Progress 5');
+
+    expect(slack.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(slack.chat.update).toHaveBeenCalledTimes(4);
+    expect(slack.chat.delete).not.toHaveBeenCalled();
+  });
+
+  it('still posts final message even after consecutive update failures', async () => {
+    const slack = {
+      chat: {
+        postMessage: jest
+          .fn()
+          .mockResolvedValueOnce({ ok: true, ts: '111.222' })
+          .mockResolvedValueOnce({ ok: true, ts: '444.555' }),
+        update: jest.fn(async () => ({ ok: false, error: 'cant_update_message' })),
+        delete: jest.fn(async () => ({ ok: true })),
+      },
+    } as any;
+
+    const sink = new SlackTaskLiveUpdateSink(slack, 'C123', '999.000');
+
+    await sink.start();
+    await sink.update('Progress 1');
+    await sink.update('Progress 2');
+    await sink.update('Progress 3');
+    await sink.update('Progress 4');
+    await sink.complete('Final answer');
+
+    expect(slack.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(slack.chat.postMessage).toHaveBeenLastCalledWith({
       channel: 'C123',
       thread_ts: '999.000',
-      text: 'Still working again',
+      text: 'Final answer',
     });
-    expect(slack.chat.delete).not.toHaveBeenCalled();
+    expect(slack.chat.delete).toHaveBeenCalledWith({
+      channel: 'C123',
+      ts: '111.222',
+    });
   });
 
   it('deletes the stale live update message when final fallback posts a new one', async () => {
@@ -118,5 +167,28 @@ describe('SlackTaskLiveUpdateSink', () => {
       channel: 'C123',
       ts: '111.222',
     });
+  });
+
+  it('updates an existing live-update message when initialized with a stored ts', async () => {
+    const slack = {
+      chat: {
+        postMessage: jest.fn(async () => ({ ok: true, ts: '111.222' })),
+        update: jest.fn(async () => ({ ok: true })),
+        delete: jest.fn(async () => ({ ok: true })),
+      },
+    } as any;
+
+    const sink = new SlackTaskLiveUpdateSink(slack, 'C123', '999.000', 'stored.123');
+
+    await sink.start();
+    await sink.update('Recovered progress');
+
+    expect(slack.chat.postMessage).not.toHaveBeenCalled();
+    expect(slack.chat.update).toHaveBeenCalledWith({
+      channel: 'C123',
+      ts: 'stored.123',
+      text: 'Recovered progress',
+    });
+    expect(slack.chat.delete).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/agent-protocol/task-live-updates.test.ts
+++ b/tests/unit/agent-protocol/task-live-updates.test.ts
@@ -107,7 +107,23 @@ describe('task-live-updates', () => {
                     eventCount: 2,
                     snapshotCount: 1,
                     tasks: [{ id: 'implement', title: 'Implement changes', status: 'in_progress' }],
-                    children: [],
+                    children: [
+                      {
+                        label: 'Search Delegate',
+                        source: 'events',
+                        eventCount: 1,
+                        snapshotCount: 0,
+                        tasks: [
+                          {
+                            id: '__scope_1',
+                            title: 'Search Delegate',
+                            status: 'completed',
+                            synthetic: true,
+                          },
+                        ],
+                        children: [],
+                      },
+                    ],
                   },
                 ],
               },
@@ -131,6 +147,7 @@ describe('task-live-updates', () => {
     expect(sink.update).toHaveBeenCalledWith(expect.stringContaining('• [x] Explore codebase'));
     expect(sink.update).toHaveBeenCalledWith(expect.stringContaining('Code Explorer'));
     expect(sink.update).toHaveBeenCalledWith(expect.stringContaining('• [~] Implement changes'));
+    expect(sink.update).not.toHaveBeenCalledWith(expect.stringContaining('Search Delegate'));
     expect(sink.update).toHaveBeenCalledWith(expect.stringContaining('- looking at logs'));
     expect(sink.update).toHaveBeenCalledWith(
       expect.stringContaining('_Metadata: elapsed 10s | first live update')
@@ -229,12 +246,127 @@ describe('task-live-updates', () => {
     const tickPromise = manager.tick();
     await Promise.resolve();
 
-    await manager.complete('Final answer');
+    const completionPromise = manager.complete('Final answer');
     resolveSummary?.('- Progress: stale progress update');
+    await completionPromise;
     await tickPromise;
 
     expect(sink.complete).toHaveBeenCalledWith('Final answer');
     expect(sink.update).not.toHaveBeenCalled();
+  });
+
+  it('does not delay final completion while a progress summary is still running', async () => {
+    let resolveSummary: ((value: string | null) => void) | undefined;
+    const summaryPromise = new Promise<string | null>(resolve => {
+      resolveSummary = resolve;
+    });
+
+    const sink = {
+      kind: 'test',
+      start: jest.fn(async () => null),
+      update: jest.fn(async () => null),
+      complete: jest.fn(async () => null),
+      fail: jest.fn(async () => null),
+    };
+
+    const manager = new TaskLiveUpdateManager(
+      {
+        taskId: 'task-complete-fast',
+        requestText: 'Investigate the issue',
+        traceRef: '/tmp/trace.ndjson',
+        sink,
+        config: {
+          enabled: true,
+          intervalSeconds: 10,
+          model: 'gemini-3.1-flash-lite-preview',
+          prompt: 'prompt',
+          initialMessage: '',
+          maxTraceChars: 4000,
+        },
+      },
+      {
+        serializeTrace: jest.fn(async () => 'trace-race-1'),
+        extractSkillMetadata: jest.fn(async () => undefined),
+        summarizeProgress: jest.fn(async () => summaryPromise),
+      }
+    );
+
+    void manager.tick();
+    await Promise.resolve();
+
+    await manager.complete('Final answer');
+
+    expect(sink.complete).toHaveBeenCalledWith('Final answer');
+    expect(sink.update).not.toHaveBeenCalled();
+
+    resolveSummary?.('- Progress: stale progress update');
+    await Promise.resolve();
+  });
+
+  it('does not let a later interval callback lose track of the real in-flight tick before completion', async () => {
+    jest.useFakeTimers();
+
+    let resolveMetadata: ((value: undefined) => void) | undefined;
+    const metadataPromise = new Promise<undefined>(resolve => {
+      resolveMetadata = resolve;
+    });
+
+    const sink = {
+      kind: 'test',
+      start: jest.fn(async () => null),
+      update: jest.fn(async () => null),
+      complete: jest.fn(async () => null),
+      fail: jest.fn(async () => null),
+    };
+
+    const manager = new TaskLiveUpdateManager(
+      {
+        taskId: 'task-scheduled-race',
+        requestText: 'Investigate the issue',
+        traceRef: '/tmp/trace.ndjson',
+        sink,
+        config: {
+          enabled: true,
+          intervalSeconds: 1,
+          model: 'gemini-3.1-flash-lite-preview',
+          prompt: 'prompt',
+          initialMessage: '',
+          maxTraceChars: 4000,
+        },
+      },
+      {
+        serializeTrace: jest
+          .fn()
+          .mockResolvedValueOnce('trace-initial')
+          .mockResolvedValueOnce('trace-stale'),
+        extractSkillMetadata: jest
+          .fn()
+          .mockResolvedValueOnce(undefined)
+          .mockImplementationOnce(() => metadataPromise),
+        summarizeProgress: jest
+          .fn()
+          .mockResolvedValueOnce('- Progress: initial live update')
+          .mockResolvedValueOnce('- Progress: stale scheduled update'),
+      }
+    );
+
+    await manager.start();
+    await jest.advanceTimersByTimeAsync(10_000);
+    expect(sink.update).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    await Promise.resolve();
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    const completionPromise = manager.complete('Final answer');
+    await Promise.resolve();
+
+    resolveMetadata?.(undefined);
+    await completionPromise;
+
+    expect(sink.complete).toHaveBeenCalledWith('Final answer');
+    expect(sink.update).toHaveBeenCalledTimes(1);
+    expect(sink.update).not.toHaveBeenCalledWith(expect.stringContaining('stale scheduled update'));
   });
 
   it('appends task id to progress and final updates when enabled', async () => {

--- a/tests/unit/agent-protocol/task-live-updates.test.ts
+++ b/tests/unit/agent-protocol/task-live-updates.test.ts
@@ -1,5 +1,9 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import {
   DEFAULT_TASK_LIVE_UPDATE_PROMPT,
+  extractTraceSkillMetadata,
   isFrontendLiveUpdatesEnabled,
   resolveTaskLiveUpdatesConfig,
   summarizeTaskProgress,
@@ -80,6 +84,35 @@ describe('task-live-updates', () => {
           .mockResolvedValueOnce('trace-2'),
         extractSkillMetadata: jest.fn(async () => ({
           activatedSkills: ['code-explorer', 'engineer'],
+          taskSummary: {
+            tasksEnabled: true,
+            source: 'snapshot',
+            eventCount: 4,
+            snapshotCount: 1,
+            tasks: [
+              { id: 'explore', title: 'Explore codebase', status: 'completed' },
+              { id: 'implement', title: 'Implement changes', status: 'in_progress' },
+            ],
+            scopes: [
+              {
+                label: 'Main Agent',
+                source: 'snapshot',
+                eventCount: 2,
+                snapshotCount: 1,
+                tasks: [{ id: 'explore', title: 'Explore codebase', status: 'completed' }],
+                children: [
+                  {
+                    label: 'Code Explorer',
+                    source: 'snapshot',
+                    eventCount: 2,
+                    snapshotCount: 1,
+                    tasks: [{ id: 'implement', title: 'Implement changes', status: 'in_progress' }],
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
         })),
         summarizeProgress: jest
           .fn()
@@ -94,6 +127,10 @@ describe('task-live-updates', () => {
 
     await jest.advanceTimersByTimeAsync(10_000);
     expect(sink.update).toHaveBeenCalledWith(expect.stringContaining('*Live Update*'));
+    expect(sink.update).toHaveBeenCalledWith(expect.stringContaining('*Tasks*'));
+    expect(sink.update).toHaveBeenCalledWith(expect.stringContaining('• [x] Explore codebase'));
+    expect(sink.update).toHaveBeenCalledWith(expect.stringContaining('Code Explorer'));
+    expect(sink.update).toHaveBeenCalledWith(expect.stringContaining('• [~] Implement changes'));
     expect(sink.update).toHaveBeenCalledWith(expect.stringContaining('- looking at logs'));
     expect(sink.update).toHaveBeenCalledWith(
       expect.stringContaining('_Metadata: elapsed 10s | first live update')
@@ -305,6 +342,133 @@ describe('task-live-updates', () => {
         secondsSincePreviousUpdate: 15,
       })
     );
+  });
+
+  it('prefers trace_file over trace_id when refreshed trace state contains both', async () => {
+    jest.useFakeTimers();
+
+    const sink = {
+      kind: 'test',
+      start: jest.fn(async () => null),
+      update: jest.fn(async () => null),
+      complete: jest.fn(async () => null),
+      fail: jest.fn(async () => null),
+    };
+    const serializeTrace = jest.fn(async () => 'trace-snapshot');
+
+    const manager = new TaskLiveUpdateManager(
+      {
+        taskId: 'task-trace-preference',
+        requestText: 'Investigate the issue',
+        traceRef: 'trace-id-only',
+        traceId: 'trace-id-only',
+        resolveTraceState: () => ({
+          traceRef: '/tmp/real-trace.ndjson',
+          traceId: 'trace-id-only',
+        }),
+        sink,
+        config: {
+          enabled: true,
+          intervalSeconds: 30,
+          model: 'gemini-3.1-flash-lite-preview',
+          prompt: 'prompt',
+          initialMessage: '',
+          maxTraceChars: 4000,
+        },
+      },
+      {
+        serializeTrace,
+        extractSkillMetadata: jest.fn(async () => undefined),
+        summarizeProgress: jest.fn(async () => '- Progress: tracing'),
+      }
+    );
+
+    await manager.start();
+    await jest.advanceTimersByTimeAsync(10_000);
+
+    expect(serializeTrace).toHaveBeenCalledWith('/tmp/real-trace.ndjson', 4000, 'trace-id-only');
+    expect(sink.update).toHaveBeenCalled();
+  });
+
+  it('extracts task metadata from the requested trace when a local NDJSON file contains multiple traces', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'task-live-updates-'));
+    const traceFile = path.join(tempDir, 'mixed.ndjson');
+    const wrongTraceId = '11111111111111111111111111111111';
+    const rightTraceId = '22222222222222222222222222222222';
+
+    const lines = [
+      JSON.stringify({
+        name: 'probe.event.task.created',
+        traceId: wrongTraceId,
+        spanId: 'span-wrong-task',
+        startTime: [1, 0],
+        endTime: [1, 1000],
+        attributes: {
+          'probe.event.name': 'task.created',
+          'task.action': 'create',
+          'task.id': 'fetch-pipeline-activity',
+          'task.title': 'Fetch Pipeline Activity',
+        },
+        events: [],
+        status: { code: 1 },
+      }),
+      JSON.stringify({
+        name: 'visor.check',
+        traceId: rightTraceId,
+        spanId: 'span-build-config',
+        startTime: [2, 0],
+        endTime: [2, 1000],
+        attributes: {
+          'visor.check.id': 'build-config',
+          'visor.check.output': JSON.stringify({ activated_skills: ['code-explorer'] }),
+        },
+        events: [],
+        status: { code: 1 },
+      }),
+      JSON.stringify({
+        name: 'probe.event.task.created',
+        traceId: rightTraceId,
+        spanId: 'span-right-task',
+        startTime: [3, 0],
+        endTime: [3, 1000],
+        attributes: {
+          'probe.event.name': 'task.created',
+          'task.action': 'create',
+          'task.id': 'validate-gateway',
+          'task.title': 'Validate Gateway',
+        },
+        events: [],
+        status: { code: 1 },
+      }),
+      JSON.stringify({
+        name: 'probe.event.task.updated',
+        traceId: rightTraceId,
+        spanId: 'span-right-task-update',
+        startTime: [4, 0],
+        endTime: [4, 1000],
+        attributes: {
+          'probe.event.name': 'task.updated',
+          'task.action': 'update',
+          'task.id': 'validate-gateway',
+          'task.new_status': 'in_progress',
+          'task.fields_updated': 'status',
+        },
+        events: [],
+        status: { code: 1 },
+      }),
+    ];
+
+    fs.writeFileSync(traceFile, `${lines.join('\n')}\n`, 'utf8');
+
+    try {
+      const metadata = await extractTraceSkillMetadata(traceFile, rightTraceId);
+      expect(metadata?.activatedSkills).toEqual(['code-explorer']);
+      expect(metadata?.taskSummary?.tasks).toEqual([
+        { id: 'validate-gateway', title: 'Validate Gateway', status: 'in_progress' },
+      ]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('refreshes only metadata every 5 seconds without making another LLM call', async () => {

--- a/tests/unit/agent-protocol/task-progress-tool.test.ts
+++ b/tests/unit/agent-protocol/task-progress-tool.test.ts
@@ -191,7 +191,7 @@ describe('task-progress-tool', () => {
           '/tmp/traces/trace-1.ndjson'
         );
         expect(traceSerializer.serializeTraceForPrompt).toHaveBeenCalledWith(
-          'abc123',
+          '/tmp/traces/trace-1.ndjson',
           8000,
           undefined,
           undefined,
@@ -199,7 +199,7 @@ describe('task-progress-tool', () => {
         );
       });
 
-      it('should prefer trace_id over trace_file when both are available', async () => {
+      it('should keep trace_file for local fallback while using trace_id as the remote hint when both are available', async () => {
         mockStore.getTask.mockReturnValue({
           state: 'working',
           created_at: new Date().toISOString(),
@@ -219,7 +219,7 @@ describe('task-progress-tool', () => {
         expect(result.success).toBe(true);
         expect(traceSerializer.readTraceIdFromFile).not.toHaveBeenCalled();
         expect(traceSerializer.serializeTraceForPrompt).toHaveBeenCalledWith(
-          'trace-from-metadata',
+          '/tmp/traces/trace-1.ndjson',
           8000,
           undefined,
           undefined,

--- a/tests/unit/agent-protocol/tasks-cli-handler.test.ts
+++ b/tests/unit/agent-protocol/tasks-cli-handler.test.ts
@@ -3,6 +3,25 @@ import fs from 'fs';
 import crypto from 'crypto';
 import { SqliteTaskStore } from '../../../src/agent-protocol/task-store';
 import type { AgentMessage } from '../../../src/agent-protocol/types';
+import { handleTasksCommand } from '../../../src/agent-protocol/tasks-cli-handler';
+import { buildTraceReport } from '../../../src/agent-protocol/trace-serializer';
+
+jest.mock('../../../src/agent-protocol/trace-serializer', () => ({
+  buildTraceReport: jest.fn().mockResolvedValue({
+    traceData: {
+      spans: [],
+      source: 'file',
+      remoteTraceId: 'trace-correct-123',
+      localTracePath: '/tmp/mixed-process-traces.ndjson',
+    },
+    taskSummary: null,
+    headerText: 'Trace source: file\nTasks: no task telemetry found in this trace',
+    tree: 'mock-trace-tree',
+    text: 'Trace source: file\nTasks: no task telemetry found in this trace\n\nmock-trace-tree',
+  }),
+  fetchTraceSpans: jest.fn().mockResolvedValue([]),
+  readTraceIdFromFile: jest.fn().mockResolvedValue(undefined),
+}));
 
 function makeMessage(text = 'Hello agent'): AgentMessage {
   return {
@@ -15,13 +34,19 @@ function makeMessage(text = 'Hello agent'): AgentMessage {
 describe('tasks CLI handler', () => {
   let store: SqliteTaskStore;
   let dbPath: string;
+  let originalCwd: string;
 
   beforeEach(async () => {
+    originalCwd = process.cwd();
     const tmpDir = path.join(__dirname, '../../fixtures/tmp-agent-tasks');
     fs.mkdirSync(tmpDir, { recursive: true });
-    dbPath = path.join(tmpDir, `test-cli-${crypto.randomUUID()}.db`);
+    const testDir = path.join(tmpDir, `case-${crypto.randomUUID()}`);
+    fs.mkdirSync(path.join(testDir, '.visor'), { recursive: true });
+    process.chdir(testDir);
+    dbPath = path.join(testDir, '.visor', 'agent-tasks.db');
     store = new SqliteTaskStore(dbPath);
     await store.initialize();
+    jest.clearAllMocks();
   });
 
   afterEach(async () => {
@@ -31,6 +56,7 @@ describe('tasks CLI handler', () => {
       fs.unlinkSync(dbPath + '-wal');
       fs.unlinkSync(dbPath + '-shm');
     } catch {}
+    process.chdir(originalCwd);
   });
 
   // -------------------------------------------------------------------------
@@ -204,6 +230,106 @@ describe('tasks CLI handler', () => {
       store.updateTaskState(task.id, 'completed');
 
       expect(() => store.updateTaskState(task.id, 'canceled')).toThrow();
+    });
+
+    it('tasks trace keeps trace_file for local fallback while preferring trace_id remotely', async () => {
+      const task = store.createTask({
+        contextId: 'ctx-1',
+        requestMessage: makeMessage('Trace me'),
+        requestMetadata: {
+          trace_id: 'trace-correct-123',
+          trace_file: '/tmp/mixed-process-traces.ndjson',
+        },
+      });
+
+      await handleTasksCommand(['trace', task.id.slice(0, 8)]);
+
+      expect(buildTraceReport).toHaveBeenCalledWith(
+        '/tmp/mixed-process-traces.ndjson',
+        8000,
+        undefined,
+        undefined,
+        'trace-correct-123'
+      );
+      expect(errorOutput).toEqual([]);
+      expect(logOutput.some(line => line.includes('Trace source: file'))).toBe(true);
+      expect(
+        logOutput.some(line => line.includes('Tasks: no task telemetry found in this trace'))
+      ).toBe(true);
+      expect(logOutput).toContain('mock-trace-tree');
+    });
+
+    it('tasks trace prints a probe task summary when task telemetry exists', async () => {
+      const task = store.createTask({
+        contextId: 'ctx-1',
+        requestMessage: makeMessage('Trace me'),
+        requestMetadata: {
+          trace_id: 'trace-correct-123',
+          trace_file: '/tmp/mixed-process-traces.ndjson',
+        },
+      });
+
+      (buildTraceReport as jest.Mock).mockResolvedValue({
+        traceData: {
+          spans: [],
+          source: 'file',
+          remoteTraceId: 'trace-correct-123',
+          localTracePath: '/tmp/mixed-process-traces.ndjson',
+        },
+        taskSummary: {
+          tasksEnabled: true,
+          source: 'snapshot',
+          eventCount: 5,
+          snapshotCount: 2,
+          tasks: [
+            { id: 'live-updates', title: 'Inspect live update flow', status: 'in_progress' },
+            { id: 'trace-spans', title: 'Inspect trace rendering', status: 'completed' },
+          ],
+          scopes: [
+            {
+              label: 'Main Agent',
+              source: 'snapshot',
+              eventCount: 3,
+              snapshotCount: 1,
+              tasks: [
+                { id: 'live-updates', title: 'Inspect live update flow', status: 'in_progress' },
+              ],
+              children: [
+                {
+                  label: 'Code Explorer',
+                  source: 'snapshot',
+                  eventCount: 2,
+                  snapshotCount: 1,
+                  tasks: [
+                    {
+                      id: 'trace-spans',
+                      title: 'Inspect trace rendering',
+                      status: 'completed',
+                    },
+                  ],
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+        headerText:
+          'Trace source: file\nTasks: 2 tracked (snapshot, 5 task events, 2 snapshots)\n  [~] Inspect live update flow\n  Code Explorer\n    [x] Inspect trace rendering',
+        tree: 'mock-trace-tree',
+        text: 'Trace source: file\nTasks: 2 tracked (snapshot, 5 task events, 2 snapshots)\n  [~] Inspect live update flow\n  Code Explorer\n    [x] Inspect trace rendering\n\nmock-trace-tree',
+      });
+
+      await handleTasksCommand(['trace', task.id.slice(0, 8)]);
+
+      expect(logOutput.some(line => line.includes('Trace source: file'))).toBe(true);
+      expect(
+        logOutput.some(line =>
+          line.includes('Tasks: 2 tracked (snapshot, 5 task events, 2 snapshots)')
+        )
+      ).toBe(true);
+      expect(logOutput.some(line => line.includes('  [~] Inspect live update flow'))).toBe(true);
+      expect(logOutput.some(line => line.includes('  Code Explorer'))).toBe(true);
+      expect(logOutput.some(line => line.includes('    [x] Inspect trace rendering'))).toBe(true);
     });
   });
 

--- a/tests/unit/agent-protocol/trace-serializer.test.ts
+++ b/tests/unit/agent-protocol/trace-serializer.test.ts
@@ -1,4 +1,6 @@
 import {
+  buildTraceReport,
+  extractProbeTaskSummary,
   fetchTraceSpans,
   renderSpanYaml,
   findTraceFile,
@@ -142,6 +144,83 @@ describe('renderSpanYaml', () => {
     expect(result).toContain('1.5k chars');
   });
 
+  it('renders Probe task events as readable task state lines', () => {
+    const created = makeTree({
+      name: 'probe.event.task.created',
+      spanId: 's2',
+      parentSpanId: 's1',
+      durationMs: 50,
+      attributes: {
+        'task.id': 'task-1',
+        'task.title': 'Investigate timeout failure',
+      },
+    });
+    const completed = makeTree({
+      name: 'probe.event.task.completed',
+      spanId: 's3',
+      parentSpanId: 's1',
+      durationMs: 40,
+      attributes: {
+        'task.id': 'task-1',
+        'task.title': 'Investigate timeout failure',
+        'task.incomplete_remaining': 1,
+      },
+    });
+    const batchCreated = makeTree({
+      name: 'probe.event.task.batch_created',
+      spanId: 's4',
+      parentSpanId: 's1',
+      durationMs: 70,
+      attributes: {
+        'task.count': 2,
+        'task.ids': 'task-1, task-2',
+        'task.total_count': 2,
+      },
+    });
+    const root = makeTree({ name: 'visor.run', spanId: 's1', durationMs: 500 }, [
+      batchCreated,
+      created,
+      completed,
+    ]);
+
+    const result = renderSpanYaml(root, [
+      root.span,
+      batchCreated.span,
+      created.span,
+      completed.span,
+    ]);
+
+    expect(result).toContain('tasks created (2, total 2): task-1, task-2');
+    expect(result).toContain('[ ] task-1: Investigate timeout failure');
+    expect(result).toContain('[x] task-1: Investigate timeout failure (1 remaining)');
+  });
+
+  it('renders task tool snapshots as checkbox lists instead of opaque task() blobs', () => {
+    const tool = makeTree({
+      name: 'probe.event.tool.result',
+      spanId: 's2',
+      parentSpanId: 's1',
+      durationMs: 20,
+      attributes: {
+        'tool.name': 'task',
+        'tool.result': `Created 2 tasks: live-updates, trace-spans
+
+<task_status>
+  <task id="live-updates" status="in_progress" priority="medium">Inspect how live updates resolve task traces</task>
+  <task id="trace-spans" status="pending" priority="medium">Inspect how tasks trace renders event spans</task>
+</task_status>`,
+      },
+    });
+    const root = makeTree({ name: 'visor.run', spanId: 's1', durationMs: 100 }, [tool]);
+
+    const result = renderSpanYaml(root, [root.span, tool.span]);
+
+    expect(result).toContain('tasks snapshot:');
+    expect(result).toContain('[~] live-updates: Inspect how live updates resolve task traces');
+    expect(result).toContain('[ ] trace-spans: Inspect how tasks trace renders event spans');
+    expect(result).not.toContain('task()');
+  });
+
   it('renders AI request with model and token info', () => {
     const ai = makeTree({
       name: 'ai.request',
@@ -282,6 +361,136 @@ describe('renderSpanYaml', () => {
     expect(result).toContain('gemini-flash');
     expect(result).toContain('search()');
     expect(result).toContain('5.0k chars');
+  });
+
+  it('filters mixed local NDJSON files by fallback trace id even when the target trace is not first', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-serializer-mixed-'));
+    const filePath = path.join(tmpDir, 'mixed.ndjson');
+
+    const lines = [
+      JSON.stringify({
+        name: 'visor.run',
+        traceId: 'trace-b',
+        spanId: 'root-b',
+        startTime: [3, 0],
+        endTime: [4, 0],
+        attributes: { started: true },
+        events: [],
+      }),
+      JSON.stringify({
+        name: 'ai.request.started',
+        traceId: 'trace-b',
+        spanId: 'child-b',
+        parentSpanId: 'root-b',
+        startTime: [3, 1000],
+        endTime: [3, 2000],
+        attributes: { 'probe.lifecycle.target': 'ai.request' },
+        events: [],
+      }),
+      JSON.stringify({
+        name: 'visor.run',
+        traceId: 'trace-a',
+        spanId: 'root-a',
+        startTime: [1, 0],
+        endTime: [2, 0],
+        attributes: { started: true },
+        events: [],
+      }),
+      JSON.stringify({
+        name: 'visor.check.chat.started',
+        traceId: 'trace-a',
+        spanId: 'child-a',
+        parentSpanId: 'root-a',
+        startTime: [1, 1000],
+        endTime: [1, 2000],
+        attributes: { 'visor.check.id': 'chat', 'visor.check.type': 'workflow' },
+        events: [],
+      }),
+    ];
+
+    fs.writeFileSync(filePath, lines.join('\n') + '\n', 'utf8');
+
+    const result = await serializeTraceForPrompt(
+      filePath,
+      8000,
+      { type: 'file' },
+      undefined,
+      'trace-a'
+    );
+
+    expect(result).toContain('trace_id: trace-a');
+    expect(result).toContain('chat [started]');
+    expect(result).not.toContain('ai.request');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('buildTraceReport uses the same filtered span set for header and body when the target trace is not first', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-report-mixed-'));
+    const filePath = path.join(tmpDir, 'mixed.ndjson');
+
+    const lines = [
+      JSON.stringify({
+        name: 'probe.event.task.batch_created',
+        traceId: 'trace-b',
+        spanId: 'b-task',
+        startTime: [3, 0],
+        endTime: [3, 1],
+        attributes: {
+          'probe.event.name': 'task.batch_created',
+          'task.action': 'create',
+          'task.count': 1,
+          'task.ids': 'wrong-task',
+          'task.total_count': 1,
+        },
+        events: [],
+      }),
+      JSON.stringify({
+        name: 'visor.run',
+        traceId: 'trace-b',
+        spanId: 'root-b',
+        startTime: [3, 0],
+        endTime: [4, 0],
+        attributes: {},
+        events: [],
+      }),
+      JSON.stringify({
+        name: 'probe.event.task.batch_created',
+        traceId: 'trace-a',
+        spanId: 'a-task',
+        startTime: [1, 0],
+        endTime: [1, 1],
+        attributes: {
+          'probe.event.name': 'task.batch_created',
+          'task.action': 'create',
+          'task.count': 1,
+          'task.ids': 'correct-task',
+          'task.total_count': 1,
+        },
+        events: [],
+      }),
+      JSON.stringify({
+        name: 'visor.run',
+        traceId: 'trace-a',
+        spanId: 'root-a',
+        startTime: [1, 0],
+        endTime: [2, 0],
+        attributes: {},
+        events: [],
+      }),
+    ];
+
+    fs.writeFileSync(filePath, lines.join('\n') + '\n', 'utf8');
+
+    const report = await buildTraceReport(filePath, 8000, { type: 'file' }, undefined, 'trace-a');
+
+    expect(report).not.toBeNull();
+    expect(report!.headerText).toContain('correct-task');
+    expect(report!.headerText).not.toContain('wrong-task');
+    expect(report!.tree).toContain('trace_id: trace-a');
+    expect(report!.tree).not.toContain('trace_id: trace-b');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it('does not truncate the YAML output', () => {
@@ -583,6 +792,176 @@ describe('renderSpanYaml', () => {
   });
 });
 
+describe('extractProbeTaskSummary', () => {
+  it('prefers the latest task snapshot and keeps current statuses', () => {
+    const spans = [
+      makeSpan({
+        spanId: 's1',
+        name: 'probe.event.task.created',
+        attributes: {
+          'task.id': 'live-updates',
+          'task.title': 'Inspect live update flow',
+        },
+      }),
+      makeSpan({
+        spanId: 's2',
+        startTimeMs: 1001000,
+        endTimeMs: 1001001,
+        name: 'probe.event.task.updated',
+        attributes: {
+          'task.id': 'live-updates',
+          'task.new_status': 'in_progress',
+        },
+      }),
+      makeSpan({
+        spanId: 's3',
+        startTimeMs: 1002000,
+        endTimeMs: 1002001,
+        name: 'probe.event.tool.result',
+        attributes: {
+          'tool.name': 'task',
+          'tool.result': `<task_status>
+  <task id="live-updates" status="completed" priority="medium">Inspect live update flow</task>
+  <task id="trace-spans" status="pending" priority="medium">Inspect trace rendering</task>
+</task_status>`,
+        },
+      }),
+    ];
+
+    const summary = extractProbeTaskSummary(spans);
+
+    expect(summary).not.toBeNull();
+    expect(summary?.source).toBe('snapshot');
+    expect(summary?.eventCount).toBe(2);
+    expect(summary?.snapshotCount).toBe(1);
+    expect(summary?.tasks).toEqual([
+      { id: 'live-updates', title: 'Inspect live update flow', status: 'completed' },
+      { id: 'trace-spans', title: 'Inspect trace rendering', status: 'pending' },
+    ]);
+    expect(summary?.scopes[0]?.label).toBe('Main Agent');
+  });
+
+  it('derives task states from events when no snapshot exists', () => {
+    const spans = [
+      makeSpan({
+        spanId: 's1',
+        name: 'probe.event.task.batch_created',
+        attributes: {
+          'task.ids': 'live-updates, trace-spans',
+          'task.count': 2,
+        },
+      }),
+      makeSpan({
+        spanId: 's2',
+        startTimeMs: 1001000,
+        endTimeMs: 1001001,
+        name: 'probe.event.task.updated',
+        attributes: {
+          'task.id': 'live-updates',
+          'task.new_status': 'in_progress',
+        },
+      }),
+      makeSpan({
+        spanId: 's3',
+        startTimeMs: 1002000,
+        endTimeMs: 1002001,
+        name: 'probe.event.task.completed',
+        attributes: {
+          'task.id': 'trace-spans',
+        },
+      }),
+    ];
+
+    const summary = extractProbeTaskSummary(spans);
+
+    expect(summary).not.toBeNull();
+    expect(summary?.source).toBe('events');
+    expect(summary?.tasks).toEqual([
+      { id: 'live-updates', title: '', status: 'in_progress' },
+      { id: 'trace-spans', title: '', status: 'completed' },
+    ]);
+    expect(summary?.scopes[0]?.label).toBe('Main Agent');
+  });
+
+  it('groups nested task snapshots under child scopes', () => {
+    const spans = [
+      makeSpan({
+        spanId: 'root',
+        name: 'visor.run',
+        startTimeMs: 1000000,
+        endTimeMs: 1005000,
+      }),
+      makeSpan({
+        spanId: 'generate',
+        parentSpanId: 'root',
+        name: 'visor.check.generate-response',
+        startTimeMs: 1000100,
+        endTimeMs: 1004900,
+        attributes: {
+          'visor.check.id': 'generate-response',
+          'visor.check.type': 'ai',
+        },
+      }),
+      makeSpan({
+        spanId: 'top-task',
+        parentSpanId: 'generate',
+        name: 'probe.event.tool.result',
+        startTimeMs: 1000200,
+        endTimeMs: 1000210,
+        attributes: {
+          'tool.name': 'task',
+          'tool.result': `<task_status>
+  <task id="fetch-docs" status="completed" priority="medium">Fetch Documentation</task>
+</task_status>`,
+        },
+      }),
+      makeSpan({
+        spanId: 'explore',
+        parentSpanId: 'generate',
+        name: 'visor.check.explore-code',
+        startTimeMs: 1000300,
+        endTimeMs: 1004800,
+        attributes: {
+          'visor.check.id': 'explore-code',
+          'visor.check.type': 'ai',
+        },
+      }),
+      makeSpan({
+        spanId: 'child-task',
+        parentSpanId: 'explore',
+        name: 'probe.event.tool.result',
+        startTimeMs: 1000400,
+        endTimeMs: 1000410,
+        attributes: {
+          'tool.name': 'task',
+          'tool.result': `<task_status>
+  <task id="extract-docs" status="completed" priority="medium">Extract Docs</task>
+  <task id="validate-gateway" status="in_progress" priority="medium">Validate Gateway</task>
+</task_status>`,
+        },
+      }),
+    ];
+
+    const summary = extractProbeTaskSummary(spans);
+
+    expect(summary).not.toBeNull();
+    expect(summary?.tasks).toHaveLength(3);
+    expect(summary?.scopes).toHaveLength(1);
+    expect(summary?.scopes[0]).toMatchObject({
+      label: 'Main Agent',
+      tasks: [{ id: 'fetch-docs', title: 'Fetch Documentation', status: 'completed' }],
+    });
+    expect(summary?.scopes[0]?.children).toHaveLength(1);
+    expect(summary?.scopes[0]?.children[0]).toMatchObject({
+      label: 'Code Explorer',
+      tasks: [
+        { id: 'extract-docs', title: 'Extract Docs', status: 'completed' },
+        { id: 'validate-gateway', title: 'Validate Gateway', status: 'in_progress' },
+      ],
+    });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // findTraceFile
 // ---------------------------------------------------------------------------
@@ -627,6 +1006,20 @@ describe('findTraceFile', () => {
 
     const result = await findTraceFile('target', tmpDir);
     expect(result).toBe(path.join(tmpDir, 'good.ndjson'));
+  });
+
+  it('finds a trace id that is not on the first line of a mixed NDJSON file', async () => {
+    const filePath = path.join(tmpDir, 'mixed.ndjson');
+    fs.writeFileSync(
+      filePath,
+      [
+        JSON.stringify({ traceId: 'other-trace', spanId: 's1', name: 'visor.run' }),
+        JSON.stringify({ traceId: 'target-trace', spanId: 's2', name: 'visor.check.chat' }),
+      ].join('\n') + '\n'
+    );
+
+    const result = await findTraceFile('target-trace', tmpDir);
+    expect(result).toBe(filePath);
   });
 
   it('reads a trace id directly from a trace file', async () => {

--- a/tests/unit/agent-protocol/trace-serializer.test.ts
+++ b/tests/unit/agent-protocol/trace-serializer.test.ts
@@ -1,5 +1,6 @@
 import {
   buildTraceReport,
+  buildTraceHeaderLines,
   extractProbeTaskSummary,
   fetchTraceSpans,
   renderSpanYaml,
@@ -48,6 +49,65 @@ describe('renderSpanYaml', () => {
     expect(result).toContain('visor.run:');
     expect(result).toContain('trace_id: abc123');
     expect(result).toContain('duration: 5.0s');
+  });
+
+  it('does not render synthesized scope placeholder tasks in the header task list', () => {
+    const lines = buildTraceHeaderLines(
+      { spans: [], source: 'file' as any },
+      {
+        tasksEnabled: true,
+        source: 'snapshot',
+        eventCount: 3,
+        snapshotCount: 1,
+        tasks: [{ id: 'real-1', title: 'Find OAS Path Compilers', status: 'in_progress' }],
+        scopes: [
+          {
+            label: 'Main Agent',
+            source: 'snapshot',
+            eventCount: 1,
+            snapshotCount: 1,
+            tasks: [{ id: 'real-1', title: 'Find OAS Path Compilers', status: 'in_progress' }],
+            children: [
+              {
+                label: 'Code Explorer',
+                source: 'events',
+                eventCount: 1,
+                snapshotCount: 0,
+                tasks: [
+                  {
+                    id: '__scope_1',
+                    title: 'Code Explorer',
+                    status: 'in_progress',
+                    synthetic: true,
+                  },
+                ],
+                children: [
+                  {
+                    label: 'Search Delegate',
+                    source: 'events',
+                    eventCount: 1,
+                    snapshotCount: 0,
+                    tasks: [
+                      {
+                        id: '__scope_2',
+                        title: 'Search Delegate',
+                        status: 'completed',
+                        synthetic: true,
+                      },
+                    ],
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+    );
+
+    expect(lines.join('\n')).toContain('[~] Find OAS Path Compilers');
+    expect(lines.join('\n')).not.toContain('Code Explorer\n');
+    expect(lines.join('\n')).not.toContain('Search Delegate');
   });
 
   it('renders visor.run with version and source attributes', () => {
@@ -361,6 +421,28 @@ describe('renderSpanYaml', () => {
     expect(result).toContain('gemini-flash');
     expect(result).toContain('search()');
     expect(result).toContain('5.0k chars');
+  });
+
+  it('renders dedup errors in search.delegate.dedup spans', () => {
+    const dedup = makeTree({
+      name: 'search.delegate.dedup',
+      spanId: 's2',
+      parentSpanId: 's1',
+      durationMs: 250,
+      attributes: {
+        'dedup.query': 'graphql complexity depth',
+        'dedup.previous_count': '3',
+        'dedup.action': 'allow',
+        'dedup.reason': 'dedup check failed',
+        'dedup.error': 'Error: 503 model overloaded',
+      },
+    });
+    const root = makeTree({ name: 'visor.run', spanId: 's1', durationMs: 1000 }, [dedup]);
+    const result = renderSpanYaml(root, [root.span, dedup.span]);
+
+    expect(result).toContain('dedup("graphql complexity depth") [3 prior]: allow');
+    expect(result).toContain('dedup check failed');
+    expect(result).toContain('503 model overloaded');
   });
 
   it('filters mixed local NDJSON files by fallback trace id even when the target trace is not first', async () => {

--- a/tests/unit/agent-protocol/trace-serializer.test.ts
+++ b/tests/unit/agent-protocol/trace-serializer.test.ts
@@ -945,20 +945,25 @@ describe('extractProbeTaskSummary', () => {
     const summary = extractProbeTaskSummary(spans);
 
     expect(summary).not.toBeNull();
-    expect(summary?.tasks).toHaveLength(3);
     expect(summary?.scopes).toHaveLength(1);
     expect(summary?.scopes[0]).toMatchObject({
       label: 'Main Agent',
       tasks: [{ id: 'fetch-docs', title: 'Fetch Documentation', status: 'completed' }],
     });
     expect(summary?.scopes[0]?.children).toHaveLength(1);
-    expect(summary?.scopes[0]?.children[0]).toMatchObject({
-      label: 'Code Explorer',
-      tasks: [
-        { id: 'extract-docs', title: 'Extract Docs', status: 'completed' },
-        { id: 'validate-gateway', title: 'Validate Gateway', status: 'in_progress' },
-      ],
-    });
+    const codeExplorer = summary?.scopes[0]?.children[0];
+    expect(codeExplorer?.label).toBe('Code Explorer');
+    // Sub-agent scope with meaningful task titles preserves them
+    expect(codeExplorer?.tasks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'extract-docs', title: 'Extract Docs', status: 'completed' }),
+        expect.objectContaining({
+          id: 'validate-gateway',
+          title: 'Validate Gateway',
+          status: 'in_progress',
+        }),
+      ])
+    );
   });
 });
 

--- a/tests/unit/agent-protocol/track-execution.test.ts
+++ b/tests/unit/agent-protocol/track-execution.test.ts
@@ -205,7 +205,7 @@ describe('trackExecution', () => {
     expect(updated?.metadata?.message_id).toBe('msg-1');
   });
 
-  it('should prefer trace_id over trace_file for live updates', async () => {
+  it('should keep trace_file as the live update ref while preserving trace_id for remote lookup', async () => {
     const sink = {
       kind: 'test',
       start: jest.fn(async () => null),

--- a/tests/unit/ai-review-service-probe-task-telemetry.test.ts
+++ b/tests/unit/ai-review-service-probe-task-telemetry.test.ts
@@ -1,0 +1,73 @@
+jest.mock('../../src/telemetry/lazy-otel', () => ({
+  trace: {
+    getTracer: jest.fn(),
+    getActiveSpan: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/telemetry/fallback-ndjson', () => ({
+  emitNdjsonFullSpan: jest.fn(),
+}));
+
+import { createProbeTracerAdapter } from '../../src/ai-review-service';
+import { trace as otTrace } from '../../src/telemetry/lazy-otel';
+import { emitNdjsonFullSpan } from '../../src/telemetry/fallback-ndjson';
+
+describe('createProbeTracerAdapter task telemetry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('promotes task events to probe.event spans and active span events', () => {
+    const end = jest.fn();
+    const startSpan = jest.fn().mockReturnValue({
+      end,
+      spanContext: () => ({ traceId: 'trace-1', spanId: 'child-1' }),
+    });
+    const addEvent = jest.fn();
+    const activeSpan = {
+      addEvent,
+      spanContext: () => ({ traceId: 'trace-1', spanId: 'parent-1' }),
+    };
+    const fallback = { recordTaskEvent: jest.fn() };
+
+    (otTrace.getTracer as jest.Mock).mockReturnValue({ startSpan });
+    (otTrace.getActiveSpan as jest.Mock).mockReturnValue(activeSpan);
+
+    const tracer = createProbeTracerAdapter(fallback);
+    tracer.recordTaskEvent('completed', {
+      'task.id': 'task-1',
+      'task.title': 'Investigate timeout failure',
+    });
+
+    expect(startSpan).toHaveBeenCalledWith('probe.event.task.completed', {
+      attributes: {
+        'probe.event.name': 'task.completed',
+        'task.id': 'task-1',
+        'task.title': 'Investigate timeout failure',
+      },
+    });
+    expect(end).toHaveBeenCalled();
+    expect(addEvent).toHaveBeenCalledWith('task.completed', {
+      'task.id': 'task-1',
+      'task.title': 'Investigate timeout failure',
+    });
+    expect(emitNdjsonFullSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'probe.event.task.completed',
+        traceId: 'trace-1',
+        spanId: 'child-1',
+        parentSpanId: 'parent-1',
+        attributes: {
+          'probe.event.name': 'task.completed',
+          'task.id': 'task-1',
+          'task.title': 'Investigate timeout failure',
+        },
+      })
+    );
+    expect(fallback.recordTaskEvent).toHaveBeenCalledWith('completed', {
+      'task.id': 'task-1',
+      'task.title': 'Investigate timeout failure',
+    });
+  });
+});

--- a/tests/unit/ai-review-service.test.ts
+++ b/tests/unit/ai-review-service.test.ts
@@ -195,7 +195,7 @@ describe('AIReviewService', () => {
       const service = new AIReviewService();
 
       await expect(service.executeReview(mockPRInfo, 'performance')).rejects.toThrow(
-        'ProbeAgent execution failed: API rate limit exceeded'
+        'The AI provider rate limit was reached before a response could be generated. Please retry shortly.'
       );
     });
 
@@ -216,7 +216,9 @@ describe('AIReviewService', () => {
 
       await expect(
         service.executeReview(mockPRInfo, 'Review this code for all issues')
-      ).rejects.toThrow('ProbeAgent execution failed: Request timed out');
+      ).rejects.toThrow(
+        'The AI request timed out before a response could be generated. Please retry.'
+      );
 
       expect(MockedProbeAgent).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -228,6 +230,29 @@ describe('AIReviewService', () => {
             /^visor-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z-unknown$/
           ),
         })
+      );
+    });
+
+    it('should normalize no-output provider failures', async () => {
+      process.env.GOOGLE_API_KEY = 'test-key';
+
+      const mockAnswer = jest
+        .fn()
+        .mockRejectedValue(
+          new Error('Error: Failed to get response from AI model. No output generated.')
+        );
+      MockedProbeAgent.mockImplementation(
+        () =>
+          ({
+            initialize: jest.fn().mockResolvedValue(undefined),
+            answer: mockAnswer,
+          }) as any
+      );
+
+      const service = new AIReviewService();
+
+      await expect(service.executeReview(mockPRInfo, 'chat prompt')).rejects.toThrow(
+        'The AI provider failed before generating any response. This is usually caused by a provider-side limit, rate limit, or outage. Please retry.'
       );
     });
   });

--- a/tests/unit/child-process-error-handler.test.ts
+++ b/tests/unit/child-process-error-handler.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the global child-process I/O error handler.
+ *
+ * The handler suppresses transient EIO / EPIPE errors that originate from
+ * broken child-process stdio pipes so the visor process doesn't crash.
+ */
+
+// Helper to emit uncaughtException without TS overload complaints
+function emitUncaughtException(err: Error): void {
+  (process as any).emit('uncaughtException', err, 'uncaughtException');
+}
+
+describe('child-process-error-handler', () => {
+  let originalListeners: NodeJS.UncaughtExceptionListener[];
+
+  beforeAll(() => {
+    // Capture pre-existing uncaughtException listeners so we can restore later
+    originalListeners = process.listeners(
+      'uncaughtException'
+    ) as NodeJS.UncaughtExceptionListener[];
+  });
+
+  afterAll(() => {
+    // Remove any listeners our import added and restore originals
+    process.removeAllListeners('uncaughtException');
+    for (const fn of originalListeners) {
+      process.on('uncaughtException', fn);
+    }
+  });
+
+  beforeEach(() => {
+    // Clear the guard so the module re-registers on each test
+    delete (globalThis as any)[Symbol.for('visor.childProcessErrorHandler')];
+  });
+
+  it('should register an uncaughtException listener', () => {
+    const before = process.listenerCount('uncaughtException');
+    jest.isolateModules(() => {
+      require('../../src/utils/child-process-error-handler');
+    });
+    const after = process.listenerCount('uncaughtException');
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it('should suppress EIO errors without crashing', () => {
+    jest.isolateModules(() => {
+      require('../../src/utils/child-process-error-handler');
+    });
+
+    const err = Object.assign(new Error('read EIO'), { code: 'EIO' });
+    expect(() => emitUncaughtException(err)).not.toThrow();
+  });
+
+  it('should suppress EPIPE errors without crashing', () => {
+    jest.isolateModules(() => {
+      require('../../src/utils/child-process-error-handler');
+    });
+
+    const err = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+    expect(() => emitUncaughtException(err)).not.toThrow();
+  });
+
+  it('should suppress ECONNRESET errors without crashing', () => {
+    jest.isolateModules(() => {
+      require('../../src/utils/child-process-error-handler');
+    });
+
+    const err = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+    expect(() => emitUncaughtException(err)).not.toThrow();
+  });
+
+  it('should suppress ERR_STREAM_DESTROYED errors without crashing', () => {
+    jest.isolateModules(() => {
+      require('../../src/utils/child-process-error-handler');
+    });
+
+    const err = new Error('ERR_STREAM_DESTROYED');
+    expect(() => emitUncaughtException(err)).not.toThrow();
+  });
+
+  it('should NOT suppress unrelated errors', () => {
+    jest.isolateModules(() => {
+      require('../../src/utils/child-process-error-handler');
+    });
+
+    const err = new Error('Something completely different');
+    expect(() => emitUncaughtException(err)).not.toThrow();
+  });
+
+  it('should only register once even when imported twice', () => {
+    jest.isolateModules(() => {
+      require('../../src/utils/child-process-error-handler');
+    });
+    const afterFirst = process.listenerCount('uncaughtException');
+    jest.isolateModules(() => {
+      require('../../src/utils/child-process-error-handler');
+    });
+    const afterSecond = process.listenerCount('uncaughtException');
+    expect(afterSecond).toBe(afterFirst);
+  });
+});

--- a/tests/unit/cli-main.test.ts
+++ b/tests/unit/cli-main.test.ts
@@ -50,6 +50,12 @@ describe('CLI Main Entry Point', () => {
     await main();
 
     expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Usage: visor [options]'));
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining('visor process list|restart|reload|stop')
+    );
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining('visor tasks list|show|logs')
+    );
     expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Examples:'));
     expect(mockProcessExit).toHaveBeenCalledWith(0);
   });

--- a/tests/unit/config-loader-bundled-default.test.ts
+++ b/tests/unit/config-loader-bundled-default.test.ts
@@ -1,0 +1,45 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+import { ConfigLoader } from '../../src/utils/config-loader';
+
+describe('ConfigLoader bundled default extends', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'visor-project-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('loads bundled default includes when project config extends default outside the package root', async () => {
+    fs.writeFileSync(
+      path.join(projectRoot, 'visor.yaml'),
+      yaml.dump({
+        extends: 'default',
+        checks: {
+          'custom-project-check': {
+            type: 'ai',
+            prompt: 'Project-specific check',
+            on: ['pr_opened'],
+          },
+        },
+      })
+    );
+
+    const loader = new ConfigLoader({
+      baseDir: projectRoot,
+      projectRoot,
+    });
+
+    const config = await loader.fetchConfig('./visor.yaml');
+
+    expect(config.steps).toBeDefined();
+    expect(config.steps?.overview).toBeDefined();
+    expect(config.checks).toBeDefined();
+    expect(config.checks?.['custom-project-check']).toBeDefined();
+  });
+});

--- a/tests/unit/debounce-manager.test.ts
+++ b/tests/unit/debounce-manager.test.ts
@@ -1,0 +1,270 @@
+import { DebounceManager } from '../../src/state-machine/dispatch/debounce-manager';
+
+describe('DebounceManager', () => {
+  let dm: DebounceManager;
+
+  beforeEach(() => {
+    // Use VISOR_DEBOUNCE_OVERRIDE=0 for instant debounce in tests
+    process.env.VISOR_DEBOUNCE_OVERRIDE = '0';
+    dm = new DebounceManager();
+  });
+
+  afterEach(() => {
+    dm.clear();
+    delete process.env.VISOR_DEBOUNCE_OVERRIDE;
+  });
+
+  it('executes a single invocation and returns the result', async () => {
+    const result = await dm.enqueue('test-key', 1000, async () => {
+      return { success: true, count: 42 };
+    });
+
+    expect(result.outcome).toBe('executed');
+    expect(result).toHaveProperty('result');
+    if (result.outcome === 'executed') {
+      expect(result.result).toEqual({ success: true, count: 42 });
+    }
+  });
+
+  it('debounces earlier invocations, only the last one executes', async () => {
+    const calls: number[] = [];
+
+    // Fire 3 invocations rapidly — only the last should execute
+    const p1 = dm.enqueue('key', 100, async () => {
+      calls.push(1);
+      return 'result-1';
+    });
+    const p2 = dm.enqueue('key', 100, async () => {
+      calls.push(2);
+      return 'result-2';
+    });
+    const p3 = dm.enqueue('key', 100, async () => {
+      calls.push(3);
+      return 'result-3';
+    });
+
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+    expect(r1.outcome).toBe('debounced');
+    expect(r2.outcome).toBe('debounced');
+    expect(r3.outcome).toBe('executed');
+    if (r3.outcome === 'executed') {
+      expect(r3.result).toBe('result-3');
+    }
+    // Only the last fn should have been called
+    expect(calls).toEqual([3]);
+  });
+
+  it('preserves the actual result from the executed function', async () => {
+    const result = await dm.enqueue('key', 1000, async () => {
+      return {
+        text: 'CVE Processor finished. Processed: 37, Created: 2, Updated: 5',
+        success: true,
+        processed: 37,
+      };
+    });
+
+    expect(result.outcome).toBe('executed');
+    if (result.outcome === 'executed') {
+      const r = result.result as any;
+      expect(r.text).toContain('CVE Processor finished');
+      expect(r.processed).toBe(37);
+    }
+  });
+
+  it('handles independent keys separately', async () => {
+    const p1 = dm.enqueue('key-a', 1000, async () => 'a');
+    const p2 = dm.enqueue('key-b', 1000, async () => 'b');
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1.outcome).toBe('executed');
+    expect(r2.outcome).toBe('executed');
+    if (r1.outcome === 'executed') expect(r1.result).toBe('a');
+    if (r2.outcome === 'executed') expect(r2.result).toBe('b');
+  });
+
+  it('rejects if the function throws', async () => {
+    await expect(
+      dm.enqueue('key', 1000, async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+  });
+
+  it('cancel resolves all waiters as debounced', async () => {
+    // Use real timer (small) to test cancel before execution
+    delete process.env.VISOR_DEBOUNCE_OVERRIDE;
+
+    const p1 = dm.enqueue('key', 5000, async () => 'should-not-run');
+    const p2 = dm.enqueue('key', 5000, async () => 'should-not-run-either');
+
+    // Cancel before debounce fires
+    const cancelled = dm.cancel('key');
+    expect(cancelled).toBe(true);
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.outcome).toBe('debounced');
+    expect(r2.outcome).toBe('debounced');
+    expect(dm.size).toBe(0);
+  });
+
+  it('clear cancels all pending keys', async () => {
+    delete process.env.VISOR_DEBOUNCE_OVERRIDE;
+
+    const p1 = dm.enqueue('a', 5000, async () => 'x');
+    const p2 = dm.enqueue('b', 5000, async () => 'y');
+
+    expect(dm.size).toBe(2);
+    dm.clear();
+    expect(dm.size).toBe(0);
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.outcome).toBe('debounced');
+    expect(r2.outcome).toBe('debounced');
+  });
+
+  it('respects VISOR_DEBOUNCE_OVERRIDE env var', async () => {
+    process.env.VISOR_DEBOUNCE_OVERRIDE = '0';
+
+    const start = Date.now();
+    const result = await dm.enqueue('key', 60000, async () => 'fast');
+    const elapsed = Date.now() - start;
+
+    expect(result.outcome).toBe('executed');
+    // With override=0, should resolve nearly instantly (not 60 seconds)
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  it('tracks size correctly across enqueue/execute cycles', async () => {
+    expect(dm.size).toBe(0);
+
+    const p1 = dm.enqueue('a', 1000, async () => 1);
+    expect(dm.size).toBe(1);
+
+    const p2 = dm.enqueue('b', 1000, async () => 2);
+    expect(dm.size).toBe(2);
+
+    await Promise.all([p1, p2]);
+    expect(dm.size).toBe(0);
+  });
+});
+
+describe('DebounceManager execution guard', () => {
+  let dm: DebounceManager;
+
+  beforeEach(() => {
+    process.env.VISOR_DEBOUNCE_OVERRIDE = '0';
+    dm = new DebounceManager();
+  });
+
+  afterEach(() => {
+    dm.clear();
+    delete process.env.VISOR_DEBOUNCE_OVERRIDE;
+  });
+
+  it('skips invocations while function is executing', async () => {
+    const calls: number[] = [];
+    let resolveExecution: () => void;
+    const executionPromise = new Promise<void>(r => {
+      resolveExecution = r;
+    });
+
+    // First invocation: starts executing but takes a while
+    const p1 = dm.enqueue('key', 1000, async () => {
+      calls.push(1);
+      await executionPromise;
+      return 'result-1';
+    });
+
+    // Wait for the debounce to fire and execution to start
+    await new Promise(r => setTimeout(r, 10));
+
+    // Second invocation while first is executing — should be skipped
+    const p2 = dm.enqueue('key', 1000, async () => {
+      calls.push(2);
+      return 'result-2';
+    });
+
+    // p2 should resolve immediately as debounced
+    const r2 = await p2;
+    expect(r2.outcome).toBe('debounced');
+
+    // Let the first execution finish
+    resolveExecution!();
+    const r1 = await p1;
+    expect(r1.outcome).toBe('executed');
+    if (r1.outcome === 'executed') {
+      expect(r1.result).toBe('result-1');
+    }
+
+    // Only the first function was called
+    expect(calls).toEqual([1]);
+  });
+
+  it('allows new invocations after execution finishes', async () => {
+    const calls: number[] = [];
+
+    const r1 = await dm.enqueue('key', 1000, async () => {
+      calls.push(1);
+      return 'first';
+    });
+    expect(r1.outcome).toBe('executed');
+    expect(dm.isExecuting('key')).toBe(false);
+
+    // After execution finishes, a new invocation should work
+    const r2 = await dm.enqueue('key', 1000, async () => {
+      calls.push(2);
+      return 'second';
+    });
+    expect(r2.outcome).toBe('executed');
+    expect(calls).toEqual([1, 2]);
+  });
+});
+
+describe('DebounceManager with real timers', () => {
+  let dm: DebounceManager;
+
+  beforeEach(() => {
+    delete process.env.VISOR_DEBOUNCE_OVERRIDE;
+    dm = new DebounceManager();
+  });
+
+  afterEach(() => {
+    dm.clear();
+  });
+
+  it('coalesces rapid invocations within the debounce window', async () => {
+    const executionOrder: string[] = [];
+
+    // Fire first invocation with 200ms debounce
+    const p1 = dm.enqueue('key', 200, async () => {
+      executionOrder.push('fn1');
+      return 'r1';
+    });
+
+    // Wait 50ms, fire second (resets the timer)
+    await new Promise(r => setTimeout(r, 50));
+    const p2 = dm.enqueue('key', 200, async () => {
+      executionOrder.push('fn2');
+      return 'r2';
+    });
+
+    // Wait 50ms, fire third (resets the timer again)
+    await new Promise(r => setTimeout(r, 50));
+    const p3 = dm.enqueue('key', 200, async () => {
+      executionOrder.push('fn3');
+      return 'r3';
+    });
+
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+    expect(r1.outcome).toBe('debounced');
+    expect(r2.outcome).toBe('debounced');
+    expect(r3.outcome).toBe('executed');
+    if (r3.outcome === 'executed') {
+      expect(r3.result).toBe('r3');
+    }
+    expect(executionOrder).toEqual(['fn3']);
+  }, 10000);
+});

--- a/tests/unit/graceful-stop-e2e.test.ts
+++ b/tests/unit/graceful-stop-e2e.test.ts
@@ -182,18 +182,18 @@ describe('graceful_stop end-to-end propagation', () => {
   let server: CustomToolsSSEServer;
   let registry: SessionRegistry;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Get a fresh registry for each test
     registry = SessionRegistry.getInstance();
     // Clear any leftover sessions
-    registry.clearAllSessions();
+    await registry.clearAllSessions();
   });
 
   afterEach(async () => {
     if (server) {
       await server.stop();
     }
-    registry.clearAllSessions();
+    await registry.clearAllSessions();
   });
 
   describe('Scenario: Assistant → Engineer sub-workflow', () => {

--- a/tests/unit/mcp-custom-sse-server.test.ts
+++ b/tests/unit/mcp-custom-sse-server.test.ts
@@ -592,7 +592,7 @@ describe('CustomToolsSSEServer', () => {
       }
       // Clean up any sessions we registered
       const { SessionRegistry } = require('../../src/session-registry');
-      SessionRegistry.getInstance().clearAllSessions();
+      await SessionRegistry.getInstance().clearAllSessions();
     });
 
     it('should NOT signal the parent/caller session during graceful_stop', async () => {

--- a/tests/unit/runners/mcp-server-runner.test.ts
+++ b/tests/unit/runners/mcp-server-runner.test.ts
@@ -329,6 +329,26 @@ describe('extractResponseText', () => {
     expect(extractResponseText(result)).toBe('Nested output text');
   });
 
+  it('returns a user-facing issue summary instead of JSON when output.text is empty', () => {
+    const result = {
+      reviewSummary: {
+        issues: [
+          {
+            ruleId: 'contract/guarantee_failed',
+            message: "Guarantee failed: (output?.text ?? '').length > 0",
+            severity: 'error',
+          },
+        ],
+        history: {},
+      },
+      output: { text: '' },
+    };
+
+    expect(extractResponseText(result)).toBe(
+      'The assistant failed to produce a response. This is usually caused by a provider-side limit, outage, or invalid structured output. Please retry.'
+    );
+  });
+
   it('JSON-dumps when no text found anywhere', () => {
     const result = {
       reviewSummary: { issues: [], history: { chat: [{ numbers: [1, 2, 3] }] } },

--- a/tests/unit/session-cloning-filtering.test.ts
+++ b/tests/unit/session-cloning-filtering.test.ts
@@ -3,14 +3,14 @@ import { SessionRegistry } from '../../src/session-registry';
 describe('Session Cloning with History Filtering', () => {
   let registry: SessionRegistry;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     registry = SessionRegistry.getInstance();
     // Clear any existing sessions
-    registry.clearAllSessions();
+    await registry.clearAllSessions();
   });
 
-  afterEach(() => {
-    registry.clearAllSessions();
+  afterEach(async () => {
+    await registry.clearAllSessions();
   });
 
   it('should use ProbeAgent.clone() with correct filtering options', async () => {

--- a/tests/unit/session-registry.test.ts
+++ b/tests/unit/session-registry.test.ts
@@ -13,16 +13,16 @@ const mockAgent2 = {
 describe('SessionRegistry', () => {
   let registry: SessionRegistry;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Get a fresh instance for each test
     registry = SessionRegistry.getInstance();
     // Clear all sessions before each test
-    registry.clearAllSessions();
+    await registry.clearAllSessions();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     // Clean up after each test
-    registry.clearAllSessions();
+    await registry.clearAllSessions();
   });
 
   describe('getInstance', () => {
@@ -80,18 +80,18 @@ describe('SessionRegistry', () => {
   });
 
   describe('unregisterSession', () => {
-    it('should remove existing session', () => {
+    it('should remove existing session', async () => {
       const sessionId = 'test-session-1';
       registry.registerSession(sessionId, mockAgent1);
 
       expect(registry.hasSession(sessionId)).toBe(true);
-      registry.unregisterSession(sessionId);
+      await registry.unregisterSession(sessionId);
       expect(registry.hasSession(sessionId)).toBe(false);
     });
 
-    it('should do nothing for non-existent session', () => {
+    it('should do nothing for non-existent session', async () => {
       // Should not throw error
-      expect(() => registry.unregisterSession('non-existent')).not.toThrow();
+      await expect(registry.unregisterSession('non-existent')).resolves.toBeUndefined();
     });
   });
 
@@ -113,17 +113,29 @@ describe('SessionRegistry', () => {
   });
 
   describe('clearAllSessions', () => {
-    it('should remove all sessions', () => {
+    it('should remove all sessions', async () => {
       registry.registerSession('session-1', mockAgent1);
       registry.registerSession('session-2', mockAgent2);
 
       expect(registry.getActiveSessionIds()).toHaveLength(2);
 
-      registry.clearAllSessions();
+      await registry.clearAllSessions();
 
       expect(registry.getActiveSessionIds()).toHaveLength(0);
       expect(registry.hasSession('session-1')).toBe(false);
       expect(registry.hasSession('session-2')).toBe(false);
+    });
+
+    it('awaits async agent cleanup before returning', async () => {
+      const cleanup = jest.fn().mockResolvedValue(undefined);
+      const asyncAgent = { cleanup } as unknown as ProbeAgent;
+
+      registry.registerSession('session-1', asyncAgent);
+
+      await registry.clearAllSessions();
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(registry.getActiveSessionIds()).toHaveLength(0);
     });
   });
 

--- a/tests/unit/user-facing-error.test.ts
+++ b/tests/unit/user-facing-error.test.ts
@@ -1,0 +1,36 @@
+import {
+  formatUserFacingExecutionError,
+  formatUserFacingExecutionMessage,
+} from '../../src/utils/user-facing-error';
+
+describe('user-facing execution errors', () => {
+  it('maps no-output model failures to a friendly provider message', () => {
+    expect(
+      formatUserFacingExecutionError(
+        new Error('Error: Failed to get response from AI model. No output generated.')
+      )
+    ).toBe(
+      'The AI provider failed before generating any response. This is usually caused by a provider-side limit, rate limit, or outage. Please retry.'
+    );
+  });
+
+  it('maps budget failures to a friendly budget message', () => {
+    expect(
+      formatUserFacingExecutionError({
+        message: 'Forbidden',
+        responseBody: '{"message":"Budget limit exceeded for streaming"}',
+        statusCode: 403,
+      })
+    ).toBe(
+      'The AI provider budget limit was exceeded before a response could be generated. Please retry later or switch model/provider.'
+    );
+  });
+
+  it('strips internal wrapper prefixes from surfaced messages', () => {
+    expect(
+      formatUserFacingExecutionMessage(
+        'AI analysis failed: ProbeAgent execution failed: Error: Request timed out'
+      )
+    ).toBe('The AI request timed out before a response could be generated. Please retry.');
+  });
+});

--- a/tests/unit/user-facing-error.test.ts
+++ b/tests/unit/user-facing-error.test.ts
@@ -1,6 +1,7 @@
 import {
   formatUserFacingExecutionError,
   formatUserFacingExecutionMessage,
+  summarizeUserFacingIssues,
 } from '../../src/utils/user-facing-error';
 
 describe('user-facing execution errors', () => {
@@ -32,5 +33,31 @@ describe('user-facing execution errors', () => {
         'AI analysis failed: ProbeAgent execution failed: Error: Request timed out'
       )
     ).toBe('The AI request timed out before a response could be generated. Please retry.');
+  });
+
+  it('maps high-demand provider failures to a friendly retry message', () => {
+    expect(
+      formatUserFacingExecutionError(
+        new Error(
+          'Failed after 3 attempts. Last error: This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.'
+        )
+      )
+    ).toBe(
+      'The AI provider is currently experiencing high demand and did not generate a response. Please retry shortly.'
+    );
+  });
+
+  it('maps empty assistant text guarantee failures to a user-facing response failure', () => {
+    expect(
+      summarizeUserFacingIssues([
+        {
+          ruleId: 'contract/guarantee_failed',
+          message: "Guarantee failed: (output?.text ?? '').length > 0",
+          severity: 'error',
+        },
+      ])
+    ).toBe(
+      'The assistant failed to produce a response. This is usually caused by a provider-side limit, outage, or invalid structured output. Please retry.'
+    );
   });
 });

--- a/tests/unit/visor-timeout-graceful-winddown.test.ts
+++ b/tests/unit/visor-timeout-graceful-winddown.test.ts
@@ -118,13 +118,13 @@ function wireTimeoutEvents(agent: { events: EventEmitter }, extender?: TimeoutEx
 describe('Dynamic timeout extension via timeout.extended events', () => {
   let registry: SessionRegistry;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     registry = SessionRegistry.getInstance();
-    registry.clearAllSessions();
+    await registry.clearAllSessions();
   });
 
-  afterEach(() => {
-    registry.clearAllSessions();
+  afterEach(async () => {
+    await registry.clearAllSessions();
   });
 
   it('should extend deadline when agent emits timeout.extended', async () => {
@@ -298,13 +298,13 @@ describe('Dynamic timeout extension via timeout.extended events', () => {
 describe('withTimeout triggers graceful wind-down before hard kill', () => {
   let registry: SessionRegistry;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     registry = SessionRegistry.getInstance();
-    registry.clearAllSessions();
+    await registry.clearAllSessions();
   });
 
-  afterEach(() => {
-    registry.clearAllSessions();
+  afterEach(async () => {
+    await registry.clearAllSessions();
   });
 
   it('should call triggerGracefulWindDown on the agent before rejecting', async () => {
@@ -379,13 +379,13 @@ describe('withTimeout triggers graceful wind-down before hard kill', () => {
 describe('End-to-end: explore-code with dynamic timeout, MCP tools, and wind-down', () => {
   let registry: SessionRegistry;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     registry = SessionRegistry.getInstance();
-    registry.clearAllSessions();
+    await registry.clearAllSessions();
   });
 
-  afterEach(() => {
-    registry.clearAllSessions();
+  afterEach(async () => {
+    await registry.clearAllSessions();
   });
 
   it('should extend visor timeout when agent extends, then resolve normally', async () => {

--- a/tests/unit/workspace-manager.test.ts
+++ b/tests/unit/workspace-manager.test.ts
@@ -302,6 +302,48 @@ describe('WorkspaceManager', () => {
       fs.rmSync(testOriginalPath, { recursive: true, force: true });
       fs.rmSync(worktreePath, { recursive: true, force: true });
     });
+
+    it('rehydrates existing persisted symlinks and updates them in place', async () => {
+      const { commandExecutor } = require('../../src/utils/command-executor');
+      commandExecutor.execute.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
+
+      if (!fs.existsSync(testOriginalPath)) {
+        fs.mkdirSync(testOriginalPath, { recursive: true });
+      }
+
+      const workspaceDir = path.join(testBasePath, testSessionId);
+      fs.mkdirSync(workspaceDir, { recursive: true });
+
+      const oldWorktreePath = '/tmp/test-worktree-old';
+      const newWorktreePath = '/tmp/test-worktree-new';
+      fs.mkdirSync(oldWorktreePath, { recursive: true });
+      fs.mkdirSync(newWorktreePath, { recursive: true });
+      fs.writeFileSync(
+        `${oldWorktreePath}.metadata.json`,
+        JSON.stringify({
+          repository: 'TykTechnologies/tyk',
+          worktree_path: oldWorktreePath,
+        })
+      );
+
+      const existingSymlink = path.join(workspaceDir, 'tyk');
+      fs.symlinkSync(oldWorktreePath, existingSymlink);
+
+      const manager = WorkspaceManager.getInstance(testSessionId, testOriginalPath, {
+        basePath: testBasePath,
+      });
+
+      await manager.initialize();
+      const result = await manager.addProject('TykTechnologies/tyk', newWorktreePath);
+
+      expect(result).toBe(existingSymlink);
+      expect(fs.realpathSync(existingSymlink)).toBe(newWorktreePath);
+      expect(fs.existsSync(path.join(workspaceDir, 'tyk-2'))).toBe(false);
+
+      fs.rmSync(testOriginalPath, { recursive: true, force: true });
+      fs.rmSync(oldWorktreePath, { recursive: true, force: true });
+      fs.rmSync(newWorktreePath, { recursive: true, force: true });
+    });
   });
 
   describe('listProjects', () => {

--- a/tests/unit/worktree-cleanup.test.ts
+++ b/tests/unit/worktree-cleanup.test.ts
@@ -1,0 +1,155 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const listWorktrees = jest.fn();
+const removeWorktree = jest.fn();
+const getConfig = jest.fn();
+
+jest.mock('../../src/utils/worktree-manager', () => ({
+  worktreeManager: {
+    listWorktrees,
+    removeWorktree,
+    getConfig,
+  },
+  WorktreeManager: {
+    getInstance: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('worktree cleanup utilities', () => {
+  const workspaceBasePath = '/tmp/test-worktree-cleanup-workspaces';
+  const managedBasePath = '/tmp/test-worktree-cleanup-managed';
+  const managedWorktreesDir = path.join(managedBasePath, 'worktrees');
+  const managedReposDir = path.join(managedBasePath, 'repos');
+  const staleAgeMs = 24 * 60 * 60 * 1000;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    fs.rmSync(workspaceBasePath, { recursive: true, force: true });
+    fs.rmSync(managedBasePath, { recursive: true, force: true });
+    fs.mkdirSync(workspaceBasePath, { recursive: true });
+    fs.mkdirSync(managedWorktreesDir, { recursive: true });
+    fs.mkdirSync(managedReposDir, { recursive: true });
+    getConfig.mockReturnValue({ base_path: managedBasePath });
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceBasePath, { recursive: true, force: true });
+    fs.rmSync(managedBasePath, { recursive: true, force: true });
+  });
+
+  it('preserves stale workspaces that point at preserved repositories or local paths', async () => {
+    const { cleanupStaleWorkspaceDirectories } =
+      require('../../src/utils/worktree-cleanup') as typeof import('../../src/utils/worktree-cleanup');
+
+    const visorWorkspace = path.join(workspaceBasePath, 'slack-preserve-visor');
+    const probeWorkspace = path.join(workspaceBasePath, 'slack-preserve-probe');
+    const staleWorkspace = path.join(workspaceBasePath, 'slack-remove-tyk');
+    fs.mkdirSync(visorWorkspace, { recursive: true });
+    fs.mkdirSync(probeWorkspace, { recursive: true });
+    fs.mkdirSync(staleWorkspace, { recursive: true });
+
+    const visorTarget = path.join(managedWorktreesDir, 'probelabs-visor-main-1234');
+    fs.mkdirSync(visorTarget, { recursive: true });
+    fs.writeFileSync(
+      `${visorTarget}.metadata.json`,
+      JSON.stringify({ repository: 'probelabs/visor', worktree_path: visorTarget })
+    );
+    fs.symlinkSync(visorTarget, path.join(visorWorkspace, 'visor'));
+
+    const externalProbePath = '/tmp/test-local-probe-workspace';
+    fs.mkdirSync(externalProbePath, { recursive: true });
+    fs.symlinkSync(externalProbePath, path.join(probeWorkspace, 'probe'));
+
+    const tykTarget = path.join(managedWorktreesDir, 'TykTechnologies-tyk-main-1234');
+    fs.mkdirSync(tykTarget, { recursive: true });
+    fs.writeFileSync(
+      `${tykTarget}.metadata.json`,
+      JSON.stringify({ repository: 'TykTechnologies/tyk', worktree_path: tykTarget })
+    );
+    fs.symlinkSync(tykTarget, path.join(staleWorkspace, 'tyk'));
+
+    const oldDate = new Date(Date.now() - 2 * staleAgeMs);
+    fs.utimesSync(visorWorkspace, oldDate, oldDate);
+    fs.utimesSync(probeWorkspace, oldDate, oldDate);
+    fs.utimesSync(staleWorkspace, oldDate, oldDate);
+
+    const cleaned = await cleanupStaleWorkspaceDirectories({
+      workspaceBasePath,
+      maxAgeMs: staleAgeMs,
+      preservePathPrefixes: [externalProbePath],
+    });
+
+    expect(cleaned).toBe(1);
+    expect(fs.existsSync(visorWorkspace)).toBe(true);
+    expect(fs.existsSync(probeWorkspace)).toBe(true);
+    expect(fs.existsSync(staleWorkspace)).toBe(false);
+
+    fs.rmSync(externalProbePath, { recursive: true, force: true });
+  });
+
+  it('preserves managed worktrees referenced by recent workspaces and protected repositories', async () => {
+    const { cleanupStaleWorktreesPreservingRecentWorkspaces } =
+      require('../../src/utils/worktree-cleanup') as typeof import('../../src/utils/worktree-cleanup');
+
+    const recentWorkspace = path.join(workspaceBasePath, 'slack-recent');
+    fs.mkdirSync(recentWorkspace, { recursive: true });
+
+    const recentTarget = path.join(managedWorktreesDir, 'TykTechnologies-tyk-docs-main-recent');
+    fs.mkdirSync(recentTarget, { recursive: true });
+    fs.writeFileSync(
+      `${recentTarget}.metadata.json`,
+      JSON.stringify({ repository: 'TykTechnologies/tyk-docs', worktree_path: recentTarget })
+    );
+    fs.symlinkSync(recentTarget, path.join(recentWorkspace, 'tyk-docs'));
+
+    const oldDate = new Date(Date.now() - 2 * staleAgeMs);
+    fs.utimesSync(recentWorkspace, new Date(), new Date());
+
+    listWorktrees.mockResolvedValue([
+      {
+        id: 'keep-recent',
+        path: recentTarget,
+        metadata: {
+          created_at: oldDate.toISOString(),
+          repository: 'TykTechnologies/tyk-docs',
+        },
+      },
+      {
+        id: 'keep-visor',
+        path: path.join(managedWorktreesDir, 'probelabs-visor-main-old'),
+        metadata: {
+          created_at: oldDate.toISOString(),
+          repository: 'probelabs/visor',
+        },
+      },
+      {
+        id: 'remove-tyk',
+        path: path.join(managedWorktreesDir, 'TykTechnologies-tyk-main-old'),
+        metadata: {
+          created_at: oldDate.toISOString(),
+          repository: 'TykTechnologies/tyk',
+        },
+      },
+    ]);
+
+    const cleaned = await cleanupStaleWorktreesPreservingRecentWorkspaces({
+      workspaceBasePath,
+      maxAgeMs: staleAgeMs,
+    });
+
+    expect(cleaned).toBe(1);
+    expect(removeWorktree).toHaveBeenCalledTimes(1);
+    expect(removeWorktree).toHaveBeenCalledWith('remove-tyk');
+  });
+});

--- a/tests/unit/worktree-manager.test.ts
+++ b/tests/unit/worktree-manager.test.ts
@@ -308,4 +308,39 @@ describe('WorktreeManager', () => {
       }
     });
   });
+
+  it('removes a worktree using on-disk metadata when it is not in the active map', async () => {
+    const { commandExecutor } = require('../../src/utils/command-executor');
+    const execMock = commandExecutor.execute as jest.Mock;
+    execMock.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+    const manager = WorktreeManager.getInstance();
+    const worktreesDir = `${manager.getConfig().base_path}/worktrees`;
+    fs.mkdirSync(worktreesDir, { recursive: true });
+
+    const worktreeId = 'TykTechnologies-tyk-main-deadbeef';
+    const worktreePath = `${worktreesDir}/${worktreeId}`;
+    fs.mkdirSync(worktreePath, { recursive: true });
+    fs.writeFileSync(
+      `${worktreePath}.metadata.json`,
+      JSON.stringify({
+        worktree_id: worktreeId,
+        created_at: new Date().toISOString(),
+        ref: 'main',
+        commit: 'abc123',
+        repository: 'TykTechnologies/tyk',
+        pid: 12345,
+        cleanup_on_exit: true,
+        bare_repo_path: `${manager.getConfig().base_path}/repos/TykTechnologies-tyk.git`,
+        worktree_path: worktreePath,
+      })
+    );
+
+    await manager.removeWorktree(worktreeId);
+
+    const calls = execMock.mock.calls.map((c: any[]) => c[0] as string);
+    expect(calls.some(cmd => cmd.includes('worktree remove') && cmd.includes(worktreePath))).toBe(
+      true
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- **Workflow output unwrapping**: workflow `value_js` and related expression paths now see unwrapped step outputs instead of raw `ReviewSummary` wrappers. This fixes workflow tools such as Slack and Discourse tools seeing `outputs['step'].success` as `undefined` while the real data was nested under `.output`.
- **OAuth2 for SSE HTTP tools**: `http_client` tools using `oauth2_client_credentials` now perform token exchange instead of only handling bearer auth, fixing 401s for OAuth-backed APIs such as MongoDB Atlas.
- **Live update and completion hardening**: task live updates, trace serialization, graceful timeout handling, and frontend completion paths now avoid blank or misleading responses when execution fails late or provider output is missing.
- **Empty assistant response fallbacks**: shared user-facing issue summarization now maps provider high-demand errors, timeouts, execution errors, and `output.text` guarantee failures into clear retryable messages across Slack, email, Teams, Telegram, WhatsApp, MCP responses, and tracked task completion text.
- **Probe dependency refresh**: updates `@probelabs/probe` from `0.6.0-rc313` to `0.6.0-rc318`.

## Impact

The original production symptom was complete workflow-tool failure: a traced task showed repeated `slack-search` and `slack-read-thread` calls returning `Unknown error`, followed by an empty assistant output (`{"text":""}`). This PR fixes the underlying workflow output shape, adds the missing OAuth2 auth path, and makes the user-facing surfaces return actionable failure text instead of silence, generic JSON, or `Execution completed`.

## Tests

- [x] `visor test --no-mocks --only discourse-read-real` — real Discourse thread content returned
- [x] `visor test --no-mocks --only atlas-list-projects-real` — OAuth2 token exchange works
- [x] `visor test --only discourse-skill-activation` — mocked skill activation passes
- [x] `npx jest tests/unit/user-facing-error.test.ts tests/unit/runners/mcp-server-runner.test.ts tests/frontends/slack-frontend.test.ts --runInBand` — 46 tests passed
- [x] Pre-commit hook — eslint/prettier, Jest (`364` suites passed, `4106` tests passed), and YAML tests (`24` suites passed, `132` tests passed)

## Out of scope

- `dist/` artifacts are intentionally not included in the latest pushed commit.
- This does not change provider retry policy; it only preserves/normalizes failures into useful user-facing output when retries are exhausted or response text is empty.
