### PR TITLE
fix: load bundled default includes outside project root

### DIFF
--- a/src/utils/config-loader.ts
+++ b/src/utils/config-loader.ts
@@ -325,35 +325,10 @@ export class ConfigLoader {
     if (defaultConfigPath) {
       // Always log to stderr to avoid contaminating formatted output
       console.error(`📦 Loading bundled default configuration from ${defaultConfigPath}`);
-      const content = fs.readFileSync(defaultConfigPath, 'utf8');
-      let config = yaml.load(content) as Partial<VisorConfig>;
-
-      if (!config || typeof config !== 'object') {
-        throw new Error('Invalid default configuration');
-      }
-
-      // Alias: support 'include' as 'extends' in packaged defaults
-      if ((config as any).include && !(config as any).extends) {
-        const inc = (config as any).include;
-        (config as any).extends = Array.isArray(inc) ? inc : [inc];
-        delete (config as any).include;
-      }
-
+      const defaultConfigDir = path.dirname(defaultConfigPath);
+      let config = await this.fetchBundledConfigFile(defaultConfigPath, defaultConfigDir);
       // Normalize 'checks' and 'steps' for backward compatibility
       config = this.normalizeStepsAndChecks(config);
-
-      // Default configs shouldn't have extends, but handle it just in case
-      if (config.extends) {
-        // Ensure relative paths (e.g., ./code-review.yaml) resolve from the defaults directory
-        const previousBaseDir = this.options.baseDir;
-        try {
-          this.options.baseDir = path.dirname(defaultConfigPath);
-          return await this.processExtends(config);
-        } finally {
-          this.options.baseDir = previousBaseDir;
-        }
-      }
-
       return config;
     }
 
@@ -370,6 +345,90 @@ export class ConfigLoader {
         },
       },
     };
+  }
+
+  /**
+   * Load a bundled config and its includes without using project-local path resolution.
+   *
+   * `extends: default` is a built-in source. Its sibling includes are part of the Visor
+   * package/action bundle, so they must resolve inside that bundle rather than inside the
+   * caller's repository root.
+   */
+  private async fetchBundledConfigFile(
+    filePath: string,
+    bundledRoot: string,
+    currentDepth: number = 0,
+    seen: Set<string> = new Set()
+  ): Promise<Partial<VisorConfig>> {
+    if (currentDepth >= (this.options.maxDepth || 10)) {
+      throw new Error(
+        `Maximum bundled default include depth (${this.options.maxDepth}) exceeded. Check for circular dependencies.`
+      );
+    }
+
+    const resolvedPath = path.resolve(filePath);
+    this.validateBundledPath(resolvedPath, bundledRoot);
+
+    if (seen.has(resolvedPath)) {
+      throw new Error(`Circular dependency detected in bundled defaults: ${resolvedPath}`);
+    }
+
+    seen.add(resolvedPath);
+
+    try {
+      const content = fs.readFileSync(resolvedPath, 'utf8');
+      const config = yaml.load(content) as Partial<VisorConfig>;
+
+      if (!config || typeof config !== 'object') {
+        throw new Error(`Invalid default configuration: ${resolvedPath}`);
+      }
+
+      const extendsValue = (config as any).extends || (config as any).include;
+      delete (config as any).extends;
+      delete (config as any).include;
+
+      this.annotateToolsBaseDir(config, path.dirname(resolvedPath));
+
+      if (!extendsValue) {
+        return config;
+      }
+
+      const { ConfigMerger } = await import('./config-merger');
+      const merger = new ConfigMerger();
+      const sources = Array.isArray(extendsValue) ? extendsValue : [extendsValue];
+      let mergedParents: Partial<VisorConfig> = {};
+
+      for (const source of sources) {
+        if (typeof source !== 'string' || this.getSourceType(source) !== ConfigSourceType.LOCAL) {
+          throw new Error(
+            `Bundled default configuration can only include local bundled files: ${String(source)}`
+          );
+        }
+
+        const parentPath = path.isAbsolute(source)
+          ? source
+          : path.resolve(path.dirname(resolvedPath), source);
+        const parentConfig = await this.fetchBundledConfigFile(
+          parentPath,
+          bundledRoot,
+          currentDepth + 1,
+          seen
+        );
+        mergedParents = merger.merge(mergedParents, parentConfig);
+      }
+
+      return merger.merge(mergedParents, config);
+    } catch (error: any) {
+      if (error && (error.code === 'ENOENT' || error.code === 'ENOTDIR')) {
+        throw new Error(`Bundled default configuration file not found: ${resolvedPath}`);
+      }
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw error;
+    } finally {
+      seen.delete(resolvedPath);
+    }
   }
 
   /**
@@ -489,6 +548,31 @@ export class ConfigLoader {
       if (lowerPath.includes(pattern)) {
         throw new Error(`Security error: Cannot access potentially sensitive file: ${pattern}`);
       }
+    }
+  }
+
+  /**
+   * Validate that bundled default includes stay inside the Visor package/action bundle.
+   */
+  private validateBundledPath(resolvedPath: string, bundledRoot: string): void {
+    const canonicalize = (p: string): string => {
+      const resolved = path.resolve(p);
+      try {
+        return path.normalize(fs.realpathSync.native(resolved));
+      } catch {
+        return path.normalize(resolved);
+      }
+    };
+    const normalizedPath = canonicalize(resolvedPath);
+    const normalizedRoot = canonicalize(bundledRoot);
+
+    if (
+      normalizedPath !== normalizedRoot &&
+      !normalizedPath.startsWith(`${normalizedRoot}${path.sep}`)
+    ) {
+      throw new Error(
+        `Security error: Bundled default include resolves outside bundled defaults directory: ${bundledRoot}`
+      );
     }
   }
 

--- a/tests/unit/config-loader-bundled-default.test.ts
+++ b/tests/unit/config-loader-bundled-default.test.ts
@@ -1,0 +1,45 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+import { ConfigLoader } from '../../src/utils/config-loader';
+
+describe('ConfigLoader bundled default extends', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'visor-project-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('loads bundled default includes when project config extends default outside the package root', async () => {
+    fs.writeFileSync(
+      path.join(projectRoot, 'visor.yaml'),
+      yaml.dump({
+        extends: 'default',
+        checks: {
+          'custom-project-check': {
+            type: 'ai',
+            prompt: 'Project-specific check',
+            on: ['pr_opened'],
+          },
+        },
+      })
+    );
+
+    const loader = new ConfigLoader({
+      baseDir: projectRoot,
+      projectRoot,
+    });
+
+    const config = await loader.fetchConfig('./visor.yaml');
+
+    expect(config.steps).toBeDefined();
+    expect(config.steps?.overview).toBeDefined();
+    expect(config.checks).toBeDefined();
+    expect(config.checks?.['custom-project-check']).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fix `extends: default` when Visor runs from a GitHub Action checkout where the repository root differs from the action bundle path.

`default` is a built-in Visor source, so bundled `include` / `extends` entries should resolve inside the Visor package/action bundle rather than through project-local config path validation.

## Root cause

This regressed in `d08f91225371fefd3c65ab9acda2a930c3447d54` (`RFC: state machine engine (#245)`). That commit extracted code-review defaults from `defaults/visor.yaml` into `defaults/code-review.yaml` and added:

```yaml
include: "./code-review.yaml"
```

The bundled include was then resolved through the generic local config loader. In GitHub Actions, that validates paths against the checked-out project root, e.g. `/home/runner/work/tyk/tyk`, so the bundled action path under `/home/runner/work/_actions/.../dist/defaults/code-review.yaml` was rejected as path traversal.

## Changes

- Load bundled default config through a bundled-only loader.
- Resolve bundled `include` / `extends` entries only within the bundled defaults directory.
- Keep project-local path traversal validation unchanged for user config files.
- Add a regression test that simulates a project config with `extends: default` outside the Visor package root.

## Verification

```text
PASS tests/unit/config-loader-bundled-default.test.ts
PASS tests/unit/config-loader-default-nondot.test.ts
PASS tests/unit/config-extends.test.ts
PASS tests/unit/config-extends-github-action.test.ts
```

Also ran eslint and prettier on the touched files.

Note: the working tree had unrelated failing empty-comment tests from a separate investigation (`tests/frontends/github-frontend.test.ts`, `tests/unit/raw-output-extraction.test.ts`). They are not part of this PR.
